### PR TITLE
setup nginx logs for splunk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,12 @@ RUN --mount=target=/mnt \
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 EXPOSE 8080
+ARG OSIM_ENV=dev
 
 STOPSIGNAL SIGQUIT
 
 RUN microdnf --nodocs --noplugins --setopt install_weak_deps=0 -y install nginx \
     && microdnf clean all \
-# Set up container logging
-    && ln -sf /dev/stdout /var/log/nginx/access.log \
-    && ln -sf /dev/stderr /var/log/nginx/error.log \
-    && chmod 755 /var/log/nginx \
 # Set up unprivileged nginx
     && sed -i '/^user nginx;$/d' /etc/nginx/nginx.conf \
     && sed -i '/^pid \/run\/nginx.pid;$/c pid /tmp/nginx.pid;' /etc/nginx/nginx.conf \

--- a/build/entrypoint.d/40-setup-logging.sh
+++ b/build/entrypoint.d/40-setup-logging.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+ACCESS_LOG=/var/log/nginx/access.log
+ERROR_LOG=/var/log/nginx/error.log
+
+if [ "${OSIM_ENV}" = "dev" ]; then
+    ACCESS_LOG=/dev/stdout
+    ERROR_LOG=/dev/stderr
+fi
+
+sed -i "s|access_log  /var/log/nginx/access.log  main;|access_log ${ACCESS_LOG} main;\n    error_log ${ERROR_LOG};|" /etc/nginx/nginx.conf


### PR DESCRIPTION
This PR makes logs available in Splunk when deployed to MP+.

In order to achieve that, this PR uses OSIM_ENV variable to define if logs should be redirected to `stdout` or if they should be in `/var/log/nginx`.

Closes OSIDB-2339.