### PR TITLE
🩹 OSIDB-2562 Hide source column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 * Implemented read-only mode (network requests involving write operations are disabled)
 * Disables form on save
 * Implemented Advanced Search Query to URL
+* `Source` column hidden on flaw lists
+* `Source` field renamed to `CVE Source` on flaw form and advanced search
 
 ### Fixed
 * Fixed overlap on edit buttons at References and Acknowledgements items

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -220,7 +220,7 @@ const onReset = () => {
           />
           <LabelSelect
             v-model="flaw.source"
-            label="Source"
+            label="CVE Source"
             :options="flawSources"
             :error="errors.source"
           />

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -14,7 +14,8 @@ type FilteredIssue = {
   selected: boolean;
 };
 
-// Temporary hiding source field [OSIDB-2424]
+// Temporarily hiding 'Source' column to avoid displaying incorrect information.
+// TODO: unhide it once final issue sources are defined. [OSIDB-2424]
 // type ColumnField = 'id' | 'impact' | 'source' | 'created_dt' | 'title' | 'state' | 'owner'; 
 type ColumnField = 'id' | 'impact' | 'created_dt' | 'title' | 'state' | 'owner';
 

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -14,7 +14,9 @@ type FilteredIssue = {
   selected: boolean;
 };
 
-type ColumnField = 'id' | 'impact' | 'source' | 'created_dt' | 'title' | 'state' | 'owner';
+// Temporary hiding source field [OSIDB-2424]
+// type ColumnField = 'id' | 'impact' | 'source' | 'created_dt' | 'title' | 'state' | 'owner'; 
+type ColumnField = 'id' | 'impact' | 'created_dt' | 'title' | 'state' | 'owner';
 
 const props = defineProps<{
   issues: any[];
@@ -63,7 +65,7 @@ const params = computed(() => {
 const columnsFieldsMap: Record<string, ColumnField> = {
   ID: 'id',
   Impact: 'impact',
-  Source: 'source',
+  // Source: 'source',
   Created: 'created_dt',
   Title: 'title',
   State: 'state',
@@ -102,7 +104,7 @@ function relevantFields(issue: any) {
   return {
     id: issue.cve_id || issue.uuid,
     impact: issue.impact,
-    source: issue.source,
+    // source: issue.source,
     created_dt: issue.created_dt,
     title: issue.title,
     workflowState: issue.classification.state,

--- a/src/components/IssueQueueItem.vue
+++ b/src/components/IssueQueueItem.vue
@@ -7,7 +7,8 @@ const props = defineProps<{
   selected: boolean;
 }>();
 
-// Temporary hiding source field [OSIDB-2424]
+// Temporarily hiding 'Source' column to avoid displaying incorrect information.
+// TODO: unhide it once final issue sources are defined. [OSIDB-2424]
 // const nonIdFields = ['impact', 'source', 'formattedDate', 'title', 'workflowState', 'owner'];
 const nonIdFields = ['impact', 'formattedDate', 'title', 'workflowState', 'owner'];
 

--- a/src/components/IssueQueueItem.vue
+++ b/src/components/IssueQueueItem.vue
@@ -7,7 +7,9 @@ const props = defineProps<{
   selected: boolean;
 }>();
 
-const nonIdFields = ['impact', 'source', 'formattedDate', 'title', 'workflowState', 'owner'];
+// Temporary hiding source field [OSIDB-2424]
+// const nonIdFields = ['impact', 'source', 'formattedDate', 'title', 'workflowState', 'owner'];
+const nonIdFields = ['impact', 'formattedDate', 'title', 'workflowState', 'owner'];
 
 const isUnembargoDateScheduledForLater = computed(
   () => DateTime.fromISO(props.issue.unembargo_dt).diffNow().milliseconds > 0,

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -28,6 +28,7 @@ const nameForOption = (fieldName: string) => {
     cwe_id: 'CWE ID',
     cve_id: 'CVE ID',
     team_id: 'Team ID',
+    source: 'CVE Source',
   };
   let name =
     mappings[fieldName] ||

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -152,7 +152,7 @@ describe('FlawForm', () => {
 
     const sourceField = subject
       .findAllComponents(LabelSelect)
-      .find((component) => component.props().label === 'Source');
+      .find((component) => component.props().label === 'CVE Source');
     expect(sourceField?.exists()).toBe(true);
 
     const statusField = subject
@@ -247,7 +247,7 @@ describe('FlawForm', () => {
 
     const sourceField = subject
       .findAllComponents(LabelSelect)
-      .find((component) => component.props().label === 'Source');
+      .find((component) => component.props().label === 'CVE Source');
     expect(sourceField?.exists()).toBe(true);
 
     const incidentStateField = subject


### PR DESCRIPTION
## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [X] Jira ticket updated

## Summary:

Temporary hiding the `Source` column on Flaw queues and renaming `Source` field labels to `CVE Source`:

> The current value of the source field is where the flaw was reported. This information is not very valuable on this page. Instead, we need to track what system the flaw was created in (SNOW, Assembler, etc; ). Today, we only get flaws from assembler or a direct users. So we should hide the source column on Index page for now. When we do an integration with SNOW, we could then expose the field with more meaningful data.

> Additionally, we should rename the source field on the CVE page to 'CVE Source' so that it is more clear what the field represents. 

## Changes:

- Hidden `Source` column from `IssueQueue` and `IssueQueueItem`
- Renamed `Source` field label to `CVE Source` at `FlawForm`
- Renamed `Source` field to `CVE Source` at `AdavancedSearch`
- Updated `FlawForm` tests with new `CVE Source` label

## Considerations:

- `CVE Source` remains editable on `FlawForm`
- `CVE Source` is still a valid search field for `AdvancedSearch`
- After SNOW integration review possible new values and field behavior (may be static and auto-generated)
