### PR TITLE
✨ OSIDB-1204 Create CVSSv3 calculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # OSIM Changelog
 
-## [Unreleased]
-### Fixed
-* The session is now shared across tabs
-
-
 ## [Unreleased] (TODO update for 2024.1.1 and 2024.2.0 releases)
+
+### Added
+* Embedded Cvss3 calculator in `Flaw` views
+
 ### Changed
 * Flaw URLs consists preferably of CVE ID if possible (OSIDB-2018)
 * Changed layout for Descriptions, References and Acknowledgements
@@ -22,6 +21,7 @@
 * `Source` field renamed to `CVE Source` on flaw form and advanced search
 * Added Total count for IndexView and AdvancedSearch Page
 * Add Default Filter on IndexView Page
+* Cvss vector and score fields converted to static (only editable through calculator)
 
 ### Fixed
 * Fixed overlap on edit buttons at References and Acknowledgements items
@@ -46,6 +46,8 @@
 * Fixed redirect `Flaws` link on `Flaw` edit page when `Flaw` is not found.
 * Fixed Scroll bar on `Flaws` list
 * Fixed 'outdated Flaw' error when updating affects, references, acknowlegdements, CVSS scores, flaw
+* The session is now shared across tabs
+
 
 
 ## [2024.1.0]

--- a/src/components/CvssCalculator.vue
+++ b/src/components/CvssCalculator.vue
@@ -81,10 +81,32 @@ const getFactorColor = computed(() => (weight: number, isHovered: boolean = fals
 function highlightFactor(factor: string | null) {
   highlightedFactor.value = factor;
 }
+
+function handlePaste(e: ClipboardEvent) {
+  let maybeCvss = e.clipboardData?.getData('text');
+  if (!maybeCvss) {
+    return; 
+  }
+
+  updateFactors(maybeCvss);
+  if (!getFactors(maybeCvss)['CVSS']) {
+    cvssFactors.value['CVSS'] = '3.1';
+  }
+
+  updateFactors(formatFactors(cvssFactors.value));
+  cvssScore.value = calculateScore(cvssFactors.value);
+}
+
+
 </script>
 
 <template>
-  <div ref="cvssDiv" tabindex="0" @focus="onInputFocus">
+  <div
+    ref="cvssDiv"
+    tabindex="0"
+    @focus="onInputFocus"
+    @paste="handlePaste"
+  >
     <div class="osim-input vector-row">
       <label class="label-group row">
         <span class="form-label col-2">

--- a/src/components/CvssCalculator.vue
+++ b/src/components/CvssCalculator.vue
@@ -1,0 +1,258 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import LabelStatic from '@/components/widgets/LabelStatic.vue';
+import { 
+  calculatorButtons,
+  getFactors,
+  formatFactor,
+  calculateScore,
+  getFactorColor,
+  formatFactors,
+  factorSeverities,
+  validateCvssVector
+} from '@/composables/useCvssCalculator';
+
+const cvssVector = defineModel<string | undefined | null>('cvssVector');
+const cvssScore = defineModel<number | null>('cvssScore');
+
+const error = computed(() => validateCvssVector(cvssVector.value));
+
+const cvssFactors = ref<Record<string, string>>({});
+const isFocused = ref(false);
+const cvssDiv = ref();
+const cvssVectorInput = ref();
+
+function updateFactors(newCvssVector: string | undefined | null) {
+  if(cvssVector.value !== newCvssVector) {
+    cvssVector.value = newCvssVector;
+  }
+  cvssFactors.value =  getFactors(newCvssVector ?? '');
+}
+
+updateFactors(cvssVector.value);
+
+function factorButton(id: string, key: string) {
+  if(!cvssFactors.value['CVSS']) {
+    cvssFactors.value = getFactors('CVSS:3.1');
+  }
+  cvssFactors.value[id] = cvssFactors.value[id] === key ? '' : key;
+  updateFactors(formatFactors(cvssFactors.value));
+  cvssScore.value = calculateScore(cvssFactors.value);
+}
+
+function onInputFocus(event: FocusEvent) {
+  isFocused.value = true;
+  if (event.target !== cvssVectorInput.value) {
+    cvssVectorInput.value.focus();
+  }
+}
+
+function onInputBlur(event: FocusEvent) {
+  if(event.relatedTarget !== cvssDiv.value) {
+    isFocused.value=false;
+  }
+}
+
+function reset() {
+  cvssScore.value = null;
+  cvssVector.value = null;
+  cvssFactors.value = {};
+}
+</script>
+
+<template>
+  <div ref="cvssDiv" tabindex="0" @focus="onInputFocus">
+    <div class="osim-input vector-row">
+      <label class="label-group row">
+        <span class="form-label col-2">
+          CVSSv3
+        </span>
+        <div class="input-wrapper col">
+          <div
+            ref="cvssVectorInput"
+            tabindex="0"
+            class="vector-input form-control"
+            :class="{ 
+              'is-invalid': error != null, 
+              'dark-background': isFocused,
+              'text-cursor': isFocused,
+              'alert alert-warning': !cvssVector
+            }"
+            v-bind="$attrs"
+            focused
+            @focus="onInputFocus"
+            @blur="onInputBlur"
+            @change="updateFactors(cvssVector)"
+          >
+            <template v-for="(value, key) in cvssFactors" :key="key">
+              <span
+                v-if="value"
+                :style="isFocused && key.toString() !== 'CVSS'
+                  ?`color: ${getFactorColor(key.toString(), value)}`
+                  : (isFocused ? 'color: white' : 'color: black')"
+              >
+                {{ formatFactor(key.toString(), value) }}
+              </span>
+            </template>
+          </div>
+        </div>
+        <div
+          v-if="error"
+          class="invalid-tooltip"
+        >
+          {{ error }}
+        </div>
+      </label>
+      <button
+        type="button"
+        :disabled="!cvssVector"
+        class="erase-button input-group-text"
+        @click="reset()"
+        @mousedown="event => event.preventDefault()"
+      >
+        <i class="bi bi-eraser"></i>
+      </button>
+    </div>
+    <div
+      class="cvss-calculator row"
+      :class="{ 'visually-hidden': !isFocused }"
+    >
+      <div
+        class="osim-input"
+        mx-0nd="$attrs"
+      >
+        <div class="px-3 py-2">
+          <div 
+            v-for="(row, rowIndex) in calculatorButtons.rows" 
+            :key="rowIndex" 
+            class="row-group"
+          >
+            <div
+              v-for="(col, colIndex) in row.cols"
+              :key="colIndex" 
+              class="col-group"
+            >
+              <div class="btn-group-vertical btn-group-sm">
+                <button class="btn-group-header btn lh-sm" disabled>{{ col.label }}</button>
+                <template v-for="(button, btnIndex) in col.buttons" :key="btnIndex">
+                  <button
+                    type="button"
+                    class="btn lh-sm"
+                    :style="{
+                      backgroundColor: cvssFactors[col.id] === button.key ?
+                        getFactorColor(col.id, button.key) : '#E0E0E0',
+                      color: (cvssFactors[col.id] === button.key && factorSeverities[col.id][button.key] !== 'Bad') ?
+                        'white' : 'inherit'
+                    }"
+                    data-bs-toggle="tooltip"
+                    data-bs-placement="right"
+                    :title="`${factorSeverities[col.id][button.key]}: ${button.info}`"
+                    @click="factorButton(col.id, button.key)"
+                    @mousedown="event => event.preventDefault()"
+                  >
+                    {{ button.name }}
+                  </button>
+                </template>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <LabelStatic
+      v-model="cvssScore"
+      label="CVSSv3 Score"
+      type="text"
+      class="score-input"
+      :hasTopLabelStyle="false"
+    />
+  </div>
+</template>
+
+<style scoped lang="scss">
+.osim-input {
+  display: inline-flex;
+  width: 100%;
+  margin-bottom: 15px;
+
+  .label-group {
+    width: 100%;
+    position: relative;
+    min-height: 38px;
+    margin-inline: 0;
+    padding-left: 0.25rem;
+    height: 100%;
+  
+    .input-wrapper {
+      z-index: 1;
+      padding-inline: 0;
+      margin-inline: 0;
+    }
+
+    .vector-input {
+      height: 100%;
+      border-radius: 0;
+      padding-left: 30px;
+    }
+
+    .vector-input.alert {
+      padding-block: 10px;
+    }
+
+  }
+
+  .erase-button {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left: 0;
+  }
+
+  .invalid-tooltip {
+    display: none;
+  }
+
+  &:hover .invalid-tooltip {
+    display: block;
+    width: 75%;
+    right: 5%;
+  }
+
+  .row-group {
+    display: flex;
+    flex-direction: row;
+    margin-block: 10px;
+
+    .col-group {
+      display: flex;
+      flex-direction: column;
+      margin-inline: 5px;
+      width: 100%;
+      
+      .btn-group-header {
+        background-color: #1F1F1F !important;
+        color: white;
+        border: 0;
+        padding-block: 7.5px;
+        font-weight: 600;
+      }
+
+      .btn, .btn:hover {
+        border: 1px;
+        margin: auto;
+      }
+    }
+  }
+}
+
+.score-input {
+  display: block;
+}
+
+.text-cursor {
+  cursor: text !important;
+}
+
+.dark-background {
+  background-color: #525252 !important;
+}
+</style>

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import { DateTime } from 'luxon';
-import { computed, ref, watch, onMounted } from 'vue';
+import { ref, watch, onMounted } from 'vue';
 import { RouterLink } from 'vue-router';
 import { deepCopyFromRaw } from '@/utils/helpers';
 
 import LabelEditable from '@/components/widgets/LabelEditable.vue';
 import LabelSelect from '@/components/widgets/LabelSelect.vue';
 import LabelTextarea from '@/components/widgets/LabelTextarea.vue';
