### PR TITLE
Fix log file permissions in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN yarn build
 RUN --mount=target=/mnt \
     cd /mnt \
     && git config --global --add safe.directory /mnt \
-    && printf '{"rev":"%s","tag":"%s","timestamp":"%s","dirty":%s}\n' >/opt/app-root/src/osim_build.json \
+    && printf '{"rev":"%s","tag":"%s","timestamp":"%s","dirty":%s}' >/opt/app-root/src/osim_build.json \
     "$(git rev-parse --verify HEAD)" \
     "$(git describe --always --tags --match 'v[0-9]*')" \
     "$(date --utc --date=@"$(git show --quiet --format=%ct)" +%FT%TZ)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=target=/mnt \
 FROM registry.access.redhat.com/ubi9/ubi-minimal AS nginx-base
 
 EXPOSE 8080
-ARG OSIM_ENV=dev
+ENV OSIM_ENV=dev
 
 STOPSIGNAL SIGQUIT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,19 @@ RUN microdnf --nodocs --noplugins --setopt install_weak_deps=0 -y install nginx 
 # Set up unprivileged nginx
     && sed -i '/^user nginx;$/d' /etc/nginx/nginx.conf \
     && sed -i '/^pid \/run\/nginx.pid;$/c pid /tmp/nginx.pid;' /etc/nginx/nginx.conf \
+# Log to symlinks in tmp
+    && sed -i 's,/var/log/nginx/access.log,/tmp/logs/nginx.access.log,' /etc/nginx/nginx.conf \
+    && sed -i 's,/var/log/nginx/error.log,/tmp/logs/nginx.error.log,' /etc/nginx/nginx.conf \
+# Create new dir in tmp to avoid sticky bit
+    && mkdir -p /tmp/logs \
+# Allow non root user to change log target
+    && chmod 777 /tmp/logs \
+# Create default log target
+    && ln -sf /var/log/nginx/access.log /tmp/logs/nginx.access.log \
+    && ln -sf /var/log/nginx/error.log /tmp/logs/nginx.error.log \
+# Set permissions for nginx user to write log files
+    && install -o999 -g999 /dev/null /var/log/nginx/access.log \
+    && install -o999 -g999 /dev/null /var/log/nginx/error.log \
 #
 # Replace port 80 with 8080 for unprivileged nginx.
 # osim-entrypoint.sh wants to delete the ipv6 line if ipv6 is not supported,

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,6 @@ COPY ./build/nginx-conf.d-fix-random-uid.conf /etc/nginx/conf.d/fix-random-uid.c
 RUN mkdir -p /entrypoint.d/
 COPY ./build/osim-entrypoint.sh /
 COPY ./build/entrypoint.d/*.sh /entrypoint.d/
-#ARG OSIM_COMMIT_HASH=dev
-#ARG OSIM_COMMIT_TAG=dev
-#ARG OSIM_COMMIT_TIMESTAMP=0
 
 ENTRYPOINT ["/osim-entrypoint.sh"]
 

--- a/build/entrypoint.d/40-setup-logging.sh
+++ b/build/entrypoint.d/40-setup-logging.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 
-ACCESS_LOG=/var/log/nginx/access.log
-ERROR_LOG=/var/log/nginx/error.log
+access_log=/var/log/nginx/access.log
+error_log=/var/log/nginx/error.log
 
 if [ "${OSIM_ENV}" = "dev" ]; then
-    ACCESS_LOG=/dev/stdout
-    ERROR_LOG=/dev/stderr
+    access_log=/dev/stdout
+    error_log=/dev/stderr
 fi
 
-sed -i "s|access_log  /var/log/nginx/access.log  main;|access_log ${ACCESS_LOG} main;\n    error_log ${ERROR_LOG};|" /etc/nginx/nginx.conf
+ln -sf -- "$access_log" /tmp/logs/nginx.access.log
+ln -sf -- "$error_log" /tmp/logs/nginx.error.log


### PR DESCRIPTION
# [OSIDB-ID] Fix log file permissions in container

## Checklist:

- [ ] Linting passed
- [ ] Type checks passed
- [ ] Tests suite passed
- [ ] Commits consolidated
- [ ] Changelog updated
- [ ] Test cases added/updated
- [ ] Jira ticket updated

## Summary:

/etc/nginx/nginx.conf is owned by root, but the entrypoint runs as the user, so the entrypoint script can't set the log paths.
Fix it by using symlink indirection.
