### PR TITLE
Fix/osidb 2454 attribution lists bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 ### Fixed
 * Fixed overlap on edit buttons at References and Acknowledgements items
 * Fixed inconsistent style on read-only fields with empty value
+* Fixed `References` and `Acknowledgements` don't open when new item is added
+* Fixed editing bugs on `References` and `Acknowledgements` lists
+* Fixed `Affiliation` text overflow on `Acknowledgements` labels
 
 ## [2024.1.0]
 

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -331,7 +331,11 @@ const onReset = () => {
             @acknowledgment:delete="deleteAcknowledgment"
           />
         </div>
-        <LabelCollapsable v-if="mode === 'edit'" :label="`Trackers: ${trackerUuids.length}`" :isExpandable="trackerUuids.length !== 0">
+        <LabelCollapsable
+          v-if="mode === 'edit'"
+          :label="`Trackers: ${trackerUuids.length}`" 
+          :isExpandable="trackerUuids.length !== 0"
+        >
           <ul>
             <li v-for="(tracker, trackerIndex) in trackerUuids" :key="trackerIndex">
               <RouterLink :to="{ name: 'tracker-details', params: { id: tracker.uuid } }">

--- a/src/components/IssueFieldAcknowledgments.vue
+++ b/src/components/IssueFieldAcknowledgments.vue
@@ -76,7 +76,7 @@ function handleDelete(uuid: string, closeModal: () => void) {
           </div>
           <button
             class="btn osim-cancel-new-acknowledgment"
-            @click="emit('acknowledgment:cancel-new', items[itemIndex])"
+            @click.prevent="emit('acknowledgment:cancel-new', items[itemIndex])"
           >
             <i class="bi bi-x" />
           </button>

--- a/src/components/IssueFieldAcknowledgments.vue
+++ b/src/components/IssueFieldAcknowledgments.vue
@@ -75,8 +75,9 @@ function handleDelete(uuid: string, closeModal: () => void) {
             />
           </div>
           <button
+            type="button"
             class="btn osim-cancel-new-acknowledgment"
-            @click.prevent="emit('acknowledgment:cancel-new', items[itemIndex])"
+            @click="emit('acknowledgment:cancel-new', items[itemIndex])"
           >
             <i class="bi bi-x" />
           </button>

--- a/src/components/IssueFieldReferences.vue
+++ b/src/components/IssueFieldReferences.vue
@@ -90,8 +90,9 @@ function handleDelete(uuid: string, closeModal: () => void) {
         <div class="form-group">
           <div class="p-3 pt-4">
             <button
+              type="button"
               class="btn osim-cancel-new-reference"
-              @click.prevent="emit('reference:cancel-new', items[itemIndex])"
+              @click="emit('reference:cancel-new', items[itemIndex])"
             >
               <i class="bi bi-x" />
             </button>

--- a/src/components/IssueFieldReferences.vue
+++ b/src/components/IssueFieldReferences.vue
@@ -91,7 +91,7 @@ function handleDelete(uuid: string, closeModal: () => void) {
           <div class="p-3 pt-4">
             <button
               class="btn osim-cancel-new-reference"
-              @click="emit('reference:cancel-new', items[itemIndex])"
+              @click.prevent="emit('reference:cancel-new', items[itemIndex])"
             >
               <i class="bi bi-x" />
             </button>

--- a/src/components/widgets/EditableList.vue
+++ b/src/components/widgets/EditableList.vue
@@ -177,7 +177,7 @@ function commitEdit(index: number) {
       >
         Save Changes to {{ entityNamePlural }}
       </button>
-      <button type="button" class="btn btn-secondary" @click.prevent="addItem()">
+      <button type="button" class="btn btn-secondary" @click="addItem()">
         Add {{ entityName }}
       </button>
     </form>

--- a/src/components/widgets/EditableList.vue
+++ b/src/components/widgets/EditableList.vue
@@ -63,7 +63,12 @@ function commitEdit(index: number) {
 
 <template>
   <div>
-    <LabelCollapsable :label="`${entityNamePlural}: ${items.length}`" :isExpandable="items.length > 0" :isExpanded="isExpanded" @setExpanded="isExpanded = !isExpanded">
+    <LabelCollapsable
+      :label="`${entityNamePlural}: ${items.length}`"
+      :isExpandable="items.length > 0"
+      :isExpanded="isExpanded"
+      @setExpanded="isExpanded = !isExpanded"
+    >
       <div
         v-for="(item, itemIndex) in items"
         :key="itemIndex"

--- a/src/components/widgets/EditableList.vue
+++ b/src/components/widgets/EditableList.vue
@@ -26,6 +26,8 @@ function useModalForItem(uuid: string) {
 
 const entityNamePlural = computed(() => props.entitiesName || `${props.entityName}s`);
 
+const isExpanded = ref(false);
+
 onMounted(() => (priorValues.value = deepCopyFromRaw(items.value)));
 
 const indexBeingEdited = ref<number | null>(null);
@@ -37,6 +39,11 @@ const itemsToSave = computed((): any[] => [
   ...items.value.filter((item, index) => modifiedItemIndexes.value.includes(index)),
   ...items.value.filter(({ uuid }) => !uuid),
 ]);
+
+function addItem() {
+  isExpanded.value = true;
+  emit('item:new');
+}
 
 function cancelEdit(index: number) {
   items.value[index] = deepCopyFromRaw(priorValues.value[index]);
@@ -56,7 +63,7 @@ function commitEdit(index: number) {
 
 <template>
   <div>
-    <LabelCollapsable :label="`${entityNamePlural}: ${items.length}`" :isExpandable="items.length > 0">
+    <LabelCollapsable :label="`${entityNamePlural}: ${items.length}`" :isExpandable="items.length > 0" :isExpanded="isExpanded" @setExpanded="isExpanded = !isExpanded">
       <div
         v-for="(item, itemIndex) in items"
         :key="itemIndex"
@@ -165,7 +172,7 @@ function commitEdit(index: number) {
       >
         Save Changes to {{ entityNamePlural }}
       </button>
-      <button type="button" class="btn btn-secondary" @click.prevent="emit('item:new')">
+      <button type="button" class="btn btn-secondary" @click.prevent="addItem()">
         Add {{ entityName }}
       </button>
     </form>

--- a/src/components/widgets/LabelInput.vue
+++ b/src/components/widgets/LabelInput.vue
@@ -46,7 +46,7 @@ const type = computed<string>(() => props.type ?? 'text');
 <template>
   <label class="osim-input has-validation mb-3 ps-3">
     <div class="row">
-      <span class="form-label col-3">
+      <span class="form-label col-3 gx-2">
         {{ label }}
         <!--attrs: {{ $attrs }}-->
       </span>

--- a/src/composables/useFlawAttributionsModel.ts
+++ b/src/composables/useFlawAttributionsModel.ts
@@ -34,7 +34,7 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, onSaveSuccess: 
   }
 
   function cancelAddReference(reference: ZodFlawReferenceType) {
-    flawReferences.value = flawReferences.value.filter((r) => r !== reference);
+    flawReferences.value.splice(flawReferences.value.indexOf(reference),1);
   }
 
   async function saveReferences(references: ZodFlawReferenceType[]) {
@@ -97,7 +97,7 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, onSaveSuccess: 
   }
 
   function cancelAddAcknowledgment(acknowledgment: ZodFlawAcknowledgmentType) {
-    flawAcknowledgments.value = flawAcknowledgments.value.filter((r) => r !== acknowledgment);
+    flawAcknowledgments.value.splice(flawAcknowledgments.value.indexOf(acknowledgment),1);
   }
 
   return {


### PR DESCRIPTION
Applies changes of OSIDB-2320:
- :bug: Expands `editableList` on new draft item added
- :bug: Prevents form submitting on `References` and `Acknowledgements` draft removals
- :bug: Fixes index errors on draft attribution removals
- :bug: Fixes `Affiliation` label text overflow on `Acknowledgements` items