### PR TITLE
Support JIRA API Key in session settings

### DIFF
--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -1,18 +1,9 @@
 <script setup lang="ts">
-import {computed, reactive, ref, watchEffect} from 'vue';
+import { ref, watchEffect } from 'vue';
 import {SettingsSchema, useSettingsStore} from '@/stores/SettingsStore';
 import type {SettingsType} from '@/stores/SettingsStore';
 import {useField, useForm} from 'vee-validate';
 import {toTypedSchema} from '@vee-validate/zod';
-import ExampleForm from '@/components/ExampleForm.vue';
-import ExampleValidatedForm from '@/components/ExampleValidatedForm.vue';
-import Modal from '@/components/widgets/Modal.vue';
-import Toast from '@/components/widgets/Toast.vue';
-import { DateTime } from 'luxon';
-import {useToastStore} from '@/stores/ToastStore';
-import ProgressRing from "@/components/widgets/ProgressRing.vue";
-
-const {addToast} = useToastStore();
 
 const settingsStore = useSettingsStore();
 type SensitiveFormInput = 'password' | 'text';
@@ -22,7 +13,7 @@ const validationSchema = toTypedSchema(SettingsSchema);
 
 const initialValues = ref(settingsStore.settings);
 
-const {handleSubmit, errors, setValues, resetForm, meta} = useForm({
+const {handleSubmit, errors, resetForm, meta} = useForm({
   validationSchema,
   initialValues,
 });

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -119,7 +119,12 @@ const { value: jiraApiKey } = useField('jiraApiKey');
           <p>Required for actions which interface with JIRA.</p>
           <p>Steps to create an API key:</p>
           <ul>
-            <li>Stretch out <i>with your feelings</i></li>
+            <li>Log into your JIRA account.</li>
+            <li>Go to 'Your Profile' page under your user icon menu in the upper right corner. </li>
+            <li>Select Personal Access Tokens from the left hand sidebar menu.</li>
+            <li>Click Create token button.</li>
+            <li>Name the token meaningfully (eg. 'OSIM token') and click create.</li>
+            <li>Copy token value and close.</li>
           </ul>
         </div>
       </div>

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -21,11 +21,8 @@ const { handleSubmit, errors, resetForm, meta } = useForm({
   initialValues,
 });
 
-console.log(initialValues.value);
-
 const onSubmit = handleSubmit((values: SettingsType) => {
   settingsStore.save(values);
-  console.log(settingsStore, values);
 });
 
 const onReset = (payload: MouseEvent) => {

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -5,32 +5,35 @@ import type {SettingsType} from '@/stores/SettingsStore';
 import {useField, useForm} from 'vee-validate';
 import {toTypedSchema} from '@vee-validate/zod';
 
-const settingsStore = useSettingsStore();
 type SensitiveFormInput = 'password' | 'text';
+
+const settingsStore = useSettingsStore();
 const revealSensitive = ref<SensitiveFormInput>('password');
-
 const validationSchema = toTypedSchema(SettingsSchema);
-
 const initialValues = ref(settingsStore.settings);
-
-const {handleSubmit, errors, resetForm, meta} = useForm({
-  validationSchema,
-  initialValues,
-});
 
 watchEffect(() => {
   initialValues.value = settingsStore.settings;
 });
 
+const { handleSubmit, errors, resetForm, meta } = useForm({
+  validationSchema,
+  initialValues,
+});
+
+console.log(initialValues.value);
+
 const onSubmit = handleSubmit((values: SettingsType) => {
   settingsStore.save(values);
+  console.log(settingsStore, values);
 });
+
 const onReset = (payload: MouseEvent) => {
-  // setValues(committedForm);
   resetForm();
 };
 
-const {value: bugzillaApiKey} = useField('bugzillaApiKey');
+const { value: bugzillaApiKey } = useField('bugzillaApiKey');
+const { value: jiraApiKey } = useField('jiraApiKey');
 
 </script>
 
@@ -70,15 +73,19 @@ const {value: bugzillaApiKey} = useField('bugzillaApiKey');
       <div class="form-control mb-3">
         <label class="d-block has-validation">
           <span class="form-label">Bugzilla API Key</span>
-          <input :type="revealSensitive" class="form-control"
-                 v-model="bugzillaApiKey"
-                 :class="{'is-invalid': errors.bugzillaApiKey != null}"
-                 placeholder="[none saved]"
+          <input 
+            class="form-control"
+            :type="revealSensitive"
+            v-model="bugzillaApiKey"
+            :class="{'is-invalid': errors.bugzillaApiKey != null}"
+            placeholder="[none saved]"
           />
           <span
-              v-if="errors.bugzillaApiKey"
-              class="invalid-feedback d-block"
-          >{{errors.bugzillaApiKey}}</span>
+            v-if="errors.bugzillaApiKey"
+            class="invalid-feedback d-block"
+          >
+            {{errors.bugzillaApiKey}}
+          </span>
         </label>
         <div class="form-text">
           <p>Required for actions which interface with Bugzilla.</p>
@@ -91,6 +98,31 @@ const {value: bugzillaApiKey} = useField('bugzillaApiKey');
             <li>Copy the API key from the banner at the top of the page. Optionally, save it to your password manager.
               The API key will not be shown again after you navigate away from the page.
             </li>
+          </ul>
+        </div>
+      </div>
+      <div class="form-control mb-3">
+        <label class="d-block has-validation">
+          <span class="form-label">JIRA API Key</span>
+          <input 
+            class="form-control"
+            :type="revealSensitive"
+            v-model="jiraApiKey"
+            :class="{'is-invalid': errors.jiraApiKey != null}"
+            placeholder="[none saved]"
+          />
+          <span
+            v-if="errors.jiraApiKey"
+            class="invalid-feedback d-block"
+          >
+            {{errors.jiraApiKey}}
+          </span>
+        </label>
+        <div class="form-text">
+          <p>Required for actions which interface with JIRA.</p>
+          <p>Steps to create an API key:</p>
+          <ul>
+            <li>Stretch out <i>with your feelings</i></li>
           </ul>
         </div>
       </div>

--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -75,7 +75,7 @@ function clearAll() {
   position: v-bind(position);
   top: v-bind(top);
   /*height: calc(100vh - 100px);*/
-  pointer-events: all !important;
+  pointer-events: all !important; /* override bootstrap .toast-container default value of 'none'*/ 
   height: v-bind(height);
   overflow-x: clip;
   overflow-y: auto;

--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -70,10 +70,12 @@ function clearAll() {
 </template>
 
 <style scoped>
+
 .osim-toast-container {
   position: v-bind(position);
   top: v-bind(top);
   /*height: calc(100vh - 100px);*/
+  pointer-events: all !important;
   height: v-bind(height);
   overflow-x: clip;
   overflow-y: auto;

--- a/src/components/__tests__/Settings.spec.ts
+++ b/src/components/__tests__/Settings.spec.ts
@@ -1,0 +1,24 @@
+import { mount } from "@vue/test-utils";
+import { describe, it, expect } from "vitest";
+
+import { mockSettingsStore } from "@/stores/__tests__/SettingsStore.spec";
+
+import Settings from "../Settings.vue";
+
+const subject = mount(Settings, {
+  plugins: [mockSettingsStore],
+});
+
+describe("Settings", () => {
+  it("renders 2 inputs", () => {
+    const inputs = subject.findAll("input.form-control");
+    expect(subject.find("div.osim-content.container")).toBeTruthy();
+    expect(inputs.length).toBe(2);
+    expect(
+      inputs.every(
+        (input) =>
+          (input.element as HTMLInputElement).placeholder === "[none saved]"
+      )
+    ).toBe(true);
+  });
+});

--- a/src/services/ApiKeyService.ts
+++ b/src/services/ApiKeyService.ts
@@ -8,33 +8,32 @@
 
 import {useSettingsStore} from '@/stores/SettingsStore';
 import {useToastStore} from '@/stores/ToastStore';
-import type { ToastNew } from "@/stores/ToastStore";
+import type { ToastNew } from '@/stores/ToastStore';
 
 export function notifyApiKeyUnset() {
+
   const { addToast } = useToastStore();
-  const settingsStore = useSettingsStore();
-  const { bugzillaApiKey, jiraApiKey } = settingsStore.settings;
-
-  const toastOptions: ToastNew = {
-    css: "warning",
-    title: "Request CVE",
-    bodyHtml: true,
-    body: "",
-  };
-
-  const isBugzillaApiKeyUnset = !/.+/.test(bugzillaApiKey ?? "");
-  const isJiraApiKeyUnset = !/.+/.test(jiraApiKey ?? "");
+  const { settings: { bugzillaApiKey, jiraApiKey } } = useSettingsStore();
   const unsetKeys: string[] = [];
 
-  if (isBugzillaApiKeyUnset) {
-    unsetKeys.push("Bugzilla");
+  if (!bugzillaApiKey) {
+    unsetKeys.push('Bugzilla');
   }
-  if (isJiraApiKeyUnset) {
-    unsetKeys.push("JIRA");
+
+  if (!jiraApiKey) {
+    unsetKeys.push('JIRA');
   }
-  if (isBugzillaApiKeyUnset || isJiraApiKeyUnset) {
+
+  if (!bugzillaApiKey || !jiraApiKey) {
     const lis = unsetKeys.map((key) => `<li>${key}</li>`).join('');
-    toastOptions.body += `You have not set the following keys in this tab: <ul>${lis}</ul>Flaw creation requires your Bugzilla API or JIRA key to be set. Visit <a href="/settings"}>Settings</a> to set any required keys.`;
+    const toastOptions: ToastNew = {
+      css: 'warning',
+      title: 'Request CVE',
+      bodyHtml: true,
+      body: '',
+    };
+    toastOptions.body += `You have not set the following keys in this tab: <ul>${lis}</ul>Flaw creation requires your Bugzilla API or JIRA key to be set. Visit <a href='/settings'}>Settings</a> to set any required keys.`;
     addToast(toastOptions);
   }
+
 }

--- a/src/services/ApiKeyService.ts
+++ b/src/services/ApiKeyService.ts
@@ -8,11 +8,9 @@
 
 import {useSettingsStore} from '@/stores/SettingsStore';
 import {useToastStore} from '@/stores/ToastStore';
-import type { ToastNew } from '@/stores/ToastStore';
 
 export function notifyApiKeyUnset() {
 
-  const { addToast } = useToastStore();
   const { settings: { bugzillaApiKey, jiraApiKey } } = useSettingsStore();
   const unsetKeys: string[] = [];
 
@@ -25,15 +23,14 @@ export function notifyApiKeyUnset() {
   }
 
   if (!bugzillaApiKey || !jiraApiKey) {
+    const { addToast } = useToastStore();
     const lis = unsetKeys.map((key) => `<li>${key}</li>`).join('');
-    const toastOptions: ToastNew = {
+    addToast({
       css: 'warning',
       title: 'Request CVE',
       bodyHtml: true,
-      body: '',
-    };
-    toastOptions.body += `You have not set the following keys in this tab: <ul>${lis}</ul>Flaw creation requires your Bugzilla API or JIRA key to be set. Visit <a href='/settings'}>Settings</a> to set any required keys.`;
-    addToast(toastOptions);
+      body: `You have not set the following keys in this tab: <ul>${lis}</ul>Flaw creation requires your Bugzilla API or JIRA key to be set. Visit <a href='/settings'}>Settings</a> to set any required keys.`
+    });
   }
 
 }

--- a/src/services/ApiKeyService.ts
+++ b/src/services/ApiKeyService.ts
@@ -8,6 +8,7 @@
 
 import {useSettingsStore} from '@/stores/SettingsStore';
 import {useToastStore} from '@/stores/ToastStore';
+import { useRouter } from 'vue-router';
 
 export function notifyApiKeyUnset() {
 
@@ -16,6 +17,7 @@ export function notifyApiKeyUnset() {
 
   if (!bugzillaApiKey) {
     unsetKeys.push('Bugzilla');
+    maybeRedirectToSettings();
   }
 
   if (!jiraApiKey) {
@@ -29,8 +31,15 @@ export function notifyApiKeyUnset() {
       css: 'warning',
       title: 'Request CVE',
       bodyHtml: true,
-      body: `You have not set the following keys in this tab: <ul>${lis}</ul>Flaw creation requires your Bugzilla API or JIRA key to be set. Visit <a href='/settings'}>Settings</a> to set any required keys.`
+      body: `You have not set the following keys in this tab: <ul>${lis}</ul>Flaw creation requires your Bugzilla API or JIRA key to be set. Visit Settings to set any required keys.`
     });
   }
 
+}
+
+function maybeRedirectToSettings () {
+  const router = useRouter();
+  if (router.currentRoute.value.fullPath === '/flaws/new') {
+    router.push({path: '/settings'});
+  }
 }

--- a/src/services/ApiKeyService.ts
+++ b/src/services/ApiKeyService.ts
@@ -17,7 +17,6 @@ export function notifyApiKeyUnset() {
 
   if (!bugzillaApiKey) {
     unsetKeys.push('Bugzilla');
-    maybeRedirectToSettings();
   }
 
   if (!jiraApiKey) {
@@ -27,14 +26,15 @@ export function notifyApiKeyUnset() {
   if (!bugzillaApiKey || !jiraApiKey) {
     const { addToast } = useToastStore();
     const lis = unsetKeys.map((key) => `<li>${key}</li>`).join('');
+
     addToast({
       css: 'warning',
       title: 'Request CVE',
       bodyHtml: true,
       body: `You have not set the following keys in this tab: <ul>${lis}</ul>Flaw creation requires your Bugzilla API or JIRA key to be set. Visit Settings to set any required keys.`
     });
+    maybeRedirectToSettings();
   }
-
 }
 
 function maybeRedirectToSettings () {
@@ -43,3 +43,4 @@ function maybeRedirectToSettings () {
     router.push({path: '/settings'});
   }
 }
+

--- a/src/services/ApiKeyService.ts
+++ b/src/services/ApiKeyService.ts
@@ -8,18 +8,33 @@
 
 import {useSettingsStore} from '@/stores/SettingsStore';
 import {useToastStore} from '@/stores/ToastStore';
-
-
+import type { ToastNew } from "@/stores/ToastStore";
 
 export function notifyApiKeyUnset() {
-  const {addToast} = useToastStore();
+  const { addToast } = useToastStore();
   const settingsStore = useSettingsStore();
-  if (!/.+/.test(settingsStore.settings.bugzillaApiKey ?? '')) {
-    addToast({
-      css: 'warning',
-      title: 'Request CVE',
-      bodyHtml: true,
-      body: 'You have not set your Bugzilla API key in this tab!<br/>Flaw editing requires your Bugzilla API key to be set.<br/>Visit <RouterLink :to="{name: \'settings\'}">Settings</RouterLink>',
-    });
+  const { bugzillaApiKey, jiraApiKey } = settingsStore.settings;
+
+  const toastOptions: ToastNew = {
+    css: "warning",
+    title: "Request CVE",
+    bodyHtml: true,
+    body: "",
+  };
+
+  const isBugzillaApiKeyUnset = !/.+/.test(bugzillaApiKey ?? "");
+  const isJiraApiKeyUnset = !/.+/.test(jiraApiKey ?? "");
+  const unsetKeys: string[] = [];
+
+  if (isBugzillaApiKeyUnset) {
+    unsetKeys.push("Bugzilla");
+  }
+  if (isJiraApiKeyUnset) {
+    unsetKeys.push("JIRA");
+  }
+  if (isBugzillaApiKeyUnset || isJiraApiKeyUnset) {
+    const lis = unsetKeys.map((key) => `<li>${key}</li>`).join('');
+    toastOptions.body += `You have not set the following keys in this tab: <ul>${lis}</ul>Flaw creation requires your Bugzilla API or JIRA key to be set. Visit <a href="/settings"}>Settings</a> to set any required keys.`;
+    addToast(toastOptions);
   }
 }

--- a/src/services/OsidbAuthService.ts
+++ b/src/services/OsidbAuthService.ts
@@ -18,6 +18,9 @@ export async function osidbFetch(config: AxiosRequestConfig) {
     if (/.+/.test(settingsStore.settings.bugzillaApiKey ?? '')) {
       config.headers['Bugzilla-Api-Key'] = settingsStore.settings.bugzillaApiKey;
     }
+    if (/.+/.test(settingsStore.settings.jiraApiKey ?? '')) {
+      config.headers['Jira-Api-Key'] = settingsStore.settings.jiraApiKey; // Source: osidb/openapi.yml
+    }
     config.baseURL = osimRuntime.value.backends.osidb;
     config.withCredentials = true;
     return axios(config);

--- a/src/stores/SettingsStore.ts
+++ b/src/stores/SettingsStore.ts
@@ -14,7 +14,8 @@ const _settingsStoreKey = 'SettingsStore';
 
 export const SettingsSchema = z.object({
   // bugzillaApiKey: z.string().length(32, {message: 'Bugzilla API Key is the wrong length!'}).optional(),
-  bugzillaApiKey: z.string().optional().or(z.literal('')),
+  bugzillaApiKey: z.string().optional().or(z.literal("")),
+  jiraApiKey: z.string().optional().or(z.literal("")),
 });
 export type SettingsType = z.infer<typeof SettingsSchema>;
 

--- a/src/stores/ToastStore.ts
+++ b/src/stores/ToastStore.ts
@@ -3,7 +3,7 @@ import {defineStore} from 'pinia';
 import { DateTime } from 'luxon';
 
 
-interface ToastNew {
+export interface ToastNew {
   title?: string,
   body: string,
   // timestamp: moment.Moment,

--- a/src/stores/__tests__/SettingsStore.spec.ts
+++ b/src/stores/__tests__/SettingsStore.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+
+import { useSettingsStore } from "../SettingsStore";
+
+import { createTestingPinia } from "@pinia/testing";
+
+// While not used in this file, store below depends on global pinia test instance
+export const mockSettingsStore = createTestingPinia({
+  initialState: {
+    bugzillaApiKey: "",
+    jiraApiKey: "",
+  }
+})
+
+const settingsStore = useSettingsStore();
+describe("SettingsStore", () => {
+  it("initializes", () => {
+    expect(settingsStore.$state.settings).toEqual({})
+  });
+  it("saves values", () => {
+    settingsStore.save({
+      bugzillaApiKey: "beep-beep-who-got-the-keys-to-the-jeep",
+      jiraApiKey: "beep-beep-who-got-the-keys-to-the-jeep",
+    })
+    expect(
+      settingsStore.settings.bugzillaApiKey === 'beep-beep-who-got-the-keys-to-the-jeep'
+    );
+    expect(
+      settingsStore.settings.jiraApiKey === 'beep-beep-who-got-the-keys-to-the-jeep'
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,9 +10,9 @@ export default mergeConfig(
       exclude: [...configDefaults.exclude, 'e2e/*'],
       root: fileURLToPath(new URL('./', import.meta.url)),
       globals: true,
-      globalSetup: [
-          './src/__tests__/global-setup.ts',
-      ],
+      // globalSetup: [
+      //     './src/__tests__/global-setup.ts',
+      // ],
     },
   }),
 )


### PR DESCRIPTION
- Reworks missing API key notification interface to accommodate multiple missing API keys (JIRA and BZ)
  > <img src="https://github.com/RedHatProductSecurity/osim/assets/17716232/66f1b35a-4f44-4573-8a3f-eaffb711f854" width="300px">
- Provides field in settings for ephemeral storage of JIRA API key, analogous to BZ KEY field (not persisted)
- Sets request header [specified in `osidb/openapi.yml` for JIRA api key](https://github.com/RedHatProductSecurity/osidb/blob/dc48ee1597f33633fe751a06a43f47bc67ca7eaf/openapi.yml#L3440-L3450)
- Provide test coverage for `<Settings/>` and its pinia store `SettingStore`