### PR TITLE
💄 OSIDB-2512: Show url on references links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Provided save operation indications
 * Implemented read-only mode (network requests involving write operations are disabled)
 * Disables form on save
+* Links on references are now displayed as urls
 
 ### Fixed
 * Fixed overlap on edit buttons at References and Acknowledgements items

--- a/src/components/IssueFieldReferences.vue
+++ b/src/components/IssueFieldReferences.vue
@@ -57,7 +57,7 @@ function handleDelete(uuid: string, closeModal: () => void) {
           >
             {{ referenceTypeLabel(type) }}
           </span>
-          <a class="ref-link" :href="url" target="_blank">{{ url }}</a>
+          <a class="m-1" :href="url" target="_blank">{{ url }}</a>
         </div>
         <div class="form-group mt-2">
           <LabelStatic v-model="item.description" label="Description" hasTopLabelStyle />
@@ -162,10 +162,6 @@ select.osim-reference-types {
 .info-group {
   display: flex;
   flex-direction: column;
-}
-
-.ref-link {
-  margin: 5px;
 }
 
 .badge {

--- a/src/components/IssueFieldReferences.vue
+++ b/src/components/IssueFieldReferences.vue
@@ -45,7 +45,7 @@ function handleDelete(uuid: string, closeModal: () => void) {
       @item:delete="emit('reference:delete', $event)"
       @item:new="emit('reference:new')"
     >
-      <template #default="{ item: { url, type, updated_dt, ...item } }">
+      <template #default="{ item: { url, type, ...item } }">
         <div class="info-group">
           <span
             class="badge rounded-pill"
@@ -57,7 +57,6 @@ function handleDelete(uuid: string, closeModal: () => void) {
           >
             {{ referenceTypeLabel(type) }}
           </span>
-          <span class="timestamp">{{ updated_dt }}</span>
           <a class="ref-link" :href="url" target="_blank">{{ url }}</a>
         </div>
         <div class="form-group mt-2">
@@ -165,14 +164,8 @@ select.osim-reference-types {
   flex-direction: column;
 }
 
-.timestamp {
-  margin-inline: 5px;
-  margin-top: 5px;
-}
-
 .ref-link {
-  margin-left: 5px;
-  margin-bottom: 5px;
+  margin: 5px;
 }
 
 .badge {

--- a/src/components/IssueFieldReferences.vue
+++ b/src/components/IssueFieldReferences.vue
@@ -53,6 +53,7 @@ function handleDelete(uuid: string, closeModal: () => void) {
               'bg-primary': type === 'ARTICLE',
               'bg-warning': type !== 'ARTICLE',
             }"
+            :style="type !== 'ARTICLE' ? 'color: black' : ''"
           >
             {{ referenceTypeLabel(type) }}
           </span>

--- a/src/components/IssueFieldReferences.vue
+++ b/src/components/IssueFieldReferences.vue
@@ -46,8 +46,7 @@ function handleDelete(uuid: string, closeModal: () => void) {
       @item:new="emit('reference:new')"
     >
       <template #default="{ item: { url, type, updated_dt, ...item } }">
-        <a :href="url" target="_blank">
-          <span class="me-2">{{ updated_dt }}</span>
+        <div class="info-group">
           <span
             class="badge rounded-pill"
             :class="{
@@ -57,7 +56,9 @@ function handleDelete(uuid: string, closeModal: () => void) {
           >
             {{ referenceTypeLabel(type) }}
           </span>
-        </a>
+          <span class="timestamp">{{ updated_dt }}</span>
+          <a class="ref-link" :href="url" target="_blank">{{ url }}</a>
+        </div>
         <div class="form-group mt-2">
           <LabelStatic v-model="item.description" label="Description" hasTopLabelStyle />
         </div>
@@ -156,5 +157,24 @@ select.osim-reference-types {
   padding: 0;
   cursor: pointer;
   font-size: 1.5rem;
+}
+
+.info-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.timestamp {
+  margin-inline: 5px;
+  margin-top: 5px;
+}
+
+.ref-link {
+  margin-left: 5px;
+  margin-bottom: 5px;
+}
+
+.badge {
+  max-width: fit-content;
 }
 </style>


### PR DESCRIPTION
## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated _(N/A)_
- [x] Jira ticket updated

## Summary:

Shows the references link as an url instead of having the link on the timestamp.
Timestamp is kept as an independent field for info purposes.

## Changes:

- Shows url on references links
- Changes the layout on info fields at references
- Improves the contrast ratio on "External" badges text

## Considerations:

- The layout change to vertical (of badge - timestamp - url)  was considered as some urls can be quite long so they should have space inline