### PR TITLE
🐛 Fix read-only badge display

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -60,7 +60,7 @@ function onSearch(query: string) {
       </RouterLink>
       <RouterLink to="/" class="osim-home-text">
         <abbr title="Open Security Issue Management">OSIM</abbr>
-        <span class="rounded-pill badge bg-danger ms-2">Read Only Mode</span>
+        <span v-if="osimRuntime.readOnly" class="rounded-pill badge bg-danger ms-2">Read Only Mode</span>
       </RouterLink>
       <!-- <div class="osim-env">
         <span class="badge bg-secondary osim-env-label">[ {{ userStore.env.toUpperCase() }} ]</span>


### PR DESCRIPTION
This was fixed on `integration` for the demo today but was not committed on the feature branch