### PR TITLE
Fix bug where owner was not able to be updated by Flaw Edit Form

### DIFF
--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -131,7 +131,7 @@ export const ZodFlawSchema = z.object({
     impact: z.nativeEnum(ImpactEnumWithBlank).nullish(),
     component: z.string().max(100).nullish(),
     title: z.string().min(1),
-    owner: z.string().min(1),
+    owner: z.string().nullish(),
     trackers: z.array(z.string()).nullish(), // read-only
     description: z.string(),
     summary: z.string().nullish(),

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -131,6 +131,7 @@ export const ZodFlawSchema = z.object({
     impact: z.nativeEnum(ImpactEnumWithBlank).nullish(),
     component: z.string().max(100).nullish(),
     title: z.string().min(1),
+    owner: z.string().min(1),
     trackers: z.array(z.string()).nullish(), // read-only
     description: z.string(),
     summary: z.string().nullish(),


### PR DESCRIPTION
`owner` was missing from the schema used by the form, but no longer. 