### PR TITLE
OSIDB-2321: Removed trackers from create flaw form and added the unit tests too

### DIFF
--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -327,7 +327,7 @@ const onReset = () => {
             @acknowledgment:delete="deleteAcknowledgment"
           />
         </div>
-        <LabelCollapsable :label="`Trackers: ${trackerUuids.length}`" :isExpandable="trackerUuids.length !== 0">
+        <LabelCollapsable v-if="mode === 'edit'" :label="`Trackers: ${trackerUuids.length}`" :isExpandable="trackerUuids.length !== 0">
           <ul>
             <li v-for="(tracker, trackerIndex) in trackerUuids" :key="trackerIndex">
               <RouterLink :to="{ name: 'tracker-details', params: { id: tracker.uuid } }">

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -12,7 +12,7 @@ import { useRouter } from 'vue-router';
 import LabelDiv from '../widgets/LabelDiv.vue';
 import LabelSelect from '../widgets/LabelSelect.vue';
 import LabelInput from '../widgets/LabelInput.vue';
-import LabelCollapsable from '../widgets/LabelCollapsable.vue'
+import LabelCollapsable from '../widgets/LabelCollapsable.vue';
 const FLAW_BASE_URI = '/osidb/api/v1/flaws';
 // const FLAW_BASE_URI = `http://localhost:5173/tests/3ede0314-a6c5-4462-bcf3-b034a15cf106`;
 const putHandler = http.put(`${FLAW_BASE_URI}/:id`, async ({ request }) => {

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -12,6 +12,7 @@ import { useRouter } from 'vue-router';
 import LabelDiv from '../widgets/LabelDiv.vue';
 import LabelSelect from '../widgets/LabelSelect.vue';
 import LabelInput from '../widgets/LabelInput.vue';
+import LabelCollapsable from '../widgets/LabelCollapsable.vue'
 const FLAW_BASE_URI = '/osidb/api/v1/flaws';
 // const FLAW_BASE_URI = `http://localhost:5173/tests/3ede0314-a6c5-4462-bcf3-b034a15cf106`;
 const putHandler = http.put(`${FLAW_BASE_URI}/:id`, async ({ request }) => {
@@ -184,6 +185,11 @@ describe('FlawForm', () => {
       .findAllComponents(LabelEditable)
       .find((component) => component.props().label === 'Assignee');
     expect(assigneeField?.exists()).toBe(true);
+
+    const trackers = subject
+      .findAllComponents(LabelCollapsable)
+      .find((component) => component.props().label.startsWith('Trackers'));
+    expect(trackers?.exists()).toBe(true);
   });
 
   it('shows the expected fields in create mode', async () => {
@@ -263,6 +269,11 @@ describe('FlawForm', () => {
       .findAllComponents(LabelEditable)
       .find((component) => component.props().label === 'Assignee');
     expect(assigneeField?.exists()).toBe(true);
+
+    const trackers = subject
+      .findAllComponents(LabelCollapsable)
+      .find((component) => component.props().label.startsWith('Trackers'));
+    expect(trackers).toBe(undefined);
   });
 
   it('displays correct Assignee field value from props', async () => {


### PR DESCRIPTION
It removes the trackers section from the FlawForm when it is on CREATE mode only.

Implements https://issues.redhat.com/browse/OSIDB-2321