### PR TITLE
Add Team Id to Issue Edit (Unblocks QE testing for Flaw Status Workflow)

### DIFF
--- a/src/components/IssueEdit.vue
+++ b/src/components/IssueEdit.vue
@@ -77,6 +77,7 @@ const {value: flawMajor_incident_state} = useField<string>('major_incident_state
 const {value: flawEmbargoed} = useField<boolean>('embargoed');
 
 const { value: flawAssignee } = useField<string>('owner');
+const { value: flawTeamId } = useField<string>('team_id');
 
 let committedFlaw: ZodFlawType = reactive(props.flaw);
 
@@ -168,7 +169,8 @@ const onSubmit = handleSubmit((flaw: ZodFlawType) => {
   for (let affect of theAffects.value) {
     console.log('saving the affect', affect);
   }
-});
+},
+console.error);
 
 const onReset = (payload: MouseEvent) => {
   console.log('onReset');
@@ -296,6 +298,7 @@ function removeAffect(affectIdx: number) {
                 v-model="flawEmbargoed"
                 :cveId="flawCve_id"/>
             <LabelEditable label="Assignee" type="text" v-model="flawAssignee" />
+            <LabelEditable type="text" label="Team ID" v-model="flawTeamId" />
             <div>
               <div v-if="flaw.trackers && flaw.trackers.length > 0">Trackers:</div>
               <div v-for="tracker in trackerUuids">
@@ -378,7 +381,7 @@ function removeAffect(affectIdx: number) {
       <button
           type="submit"
           class="btn btn-primary"
-          @click="onSubmitAffect"
+          @click="onSubmit"
       >Save Changes</button>
     </div>
   </form>

--- a/src/components/__tests__/IssueEdit.spec.ts
+++ b/src/components/__tests__/IssueEdit.spec.ts
@@ -50,7 +50,21 @@ vi.mock('vue-router', async () => {
 
 describe('IssueEdit', () => {
   let subject: VueWrapper<InstanceType<typeof IssueEdit>>;
-
+  function mountWithProps(props: typeof IssueEdit.$props) {
+    subject =  mount(IssueEdit, {
+      plugins: [useToastStore()],
+      props,
+      global: {
+        directives: {
+          tooltip: TooltipDirective
+        },
+        stubs: {
+          // osimFormatDate not defined on test run, so we need to stub it
+          EditableDate: true,
+        },
+      },
+    });
+  }
   beforeAll(() => {
     // Store below depends on global pinia test instance
     createTestingPinia({
@@ -61,8 +75,6 @@ describe('IssueEdit', () => {
 
     server.listen({ onUnhandledRequest: 'error' });
 
-    const flaw = sampleFlaw();
-    flaw.owner = 'test owner';
     (useRouter as Mock).mockReturnValue({
       'currentRoute': { 'value': { 'fullPath': '/flaws/uuiddddd' } },
     });
@@ -71,7 +83,7 @@ describe('IssueEdit', () => {
       plugins: [useToastStore()],
       // shallow: true,
       props: {
-        flaw,
+        flaw: sampleFlaw()
       },
       global: {
         mocks: {
@@ -99,6 +111,9 @@ describe('IssueEdit', () => {
   });
 
   it('displays correct Assignee field value from props', async () => {
+    const flaw = sampleFlaw();
+    flaw.owner = 'test owner';
+    mountWithProps({flaw});
     const assigneeField = subject
       .findAllComponents(LabelEditable)
       .find((component) => component.text().includes('Assignee'));
@@ -119,6 +134,7 @@ describe('IssueEdit', () => {
       statusField?.find('div.form-control > span').text()
     ).toBe('REVIEW');
   });
+
   it('displays promote and reject buttons for status', async () => {
     const statusField = subject
     .findAllComponents(LabelStatic)

--- a/src/components/__tests__/IssueEdit.spec.ts
+++ b/src/components/__tests__/IssueEdit.spec.ts
@@ -148,13 +148,13 @@ describe('IssueEdit', () => {
         .exists()
     ).toBe(true);
   });
+
   it('shows a modal for reject button clicks', async () => {
     const statusField = subject
-    .findAllComponents(LabelStatic)
-    .find((component) => component.text().includes('Status'));
-    const rejectButton = statusField?.find('button#osim-status-reject-button')
-      await rejectButton?.trigger('click');
-      // await new Promise((resolve) => setTimeout(resolve, 1000));
+      .findAllComponents(LabelStatic)
+      .find((component) => component.text().includes('Status'));
+    const rejectButton = statusField?.find('button#osim-status-reject-button');
+    await rejectButton?.trigger('click');
 
     expect(
       subject.find('.modal-dialog').exists()
@@ -166,11 +166,8 @@ describe('IssueEdit', () => {
   });
 
   it('sends a mocked PUT request with an updated owner', async () => {
-    // @ts-ignore
-    const flaw: ZodFlawType = sampleFlaw();
-    // @ts-ignore
+    const flaw = sampleFlaw();
     flaw.owner = 'networking test owner';
-    // @ts-ignore
     const result = await mockedPutFlaw(flaw.uuid, flaw);
     expect(result.owner).toBe('networking test owner');
   });
@@ -208,7 +205,7 @@ describe('IssueEdit', () => {
   })
 });
 
-function mockedPutFlaw(uuid: string, flawObject: typeof sampleFlaw) {
+function mockedPutFlaw(uuid: string, flawObject: Record<any, any>) {
   return axios({
     method: 'put',
     url: `${FLAW_BASE_URI}/${uuid}`,
@@ -220,7 +217,7 @@ function mockedPutFlaw(uuid: string, flawObject: typeof sampleFlaw) {
     .catch((e) => console.error('🚨 Mocked PUT failed due to', e.message));
 }
 
-function sampleFlaw() /*:ZodFlawType */ {
+function sampleFlaw() {
   return {
     uuid: '3ede0314-a6c5-4462-bcf3-b034a15cf106',
     type: 'VULNERABILITY',

--- a/src/components/__tests__/IssueEdit.spec.ts
+++ b/src/components/__tests__/IssueEdit.spec.ts
@@ -8,12 +8,7 @@ import { useToastStore } from '@/stores/ToastStore';
 import LabelEditable from '@/components/widgets/LabelEditable.vue';
 import LabelStatic from '@/components/widgets/LabelStatic.vue';
 import IssueEdit from '@/components/IssueEdit.vue';
-import { InputLabelDirective } from '@/directives/InputLabelDirective';
 import { useRouter } from 'vue-router';
-
-
-
-import type { ZodFlawType } from '@/types/zodFlaw';
 
 const FLAW_BASE_URI = `/osidb/api/v1/flaws`;
 // const FLAW_BASE_URI = `http://localhost:5173/tests/3ede0314-a6c5-4462-bcf3-b034a15cf106`;
@@ -55,9 +50,6 @@ describe('IssueEdit', () => {
       plugins: [useToastStore()],
       props,
       global: {
-        directives: {
-          tooltip: TooltipDirective
-        },
         stubs: {
           // osimFormatDate not defined on test run, so we need to stub it
           EditableDate: true,
@@ -170,6 +162,18 @@ describe('IssueEdit', () => {
     flaw.owner = 'networking test owner';
     const result = await mockedPutFlaw(flaw.uuid, flaw);
     expect(result.owner).toBe('networking test owner');
+  });
+
+  it('shows a Team Id field', async () => {
+    mountWithProps({flaw: {...sampleFlaw(), team_id: '12345'}});
+
+    const teamIdField = subject
+      .findAllComponents(LabelEditable)
+      .find((component) => component.text().includes('Team ID'));
+
+    expect(teamIdField?.find('span.form-label').text()).toBe('Team ID');
+
+    expect(teamIdField?.attributes().modelvalue).toBe('12345');
   });
 
   it("displays correct Cvss3 calculator link for empty value", async () => {

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -140,6 +140,7 @@ export const ZodFlawSchema = z.object({
     component: z.string().max(100).nullish(),
     title: z.string().min(1),
     owner: z.string().nullish(),
+    team_id: z.string().nullish(),
     trackers: z.array(z.string()).nullish(), // read-only
     description: z.string(),
     summary: z.string().nullish(),


### PR DESCRIPTION
* Provides an editable field for assigning team id
* Bundles in tooltips (optional, can be removed)