### PR TITLE
🐛 OSIDB-2458 Reference deletion wrong message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Supplied missing validation indication fo Reported Date
 * Removed CVE as required field
 * Refreshing behavior fixed
+* Fixed incorrect prompt message on `References` deletion
 
 
 ## [2024.1.0]

--- a/src/components/IssueFieldReferences.vue
+++ b/src/components/IssueFieldReferences.vue
@@ -117,13 +117,13 @@ function handleDelete(uuid: string, closeModal: () => void) {
       </template>
       <template #modal-header>
         <div>
-          <h5>Confirm Acknowledgment Deletion</h5>
+          <h5>Confirm Reference Deletion</h5>
         </div>
       </template>
       <template #modal-body>
         <div>
           <p class="text-danger">
-            Are you sure you want to delete this acknowledgment? This action will take place
+            Are you sure you want to delete this reference? This action will take place
             immediately and will not require saving the Flaw to take effect.
           </p>
         </div>

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -246,7 +246,12 @@ export const ZodFlawSchema = z.object({
   uuid: z.string().default(''),
   cve_id: z.string().nullable().refine(
     (cve) => !cve || cveRegex.test(cve),
-    { message: 'The CVE ID is invalid: It must begin with "CVE-", have a year between 1999-2999, and have an identifier at least 4 digits long (e.g. use 0001 for 1). Please also check for unexpected characters like spaces.' }
+    {
+      message: 'The CVE ID is invalid: It must begin with "CVE-", ' +
+        'have a year between 1999-2999, and have an identifier at least ' +
+        '4 digits long (e.g. use 0001 for 1). Please also check for ' +
+        'unexpected characters like spaces.'
+    }
   ),
   impact: z.nativeEnum(ImpactEnumWithBlank)
     .refine(


### PR DESCRIPTION
## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [ ] Test cases added/updated _(N/A)_
- [x] Jira ticket updated

## Summary:

Fix for incorrect prompt message and title on reference deletion popup:
> Are you sure you want to delete this acknowledgment? This action will take place immediately and will not require saving the Flaw to take effect.  

## Changes:

- Replaced "Acknowledgment" mentions for "Reference" on `IssueFieldReferences` modal texts
- Corrected minor lint `max-len` warn on `zodFlaw.ts` cve_id validation message
