### PR TITLE
Fix MyIssues filter on IndexView

### DIFF
--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -5,7 +5,7 @@ import IssueQueueItem from '@/components/IssueQueueItem.vue';
 import LabelCheckbox from './widgets/LabelCheckbox.vue';
 import { useUserStore } from '@/stores/UserStore';
 import { FlawClassificationStateEnum } from '../generated-client';
-const { userName } = useUserStore();
+const userStore = useUserStore();
 
 const emit = defineEmits(['flaws:fetch', 'flaws:load-more']);
 
@@ -45,7 +45,7 @@ const filters = computed(() => {
   const filterObj: Record<string, any> = {};
 
   if (isMyIssuesSelected.value) {
-    filterObj.owner = userName;
+    filterObj.owner = userStore.userName;
   }
 
   if (isOpenIssuesSelected.value) {


### PR DESCRIPTION
MyIssues filter fix on IndexView

After user login, MyIssues filter is passing 'Current_user' filter to owner query. This is happening because of losing reactivity on username.