-import LabelStatic from '@/components/widgets/LabelStatic.vue';
 import LabelCollapsable from '@/components/widgets/LabelCollapsable.vue';
 import AffectedOfferings from '@/components/AffectedOfferings.vue';
 import IssueFieldEmbargo from '@/components/IssueFieldEmbargo.vue';
@@ -19,6 +18,7 @@ import IssueFieldAcknowledgments from './IssueFieldAcknowledgments.vue';
 import CvssNISTForm from '@/components/CvssNISTForm.vue';
 import FlawComments from '@/components/FlawComments.vue';
 import LabelDiv from '@/components/widgets/LabelDiv.vue';
+import CvssCalculator from '@/components/CvssCalculator.vue';
 
 import { useFlawModel } from '@/composables/useFlawModel';
 import { fileTracker, type TrackersFilePost } from '@/services/TrackerService';
@@ -100,10 +100,6 @@ const showSummary = ref(flaw.value.summary && flaw.value.summary.trim() !== '');
 const showStatement = ref(flaw.value.statement && flaw.value.statement.trim() !== '');
 const showMitigation = ref(flaw.value.mitigation && flaw.value.mitigation.trim() !== '');
 
-const flawCvss3CaculatorLink = computed(
-  () => `https://www.first.org/cvss/calculator/3.1#${flawRhCvss3.value?.vector}`,
-);
-
 const onReset = () => {
   flaw.value = deepCopyFromRaw(initialFlaw.value as Record<string, any>) as ZodFlawType;
 };
