### PR TITLE
Revises Flaw validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Renamed `Description` (to Comment#0) and `Summary` (to Description)
 * Made text area fields visible with empty content
 * Minor style adjustments on `Flaw` views
+* Validates Flaw form fields with visual fieldback 
+* Provided save operation indications
+* Implemented read-only mode (network requests involving write operations are disabled)
 
 ### Fixed
 * Fixed overlap on edit buttons at References and Acknowledgements items
@@ -18,7 +21,10 @@
 * Flaw CVSS3 score is now readonly (OSIDB-2308)
 * Flaw Comment#0 (former description) field is now writable only upon Flaw creation (OSIDB-2308)
 * Fixed ability to create comments on public flaws
-
+* Provide unembargo confirmation ID for Embargoed Flaws without a CVE
+* Saving indication for saving Flaw edits
+* Supplied missing validation indication fo Reported Date
+* Removed CVE as required field
 
 ## [2024.1.0]
 

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -253,7 +253,7 @@ const onReset = () => {
           <IssueFieldEmbargo
             v-model="flaw.embargoed"
             :isFlawNew="!flaw.uuid"
-            :cveId="flaw.cve_id"
+            :flawId="flaw.cve_id || flaw.uuid"
           />
           <LabelEditable v-model="flaw.owner" label="Assignee" type="text" />
           <LabelEditable v-model="flaw.team_id" type="text" label="Team ID" />

--- a/src/components/IssueFieldEmbargo.vue
+++ b/src/components/IssueFieldEmbargo.vue
@@ -7,7 +7,7 @@ import LabelDiv from '@/components/widgets/LabelDiv.vue';
 import LabelCheckbox from '@/components/widgets/LabelCheckbox.vue';
 
 const props = defineProps<{
-  cveId: string | null | undefined;
+  flawId: string | null | undefined;
   isFlawNew: boolean;
 }>();
 
@@ -21,7 +21,7 @@ const emit = defineEmits<{
 
 const { isModalOpen, openModal, closeModal } = useModal();
 const confirmationId = ref('');
-const isFlawIdConfirmed = computed(() => confirmationId.value === props.cveId);
+const isFlawIdConfirmed = computed(() => confirmationId.value === props.flawId);
 
 function handleConfirm() {
   emit('update:modelValue', false);
@@ -68,7 +68,7 @@ function handleConfirm() {
                 </ol>
                 <div class="alert alert-info">
                   To prevent an accidental unembargo please confirm your intention by typing
-                  {{ cveId }} if you wish to proceed.
+                  {{ flawId }} if you wish to proceed.
                 </div>
                 <LabelInput v-model="confirmationId" label="Confirm" />
                 <p v-if="confirmationId" class="alert alert-warning mt-2">

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -205,8 +205,8 @@ watch(params, () => {
         </tbody>
       </table>
       <button
-        v-if="!isFinalPageFetched"
-        class="btn btn-primary ms-4"
+        v-if="relevantIssues.length !== 0 && !isFinalPageFetched"
+        class="btn btn-primary"
         type="button"
         :disabled="isLoading"
         @click="emitLoadMore"

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -31,7 +31,8 @@ function quickMatchCVE(query: string) {
   // Match `CVE-`, 4 digits, a hyphen, then 4-7 digits,
   // with optional surrounding whitespace.
   // match[1] will be the CVE ID if it exists
-  return query.match(cveRegex)?.[1];
+  let trimmedQuery = query.trim();
+  return trimmedQuery.match(cveRegex)?.[0];
 }
 
 const searchIssue = ref('');
@@ -41,7 +42,7 @@ function onSearch(query: string) {
   if (trimmedQuery === '') {
     return;
   }
-  const maybeCveId =  quickMatchCVE(query);
+  const maybeCveId = quickMatchCVE(query);
   if (maybeCveId) {
     router.push({ path: `/flaws/${maybeCveId}` });
     return;

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -47,7 +47,14 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     if (!validatedFlaw.success) {
       return;
     }
-    postFlaw(validatedFlaw.data)
+    // Remove any empty fields before request
+    const flawForPost: any = Object.assign({}, validatedFlaw.data);
+    Object.entries(flawForPost).forEach(([key, value])=>{
+      if (value === '') {
+        delete flawForPost[key];
+      }
+    });
+    postFlaw(flawForPost)
       .then(createSuccessHandler({ title: 'Success!', body: 'Flaw created' }))
       .then((response: any) => {
         router.push({

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -86,6 +86,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
   }
 
   async function updateFlaw() {
+    isSaving.value = true;
     const validatedFlaw = validate();
     if (!validatedFlaw.success) {
       return;

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -62,8 +62,12 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
   function validate(){
     const validatedFlaw = ZodFlawSchema.safeParse(flaw.value);
     if (!validatedFlaw.success) {
-      console.log(validatedFlaw.error.issues);
-      const errorMessage = ({ message, path }: ZodIssue) => `${path.join('/')}: ${message}`;
+
+      const temporaryFieldRenaming = (fieldName: string | number) => 
+        fieldName === 'description' ? 'Comment#0' : fieldName;
+
+      const errorMessage = ({ message, path }: ZodIssue) => `${path.map(temporaryFieldRenaming).join('/')}: ${message}`;
+
       addToast({
         title: 'Flaw validation failed before submission',
         body: validatedFlaw.error.issues.map(errorMessage).join('\n '),

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -151,6 +151,7 @@ export function blankFlaw(): ZodFlawType {
     },
     component: '',
     unembargo_dt: '',
+    reported_dt: '',
     uuid: '',
     cve_id: '',
     cvss3: '',

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -48,12 +48,10 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
       return;
     }
     // Remove any empty fields before request
-    const flawForPost: any = Object.assign({}, validatedFlaw.data);
-    Object.entries(flawForPost).forEach(([key, value])=>{
-      if (value === '') {
-        delete flawForPost[key];
-      }
-    });
+    const flawForPost: any = Object.fromEntries(
+      Object.entries(validatedFlaw.data).filter(([, value]) => value !== '')
+    );
+
     postFlaw(flawForPost)
       .then(createSuccessHandler({ title: 'Success!', body: 'Flaw created' }))
       .then((response: any) => {

--- a/src/services/ApiKeyService.ts
+++ b/src/services/ApiKeyService.ts
@@ -29,7 +29,7 @@ export function notifyApiKeyUnset() {
 
     addToast({
       css: 'warning',
-      title: 'Read-Only Mode',
+      title: 'Cannot Edit/Create Flaws',
       bodyHtml: true,
       body: `You have not set the following keys in this tab: <ul>${lis}</ul>` +
       'Flaw creation requires your Bugzilla API or JIRA key to be set. ' +

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -245,8 +245,8 @@ export const ZodFlawSchema = z.object({
   type: z.nativeEnum(FlawTypeWithBlank).nullish(),
   uuid: z.string().default(''),
   cve_id: z.string().refine(
-    (cve) => cveRegex.test(cve),
-    { message: 'You must enter a valid CVE ID before saving the Flaw.' }
+    (cve) => cveRegex.test(cve) || cve === '',
+    { message: 'The CVE ID is invalid: It must begin with "CVE-", have a year between 1999-2999, and have an identifier at least 4 digits long (e.g. use 0001 for 1). Please also check for unexpected characters like spaces.' }
   ),
   impact: z.nativeEnum(ImpactEnumWithBlank)
     .refine(
@@ -259,7 +259,10 @@ export const ZodFlawSchema = z.object({
   team_id: z.string().nullish(),
   trackers: z.array(z.string()).nullish(), // read-only
   classification: ZodFlawClassification.nullish(),
-  description: z.string().min(10),
+  description: z.string().refine(
+    description => description.trim().length > 0,
+    { message: 'Comment#0 cannot be empty.' }
+  ),
   summary: z.string().nullish(),
   requires_summary: z.nativeEnum(RequiresSummaryEnumWithBlank).nullish(),
   statement: z.string().nullish(),

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -244,8 +244,8 @@ export const ZodFlawSchema = z.object({
   // type: z.nativeEnum(FlawType).optional(),
   type: z.nativeEnum(FlawTypeWithBlank).nullish(),
   uuid: z.string().default(''),
-  cve_id: z.string().refine(
-    (cve) => cveRegex.test(cve) || cve === '',
+  cve_id: z.string().nullable().refine(
+    (cve) => !cve || cveRegex.test(cve),
     { message: 'The CVE ID is invalid: It must begin with "CVE-", have a year between 1999-2999, and have an identifier at least 4 digits long (e.g. use 0001 for 1). Please also check for unexpected characters like spaces.' }
   ),
   impact: z.nativeEnum(ImpactEnumWithBlank)

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -79,6 +79,6 @@ export const deepMap = (transform: (arg: any) => any, object: DeepMappable): any
     , object
   );
 
-export const cveRegex = /^\s*(CVE-\d{4}-\d{4,7})\s*$/;
+export const cveRegex = /^CVE-(?:1999|2\d{3})-(?!0{4})(?:0\d{3}|[1-9]\d{3,})$/;
 
 export const uniques = <T>(array: T[]) => Array.from(new Set(array));


### PR DESCRIPTION

- CVE validation on OSIM now matches OSIDB
- New error messages
- CVEs can be blank (OSIDB seems to complain for me still though)
- Reported Date validation has been added (doesn't show on initial load for Create Flaw for some reason)
- Comment#0 minimum length is back to one from 1

Handles:
- OSIDB-2260
- OSIDB-2453
- OSIDB-2311

Changes comment#0 error messages to indicate `Comment#0` instead of `description` and remove arbitrary 10 character length.