### PR TITLE
🐛 Source flaw workflow status from classification field on flaw list [OSIDB-2504]

### DIFF
--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -105,7 +105,7 @@ function relevantFields(issue: any) {
     source: issue.source,
     created_dt: issue.created_dt,
     title: issue.title,
-    state: issue.state,
+    workflowState: issue.classification.state,
     unembargo_dt: issue.unembargo_dt,
     embargoed: issue.embargoed,
     owner: issue.owner,

--- a/src/components/IssueQueueItem.vue
+++ b/src/components/IssueQueueItem.vue
@@ -7,7 +7,7 @@ const props = defineProps<{
   selected: boolean;
 }>();
 
-const nonIdFields = ['impact', 'source', 'formattedDate', 'title', 'state', 'owner'];
+const nonIdFields = ['impact', 'source', 'formattedDate', 'title', 'workflowState', 'owner'];
 
 const isUnembargoDateScheduledForLater = computed(
   () => DateTime.fromISO(props.issue.unembargo_dt).diffNow().milliseconds > 0,
@@ -26,7 +26,7 @@ const hasBadges = computed(() => isEmbargoed.value);
 defineEmits<{
   (e: 'update:selected', selected: boolean): void;
 }>();
-// console.log('IssueQueueItem:', props.issue);
+
 </script>
 
 <template>

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -17,7 +17,7 @@ const FLAW_LIST_FIELDS = [
   'classification',
   // 'is_major_incident', TODO: replace with major_incident_state?
   'title',
-  'state',
+  'state', // not to be confused with classification.state
   'unembargo_dt',
   'embargoed',
   'owner',


### PR DESCRIPTION
# [OSIDB-2504] [Correct data source for workflow state in index view]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [ ] Changelog updated
- [ ] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Index/Flaw list view uses `flaw.state` instead of `flaw.classification.state`; this has been remedied.

## Changes: 

Issue Queue item component remaps to the correct field for workflow status.

## Considerations:

Very ambiguously named field name difference--should one (`flaw.state`) be deprecated/removed in OSIDB?