@@ -159,26 +155,16 @@ const onReset = () => {
               />
             </div>
           </div>
-
           <LabelSelect
             v-model="flaw.impact"
             label="Impact"
             :options="flawImpacts"
             :error="errors.impact"
           />
-          <LabelEditable v-model="flawRhCvss3.vector" type="text">
-            <template #label>
-              <span class="mb-0 pt-2 pb-2">CVSSv3
-                <br />
-                <a
-                  :href="flawCvss3CaculatorLink"
-                  target="_blank"
-                ><i class="bi-calculator me-1"></i>Calculator</a>
-              </span>
-            </template>
-          </LabelEditable>
-
-          <LabelStatic v-model="flawRhCvss3.score" label="CVSSv3 Score" type="text" />
+          <CvssCalculator
+            v-model:cvss-vector="flawRhCvss3.vector"
+            v-model:cvss-score="flawRhCvss3.score"
+          />
           <div class="row">
             <div class="col">
               <LabelDiv label="NVD CVSSv3">

--- a/src/components/__tests__/CvssCalculator.spec.ts
+++ b/src/components/__tests__/CvssCalculator.spec.ts
@@ -1,0 +1,401 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+
+import CvssCalculator from '../CvssCalculator.vue';
+
+function activateFactorButton(subject: any, factor: string, value: string) {
+  const factorButtonGroup = subject.findAll('.btn-group-vertical')
+    .filter((node: { text: () => string | string[]; }) => node.text().includes(factor))[0];
+  const factorButton = factorButtonGroup
+    .findAll('.btn')
+    .filter((node: { text: () => string; }) => node.text() === value)[0];
+  factorButton.trigger('click');
+}
+
+function activateMultipleFactorButtons(subject: any, factorValuePairs: [string, string][]) {
+  for (const [factor, value] of factorValuePairs) {
+    activateFactorButton(subject, factor, value);
+  }
+}
+
+describe('CvssCalculator', () => {
+  
+  let subject: any;
+
+  beforeEach(() => {
+    subject = mount(CvssCalculator, {
+      props: {
+        'cvssScore': null,
+        'onUpdate:cvssScore': (e: any) => subject.setProps({ 'cvssScore': e }),
+        'cvssVector': '',
+        'onUpdate:cvssVector': (e: any) => subject.setProps({ 'cvssVector': e }),
+      },
+    });
+  });
+
+  it('Shows calculator on input focus', async () => {
+    await subject.find('.vector-input').trigger('focus');
+    expect(subject.find('.cvss-calculator').classes('visually-hidden')).toBe(false);
+  });
+
+  it('Hides calculator on input blur', async () => {
+    await subject.find('.vector-input');
+    expect(subject.find('.cvss-calculator').classes('visually-hidden')).toBe(true);
+  });
+
+  // Validations
+  it('Doesn\'t show validation on empty vector', async () => {
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.classes().includes('is-invalid')).toBe(false);
+  });
+
+  it('Doesn\'t show validation on complete vector', async () => {
+    const factorValuePairs: [string, string][] = [
+      ['Attack Vector', 'Network'],
+      ['Attack Complexity', 'Low'],
+      ['Privileges Required', 'None'],
+      ['User Interaction', 'None'],
+      ['Scope', 'Changed'],
+      ['Confidentiality', 'High'],
+      ['Integrity', 'High'],
+      ['Availability', 'High']
+    ];
+    await activateMultipleFactorButtons(subject, factorValuePairs);
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.classes().includes('is-invalid')).toBe(false);
+  });
+
+  it('Shows validation on incomplete vector', async () => {
+    const factorValuePairs: [string, string][] = [
+      ['Availability', 'High']
+    ];
+    await activateMultipleFactorButtons(subject, factorValuePairs);
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.classes().includes('is-invalid')).toBe(true);
+  });
+
+  // Score Calculation Test Cases
+  // Critical score
+  it('Calculates critical score correctly', async () => {
+    const factorValuePairs: [string, string][] = [
+      ['Attack Vector', 'Network'],
+      ['Attack Complexity', 'Low'],
+      ['Privileges Required', 'None'],
+      ['User Interaction', 'None'],
+      ['Scope', 'Changed'],
+      ['Confidentiality', 'High'],
+      ['Integrity', 'High'],
+      ['Availability', 'High']
+    ];
+    await activateMultipleFactorButtons(subject, factorValuePairs);
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toBe('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H');
+    const inputScoreValue = subject.find('.score-input');
+    expect(inputScoreValue.text()).toContain('10');
+  });
+
+  // High score
+  it('Calculates high score correctly', async () => {
+    const factorValuePairs: [string, string][] = [
+      ['Attack Vector', 'Adjacent'],
+      ['Attack Complexity', 'High'],
+      ['Privileges Required', 'Low'],
+      ['User Interaction', 'Required'],
+      ['Scope', 'Changed'],
+      ['Confidentiality', 'Low'],
+      ['Integrity', 'High'],
+      ['Availability', 'High']
+    ];
+    await activateMultipleFactorButtons(subject, factorValuePairs);
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toBe('CVSS:3.1/AV:A/AC:H/PR:L/UI:R/S:C/C:L/I:H/A:H');
+    const inputScoreValue = subject.find('.score-input');
+    expect(inputScoreValue.text()).toContain('7.5');
+  });
+
+  // Medium score
+  it('Calculates medium score correctly', async () => {
+    const factorValuePairs: [string, string][] = [
+      ['Attack Vector', 'Adjacent'],
+      ['Attack Complexity', 'High'],
+      ['Privileges Required', 'Low'],
+      ['User Interaction', 'Required'],
+      ['Scope', 'Unchanged'],
+      ['Confidentiality', 'Low'],
+      ['Integrity', 'Low'],
+      ['Availability', 'Low']
+    ];
+    await activateMultipleFactorButtons(subject, factorValuePairs);
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toBe('CVSS:3.1/AV:A/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L');
+    const inputScoreValue = subject.find('.score-input');
+    expect(inputScoreValue.text()).toContain('4.3');
+  });
+
+  // Low score
+  it('Calculates low score correctly', async () => {
+    const factorValuePairs: [string, string][] = [
+      ['Attack Vector', 'Local'],
+      ['Attack Complexity', 'High'],
+      ['Privileges Required', 'High'],
+      ['User Interaction', 'Required'],
+      ['Scope', 'Unchanged'],
+      ['Confidentiality', 'None'],
+      ['Integrity', 'Low'],
+      ['Availability', 'Low']
+    ];
+    await activateMultipleFactorButtons(subject, factorValuePairs);
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toBe('CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L');
+    const inputScoreValue = subject.find('.score-input');
+    expect(inputScoreValue.text()).toContain('2.9');
+  });
+
+  // Zero score
+  it('Calculates zero score correctly', async () => {
+    const factorValuePairs: [string, string][] = [
+      ['Attack Vector', 'Physical'],
+      ['Attack Complexity', 'High'],
+      ['Privileges Required', 'High'],
+      ['User Interaction', 'Required'],
+      ['Scope', 'Unchanged'],
+      ['Confidentiality', 'None'],
+      ['Integrity', 'None'],
+      ['Availability', 'None']
+    ];
+    await activateMultipleFactorButtons(subject, factorValuePairs);
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toBe('CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N');
+    const inputScoreValue = subject.find('.score-input');
+    expect(inputScoreValue.text()).toContain('0');
+  });
+
+  // Calculator Buttons Test Cases
+  // Attack Vector
+  // Network button
+  it('Attack vector\'s network button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Attack Vector', 'Network');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('AV:N');
+    // Reactivating button
+    await activateFactorButton(subject, 'Attack Vector', 'Network');
+    expect(inputVectorValue.text().includes('AV:N')).toBe(false);
+  });
+
+  // Adjacent button
+  it('Attack vector\'s adjacent button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Attack Vector', 'Adjacent');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('AV:A');
+    // Reactivating button
+    await activateFactorButton(subject, 'Attack Vector', 'Adjacent');
+    expect(inputVectorValue.text().includes('AV:A')).toBe(false);
+  });
+
+  // Local button
+  it('Attack vector\'s local button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Attack Vector', 'Local');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('AV:L');
+    // Reactivating button
+    await activateFactorButton(subject, 'Attack Vector', 'Local');
+    expect(inputVectorValue.text().includes('AV:L')).toBe(false);
+  });
+
+  // Physical button
+  it('Attack vector\'s physical button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Attack Vector', 'Physical');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('AV:P');
+    // Reactivating button
+    await activateFactorButton(subject, 'Attack Vector', 'Physical');
+    expect(inputVectorValue.text().includes('AV:P')).toBe(false);
+  });
+
+  // Attack Complexity
+  // Low button
+  it('Attack complexity\'s low button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Attack Complexity', 'Low');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('AC:L');
+    // Reactivating button
+    await activateFactorButton(subject, 'Attack Complexity', 'Low');
+    expect(inputVectorValue.text().includes('AC:L')).toBe(false);
+  });
+
+  // High button
+  it('Attack complexity\'s high button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Attack Complexity', 'High');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('AC:H');
+    // Reactivating button
+    await activateFactorButton(subject, 'Attack Complexity', 'High');
+    expect(inputVectorValue.text().includes('AC:H')).toBe(false);
+  });
+
+  // Privileges Required
+  // None button
+  it('Privileges required\'s none button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Privileges Required', 'None');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('PR:N');
+    // Reactivating button
+    await activateFactorButton(subject, 'Privileges Required', 'None');
+    expect(inputVectorValue.text().includes('PR:N')).toBe(false);
+  });
+
+  // Low button
+  it('Privileges required\'s low button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Privileges Required', 'Low');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('PR:L');
+    // Reactivating button
+    await activateFactorButton(subject, 'Privileges Required', 'Low');
+    expect(inputVectorValue.text().includes('PR:L')).toBe(false);
+  });
+
+  // High button
+  it('Privileges required\'s high button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Privileges Required', 'High');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('PR:H');
+    // Reactivating button
+    await activateFactorButton(subject, 'Privileges Required', 'High');
+    expect(inputVectorValue.text().includes('PR:H')).toBe(false);
+  });
+
+  // User Interaction
+  // None button
+  it('User Interaction\'s none button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'User Interaction', 'None');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('UI:N');
+    // Reactivating button
+    await activateFactorButton(subject, 'User Interaction', 'None');
+    expect(inputVectorValue.text().includes('UI:N')).toBe(false);
+  });
+
+  // Required button
+  it('User Interaction\'s required button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'User Interaction', 'Required');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('UI:R');
+    // Reactivating button
+    await activateFactorButton(subject, 'User Interaction', 'Required');
+    expect(inputVectorValue.text().includes('UI:R')).toBe(false);
+  });
+
+  // Scope
+  // Unchanged button
+  it('Scope\'s unchanged button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Scope', 'Unchanged');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('S:U');
+    // Reactivating button
+    await activateFactorButton(subject, 'Scope', 'Unchanged');
+    expect(inputVectorValue.text().includes('S:U')).toBe(false);
+  });
+
+  // Changed button
+  it('Scope\'s changed button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Scope', 'Changed');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('S:C');
+    // Reactivating button
+    await activateFactorButton(subject, 'Scope', 'Changed');
+    expect(inputVectorValue.text().includes('S:C')).toBe(false);
+  });
+
+  // Confidentiality
+  // None button
+  it('Confidentiality\'s none button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Confidentiality', 'None');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('C:N');
+    // Reactivating button
+    await activateFactorButton(subject, 'Confidentiality', 'None');
+    expect(inputVectorValue.text().includes('C:N')).toBe(false);
+  });
+
+  // Low button
+  it('Confidentiality\'s low button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Confidentiality', 'Low');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('C:L');
+    // Reactivating button
+    await activateFactorButton(subject, 'Confidentiality', 'Low');
+    expect(inputVectorValue.text().includes('C:L')).toBe(false);
+  });
+
+  // High button
+  it('Confidentiality\'s high button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Confidentiality', 'High');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('C:H');
+    // Reactivating button
+    await activateFactorButton(subject, 'Confidentiality', 'High');
+    expect(inputVectorValue.text().includes('C:H')).toBe(false);
+  });
+
+  // Integrity
+  // None button
+  it('Integrity\'s none button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Integrity', 'None');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('I:N');
+    // Reactivating button
+    await activateFactorButton(subject, 'Integrity', 'None');
+    expect(inputVectorValue.text().includes('I:N')).toBe(false);
+  });
+
+  // Low button
+  it('Integrity\'s low button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Integrity', 'Low');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('I:L');
+    // Reactivating button
+    await activateFactorButton(subject, 'Integrity', 'Low');
+    expect(inputVectorValue.text().includes('I:L')).toBe(false);
+  });
+
+  // High button
+  it('Integrity\'s high button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Integrity', 'High');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('I:H');
+    // Reactivating button
+    await activateFactorButton(subject, 'Integrity', 'High');
+    expect(inputVectorValue.text().includes('I:H')).toBe(false);
+  });
+
+  // Availability
+  // None button
+  it('Availability\'s none button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Availability', 'None');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('A:N');
+    // Reactivating button
+    await activateFactorButton(subject, 'Availability', 'None');
+    expect(inputVectorValue.text().includes('A:N')).toBe(false);
+  });
+
+  // Low button
+  it('Availability\'s low button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Availability', 'Low');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('A:L');
+    // Reactivating button
+    await activateFactorButton(subject, 'Availability', 'Low');
+    expect(inputVectorValue.text().includes('A:L')).toBe(false);
+  });
+
+  // High button
+  it('Availability\'s high button updates vector input field correctly', async () => {
+    await activateFactorButton(subject, 'Availability', 'High');
+    const inputVectorValue = subject.find('.vector-input');
+    expect(inputVectorValue.text()).toContain('A:H');
+    // Reactivating button
+    await activateFactorButton(subject, 'Availability', 'High');
+    expect(inputVectorValue.text().includes('A:H')).toBe(false);
+  });
+});

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -132,7 +132,7 @@ describe('FlawForm', () => {
 
     const cvssV3Field = subject
       .findAllComponents(LabelEditable)
-      .find((component) => component.text().includes('CVSSv3') && component.text().includes('Calculator'));
+      .find((component) => component.text().includes('CVSSv3'));
     expect(cvssV3Field?.exists()).toBe(true);
 
     const cvssV3ScoreField = subject

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -14,8 +14,8 @@ import { DateTime } from 'luxon';
 import LabelDiv from '../widgets/LabelDiv.vue';
 import LabelSelect from '../widgets/LabelSelect.vue';
 import LabelCollapsable from '../widgets/LabelCollapsable.vue';
-import LabelStatic from '../widgets/LabelStatic.vue';
 import LabelTextarea from '../widgets/LabelTextarea.vue';
+import CvssCalculator from '../CvssCalculator.vue';
 
 const FLAW_BASE_URI = '/osidb/api/v1/flaws';
 // const FLAW_BASE_URI = `http://localhost:5173/tests/3ede0314-a6c5-4462-bcf3-b034a15cf106`;
@@ -136,8 +136,8 @@ describe('FlawForm', () => {
     expect(cvssV3Field?.exists()).toBe(true);
 
     const cvssV3ScoreField = subject
-      .findAllComponents(LabelStatic)
-      .find((component) => component.props().label === 'CVSSv3 Score');
+      .findAllComponents(CvssCalculator)
+      .find((component) => component.html().includes('CVSSv3 Score'));
     expect(cvssV3ScoreField?.exists()).toBe(true);
 
     const nvdCvssField = subject
@@ -226,13 +226,13 @@ describe('FlawForm', () => {
     expect(impactField?.exists()).toBe(true);
 
     const cvssV3Field = subject
-      .findAllComponents(LabelEditable)
+      .findAllComponents(CvssCalculator)
       .find((component) => component.html().includes('CVSSv3'));
     expect(cvssV3Field?.exists()).toBe(true);
 
     const cvssV3ScoreField = subject
-      .findAllComponents(LabelStatic)
-      .find((component) => component.props().label === 'CVSSv3 Score');
+      .findAllComponents(CvssCalculator)
+      .find((component) => component.html().includes('CVSSv3 Score'));
     expect(cvssV3ScoreField?.exists()).toBe(true);
 
     const nvdCvssField = subject
@@ -394,13 +394,6 @@ describe('FlawForm', () => {
         },
       },
     });
-    const cvss3EditField = subject
-      .findAllComponents(LabelEditable)
-      .find((component) => component.text().includes('CVSSv3'));
-    expect(cvss3EditField?.exists()).toBeTruthy();
-    const linkElement = cvss3EditField?.find('a');
-    expect(linkElement?.exists()).toBeTruthy();
-    expect(linkElement?.attributes('href')).toBe('https://www.first.org/cvss/calculator/3.1#null');
   });
 
   it('displays correct CVSSv3 calculator link for CVSSv3 value', async () => {
@@ -421,15 +414,6 @@ describe('FlawForm', () => {
         },
       },
     });
-    const cvss3EditField = subject
-      .findAllComponents(LabelEditable)
-      .find((component) => component.text().includes('CVSSv3'));
-    expect(cvss3EditField?.exists()).toBeTruthy();
-    const linkElement = cvss3EditField?.find('a');
-    expect(linkElement?.exists()).toBeTruthy();
-    expect(linkElement?.attributes('href')).toBe(
-      'https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:L/I:N/A:N',
-    );
   });
 
   it('shows a error message when nvd score and Rh score mismatch', async () => {

--- a/src/components/widgets/LabelStatic.vue
+++ b/src/components/widgets/LabelStatic.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
-defineProps<{
+import { computed } from 'vue';
+
+const props = defineProps<{
   modelValue: string | number | null | undefined;
   label: string;
   error?: string;
   hasTopLabelStyle?: boolean;
 }>();
+
+const emptyModel = computed(() => {
+  return props.modelValue === null || props.modelValue === undefined;
+});
 </script>
 
 <template>
@@ -16,7 +22,7 @@ defineProps<{
       <div class="top-left-corner">
         <span 
           class="form-control top-left-corner" 
-          :class="{ 'alert alert-warning': !modelValue }"
+          :class="{ 'alert alert-warning': emptyModel }"
         >
           {{ modelValue }}
         </span>
@@ -27,7 +33,7 @@ defineProps<{
         {{ label }}
       </span>
       <div class="col-9">
-        <span class="form-control" :class="{ 'alert alert-warning': !modelValue }">{{ modelValue }}</span>
+        <span class="form-control" :class="{ 'alert alert-warning': emptyModel }">{{ modelValue }}</span>
       </div>
     </div>
   </div>
@@ -36,6 +42,10 @@ defineProps<{
 <style scoped>
 .osim-static-label span.form-control {
   word-wrap: break-word;
+}
+
+span.form-control.alert {
+  padding-block: 10px;
 }
 
 .osim-static-label .osim-static-label-top-style .top-label {

--- a/src/composables/useCvssCalculator.ts
+++ b/src/composables/useCvssCalculator.ts
@@ -89,23 +89,22 @@ function calculateBaseScore(factors: Record<string, string>) {
 }
 
 // Gets color for factor weight
-export function getFactorColor(factor: string, value: string) {
-  const severity = factorSeverities[factor][value];
-  switch (severity) {
-  case 'Good':
-    return '#4CBD52'; // Green
-  case 'Bad':
-    return '#FBC94B'; // Yellow
-  case 'Worse':
-    return '#FF841F'; // Orange
-  default:
-    return '#FF5447'; // Red
-  }
-  
-}
+// export function getFactorColor(factor: string, value: string) {
+//   const severity = factorSeverities[factor][value];
+//   switch (severity) {
+//   case 'Good':
+//     return '#4CBD52'; // Green
+//   case 'Bad':
+//     return '#FBC94B'; // Yellow
+//   case 'Worse':
+//     return '#FF841F'; // Orange
+//   default:
+//     return '#FF5447'; // Red
+//   }
+// }
 
 // Factors Weights
-const weights: { [factor: string]: { [value: string]: number } } = {
+export const weights: { [factor: string]: { [value: string]: number } } = {
   AV: { N: 0.85, A: 0.62, L: 0.55, P: 0.2 },
   AC: { L: 0.77, H: 0.44 },
   PRU: { N: 0.85, L: 0.62, H: 0.27 },
@@ -114,9 +113,11 @@ const weights: { [factor: string]: { [value: string]: number } } = {
   C: { N: 0.0, L: 0.22, H: 0.56 },
   I: { N: 0.0, L: 0.22, H: 0.56 },
   A: { N: 0.0, L: 0.22, H: 0.56 },
+  S: { U: .5, C: 1 },
+  PR: { N: 0.85, L: 0.62, H: 0.33 },
+
 };
 
-// Factors severities
 export const factorSeverities: { [factor: string]: { [value: string]: string } } = {
   AV: { N: 'Worst', A: 'Worse', L: 'Bad', P: 'Bad' },
   AC: { L: 'Worst', H: 'Bad' },

--- a/src/composables/useCvssCalculator.ts
+++ b/src/composables/useCvssCalculator.ts
@@ -1,0 +1,337 @@
+import { z } from 'zod';
+
+export const cvssVectorSchema = z.union([
+  z.string().length(44, { message: 'Incomplete Cvss Vector. There are factors missing.' }),
+  z.string().length(0).nullable()]);
+
+export function validateCvssVector(cvssVector: string | undefined | null) {
+  const parseResult = cvssVectorSchema.safeParse(cvssVector);
+  if(parseResult.success === false) {
+    return parseResult.error.errors[0].message;
+  }
+  return null;
+}
+
+// Format factor for vector display
+export function formatFactor(key: string, value: string) {
+  return key === 'CVSS' ? `${key}:${value}` : `/${key}:${value}`;
+}
+
+// Get vector string from factors
+export function formatFactors(factors: Record<string, string>) {
+  let vector = '';
+  for(const key in factors) {
+    if(factors[key]) {
+      vector += formatFactor(key, factors[key]);
+    }
+  }
+  return vector;
+}
+
+// Get factor values from vector
+export function getFactors(cvssVector: string){
+  const factors: Record<string, string> = {};
+  if (!cvssVector) {
+    for (const key in factorPatterns) {
+      factors[key] = '';
+    }
+  } else {
+    for (const key in factorPatterns) {
+      const regex = factorPatterns[key];
+      const match = cvssVector.match(regex);
+      factors[key] = match && match.groups ? 
+        match.groups[key]
+        : '';
+    }
+  }
+  return factors;
+}
+
+// Calculates score
+export function calculateScore(factors: Record<string, string>) {
+  const score = calculateBaseScore(factors);
+  return isNaN(score) || Object.values(factors).includes('') ? null : score;
+}
+
+// Calculates base score
+function calculateBaseScore(factors: Record<string, string>) {
+  const unchangedScope = factors['S'] === 'U';
+
+  // ISS
+  const confidentiality = weights['C'][factors['C']];
+  const integrity = weights['I'][factors['I']];
+  const availability = weights['A'][factors['A']];
+  
+  const iss = 1 - ((1 - confidentiality) * (1 - integrity) * (1 - availability));
+
+  // Impact
+  const impact = unchangedScope ? 6.42 * iss : (7.52 * (iss - 0.029) - (3.25 * ((iss - 0.02)**15)));
+
+  // Exploitability
+  const attackVector = weights['AV'][factors['AV']];
+  const attackComplexity = weights['AC'][factors['AC']];
+  const privilegesRequired = unchangedScope ? weights['PRU'][factors['PR']] : weights['PRC'][factors['PR']];
+  const userInteraction = weights['UI'][factors['UI']];
+
+  const exploitability = 8.22 * attackVector * attackComplexity * privilegesRequired * userInteraction;
+
+  // Base score
+  let baseScore = 0;
+
+  if(impact > 0) {
+    baseScore = unchangedScope ? Math.min((impact + exploitability), 10)
+      : Math.min(1.08 * (impact + exploitability), 10);
+    // Round up with one decimal precision
+    baseScore = Math.round(Math.ceil(10 * baseScore)) / 10;
+  }
+
+  return baseScore;
+}
+
+// Gets color for factor weight
+export function getFactorColor(factor: string, value: string) {
+  const severity = factorSeverities[factor][value];
+  switch (severity) {
+  case 'Good':
+    return '#4CBD52'; // Green
+  case 'Bad':
+    return '#FBC94B'; // Yellow
+  case 'Worse':
+    return '#FF841F'; // Orange
+  default:
+    return '#FF5447'; // Red
+  }
+  
+}
+
+// Factors Weights
+const weights: { [factor: string]: { [value: string]: number } } = {
+  AV: { N: 0.85, A: 0.62, L: 0.55, P: 0.2 },
+  AC: { L: 0.77, H: 0.44 },
+  PRU: { N: 0.85, L: 0.62, H: 0.27 },
+  PRC: { N: 0.85, L: 0.68, H: 0.5 },
+  UI: { N: 0.85, R: 0.62 },
+  C: { N: 0.0, L: 0.22, H: 0.56 },
+  I: { N: 0.0, L: 0.22, H: 0.56 },
+  A: { N: 0.0, L: 0.22, H: 0.56 },
+};
+
+// Factors severities
+export const factorSeverities: { [factor: string]: { [value: string]: string } } = {
+  AV: { N: 'Worst', A: 'Worse', L: 'Bad', P: 'Bad' },
+  AC: { L: 'Worst', H: 'Bad' },
+  PR: { N: 'Worst', L: 'Worse', H: 'Bad' },
+  UI: { N: 'Worst', R: 'Bad' },
+  S: { U: 'Bad', C: 'Worst' },
+  C: { H: 'Worst', L: 'Bad', N: 'Good' },
+  I: { H: 'Worst', L: 'Bad', N: 'Good' },
+  A: { H: 'Worst', L: 'Bad', N: 'Good' },
+};
+
+
+// Factor regex patterns
+const factorPatterns: { [id: string]: RegExp } = {
+  CVSS: /(?<=^|\/)CVSS:(?<CVSS>[^/]+)/,
+  AV: /(?<=^|\/)AV:(?<AV>[NALP])/,
+  AC: /(?<=^|\/)AC:(?<AC>[LH])/,
+  PR: /(?<=^|\/)PR:(?<PR>[NLH])/,
+  UI: /(?<=^|\/)UI:(?<UI>[NR])/,
+  S: /(?<=^|\/)S:(?<S>[UC])/,
+  C: /(?<=^|\/)C:(?<C>[NLH])/,
+  I: /(?<=^|\/)I:(?<I>[NLH])/,
+  A: /(?<=^|\/)A:(?<A>[NLH])/
+};
+
+/* eslint-disable max-len */
+// Calculator Buttons Data
+export const calculatorButtons = {
+  name: 'Base Score',
+  rows: [
+    {
+      cols: [
+        {
+          id: 'AV',
+          label: 'Attack Vector',
+          buttons: [
+            { 
+              key: 'N',
+              name: 'Network',
+              value:'Network Attack Vector',
+              info: 'The vulnerable component is bound to the network stack and the set of possible attackers extends beyond the other options listed below, up to and including the entire Internet. Such a vulnerability is often termed “remotely exploitable” and can be thought of as an attack being exploitable at the protocol level one or more network hops away (e.g., across one or more routers).' 
+            },
+            {
+              key: 'A',
+              name: 'Adjacent', value:'Adjacent Attack Vector',
+              info: 'The vulnerable component is bound to the network stack, but the attack is limited at the protocol level to a logically adjacent topology. This can mean an attack must be launched from the same shared physical (e.g., Bluetooth or IEEE 802.11) or logical (e.g., local IP subnet) network, or from within a secure or otherwise limited administrative domain (e.g., MPLS, secure VPN to an administrative network zone). One example of an Adjacent attack would be an ARP (IPv4) or neighbor discovery (IPv6) flood leading to a denial of service on the local LAN segment.'
+            },
+            { 
+              key: 'L',
+              name: 'Local',
+              value:'Local Attack Vector',
+              info: 'The vulnerable component is not bound to the network stack and the attacker’s path is via read/write/execute capabilities. Either: 1.the attacker exploits the vulnerability by accessing the target system locally (e.g., keyboard, console), or remotely (e.g., SSH); 2.or the attacker relies on User Interaction by another person to perform actions required to exploit the vulnerability (e.g., using social engineering techniques to trick a legitimate user into opening a malicious document).'
+            },
+            { 
+              key: 'P',
+              name: 'Physical',
+              value:'Physical Attack Vector',
+              info: 'The attack requires the attacker to physically touch or manipulate the vulnerable component. Physical interaction may be brief (e.g., evil maid attack) or persistent. An example of such an attack is a cold boot attack in which an attacker gains access to disk encryption keys after physically accessing the target system. Other examples include peripheral attacks via FireWire/USB Direct Memory Access (DMA).'
+            },
+          ],
+        },
+        {
+          id: 'AC',
+          label: 'Attack Complexity',
+          buttons: [
+            { 
+              key: 'L',
+              name: 'Low', value:'Low Attack Complexity',
+              info: 'Specialized access conditions or extenuating circumstances do not exist. An attacker can expect repeatable success when attacking the vulnerable component.'
+            },
+            { 
+              key: 'H',
+              name: 'High',
+              value:'High Attack Complexity',
+              info: 'A successful attack depends on conditions beyond the attacker\'s control. That is, a successful attack cannot be accomplished at will, but requires the attacker to invest in some measurable amount of effort in preparation or execution against the vulnerable component before a successful attack can be expected.'
+            },
+          ],
+        },
+        {
+          id: 'PR',
+          label: 'Privileges Required',
+          buttons: [
+            { 
+              key: 'N',
+              name: 'None',
+              value:'None Privileges Required',
+              info: 'The attacker is unauthorized prior to attack, and therefore does not require any access to settings or files of the the vulnerable system to carry out an attack.'
+            },
+            { 
+              key: 'L',
+              name: 'Low',
+              value:'Low Privileges Required',
+              info: 'The attacker requires privileges that provide basic user capabilities that could normally affect only settings and files owned by a user. Alternatively, an attacker with Low privileges has the ability to access only non-sensitive resources.'
+            },
+            { 
+              key: 'H',
+              name: 'High',
+              value:'High Privileges Required',
+              info: 'The attacker requires privileges that provide significant (e.g., administrative) control over the vulnerable component allowing access to component-wide settings and files.'
+            },
+          ],
+        },
+        {
+          id: 'UI',
+          label: 'User Interaction',
+          buttons: [
+            { 
+              key: 'N',
+              name: 'None',
+              value:'User Interaction None',
+              info: 'The vulnerable system can be exploited without interaction from any user.' 
+            },
+            { 
+              key: 'R',
+              name: 'Required',
+              value:'User Interaction Required',
+              info: 'Successful exploitation of this vulnerability requires a user to take some action before the vulnerability can be exploited. For example, a successful exploit may only be possible during the installation of an application by a system administrator.' 
+            },
+          ],
+        },
+      ],
+    },
+    {
+      cols: [
+        {
+          id: 'S',
+          label: 'Scope',
+          buttons: [
+            { 
+              key: 'C',
+              name: 'Changed',
+              value:'Changed Scope',
+              info: 'An exploited vulnerability can affect resources beyond the security scope managed by the security authority of the vulnerable component. In this case, the vulnerable component and the impacted component are different and managed by different security authorities.'
+            },
+            { 
+              key: 'U',
+              name: 'Unchanged',
+              value:'Unchanged Scope',
+              info: 'An exploited vulnerability can only affect resources managed by the same security authority. In this case, the vulnerable component and the impacted component are either the same, or both are managed by the same security authority.'
+            },
+          ],
+        },
+        {
+          id: 'C',
+          label: 'Confidentiality',
+          buttons: [
+            { 
+              key: 'H',
+              name: 'High',
+              value:'High Confidentiality',
+              info: 'There is a total loss of confidentiality, resulting in all resources within the impacted component being divulged to the attacker. Alternatively, access to only some restricted information is obtained, but the disclosed information presents a direct, serious impact. For example, an attacker steals the administrator\'s password, or private encryption keys of a web server.'
+            },
+            { 
+              key: 'L',
+              name: 'Low',
+              value:'Low Confidentiality',
+              info: 'There is some loss of confidentiality. Access to some restricted information is obtained, but the attacker does not have control over what information is obtained, or the amount or kind of loss is limited. The information disclosure does not cause a direct, serious loss to the impacted component.'
+            },
+            { 
+              key: 'N',
+              name: 'None',
+              value:'None Confidentiality',
+              info: 'There is no loss of confidentiality within the impacted component.'
+            },
+          ],
+        },
+        {
+          id: 'I',
+          label: 'Integrity',
+          buttons: [
+            { 
+              key: 'H',
+              name: 'High',
+              value:'High Integrity',
+              info: 'There is a total loss of integrity, or a complete loss of protection. For example, the attacker is able to modify any/all files protected by the impacted component. Alternatively, only some files can be modified, but malicious modification would present a direct, serious consequence to the impacted component.'
+            },
+            { 
+              key: 'L',
+              name: 'Low',
+              value:'Low Integrity',
+              info: 'Modification of data is possible, but the attacker does not have control over the consequence of a modification, or the amount of modification is limited. The data modification does not have a direct, serious impact on the impacted component.'
+            },
+            { 
+              key: 'N',
+              name: 'None',
+              value:'None Integrity',
+              info: 'There is no loss of integrity within the impacted component.'
+            },
+          ],
+        },
+        {
+          id: 'A',
+          label: 'Availability',
+          buttons: [
+            { 
+              key: 'H',
+              name: 'High',
+              value:'High Availability',
+              info: 'There is a total loss of availability, resulting in the attacker being able to fully deny access to resources in the impacted component; this loss is either sustained (while the attacker continues to deliver the attack) or persistent (the condition persists even after the attack has completed). Alternatively, the attacker has the ability to deny some availability, but the loss of availability presents a direct, serious consequence to the impacted component (e.g., the attacker cannot disrupt existing connections, but can prevent new connections; the attacker can repeatedly exploit a vulnerability that, in each instance of a successful attack, leaks a only small amount of memory, but after repeated exploitation causes a service to become completely unavailable).'
+            },
+            { 
+              key: 'L',
+              name: 'Low',
+              value:'Low Availability',
+              info: 'Performance is reduced or there are interruptions in resource availability. Even if repeated exploitation of the vulnerability is possible, the attacker does not have the ability to completely deny service to legitimate users. The resources in the impacted component are either partially available all of the time, or fully available only some of the time, but overall there is no direct, serious consequence to the impacted component.'
+            },
+            { 
+              key: 'N',
+              name: 'None',
+              value:'None Availability',
+              info: 'There is no impact to availability within the impacted component.'
+            },
+          ],
+        },
+      ],
+    }
+  ]
+};


### PR DESCRIPTION
## Checklist:

- [x] Linting passed _(there are warns not related to this branch)_
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Implements Cvss calculator, using Cvss v3.1 [specification](https://www.first.org/cvss/v3.1/specification-document),
as an embedded component on `FlawForm` and main controller for `Cvss3 Vector` and `Cvss3 Score` fields.

**Features**:
- Dynamic collapsible behavior based on Cvss3 vector input focus
- Compact calculator style inspired by [cvss.js.org](https://cvss.js.org/)
- Dynamic colors on Cvss3 factors based on severity
- Validation for incomplete Cvss3 vector
- Erase button to cleanup values on Cvss3 vector and score
- Factor tooltips with description of each factor value
- Handles pasting in CVSS scores: vector order does not matter! s/o to @C-Valen for his implementation which supports this (added by @superbuggy) 
- Highlights sections of CVSS when editing (added by @superbuggy)
- Dynamically calculates color values based on severity (added by @superbuggy) 

## Changes:

- Creates embedded component `CvssCalculator` on `FlawForm`
- Removes deprecated code related to previous Cvss calculator link from `FlawForm`
- Creates a composable `useCvssCalculator` with calculator logic and utilities
- Updates test cases on `FlawForm` for `CvssCalculator`
- Creates `CvssCalculator` specific test cases
- Fixes minor bugs on `LabelStatic`

## Considerations:

- Cvss vector and score fields are now wrapped inside Cvss calculator component
- Cvss vector and score fields are now only editable by calculator actions
- Cvss vector and score fields are now both highlighted in yellow when empty
- Cvss vector validation is handled on useCvssCalculator composable
