### PR TITLE
🐛 Fix collapsible state management for affected product streams

### DIFF
--- a/src/components/AffectedOfferings.vue
+++ b/src/components/AffectedOfferings.vue
@@ -46,11 +46,19 @@ const streamsAccordionState = ref(
 
 watchArray(
   theAffects.value,
-  (nextList, priorList, addedAffects) => {
-    addedAffects.forEach((affect) => {
-      streamsAccordionState.value[streamPath(affect)] = false;
-      streamsAccordionState.value[affect.ps_module] = false;
-    });
+  (nextList) => {
+    streamsAccordionState.value = nextList
+      .filter(isProductStreamDefined)
+      .reduce(
+        (accordionStates: Record<string, boolean>, affect) => {
+          const currentPSComponentValue = streamsAccordionState.value[streamPath(affect)];
+          const currentPSModuleValue = streamsAccordionState.value[affect.ps_module];
+          accordionStates[streamPath(affect)] = currentPSComponentValue || false;
+          accordionStates[affect.ps_module] = currentPSModuleValue || false;
+          return accordionStates;
+        },
+        {}
+      );
   },
   { deep: true }
 );


### PR DESCRIPTION
# [OSIDB-2414] [The save “check mark” of the affect form can’t work]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [ ] Changelog updated
- [ ] Test cases added/updated
- [ ] Jira ticket updated

## Summary:

Bug when changing an affect (step 2 of bug reproduction steps) would cause the affect section to break, affecting the form and expandable menu functionalities.

## Changes:

Fixes the collapsible state management.

## Considerations:

[Replace with any additional considerations, notes, or instructions for reviewers.]