### PR TITLE
♻️ OSIDB 1596: Unembargo confirmation on save flaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Implemented read-only mode (network requests involving write operations are disabled)
 * Disables form on save
 * Implemented Advanced Search Query to URL
+* Unembargo confirmation now happens on saving flaw
 
 ### Fixed
 * Fixed overlap on edit buttons at References and Acknowledgements items

--- a/src/components/IssueFieldEmbargo.vue
+++ b/src/components/IssueFieldEmbargo.vue
@@ -15,8 +15,6 @@ const props = defineProps<{
 const modelValue = defineModel<boolean | undefined>();
 const showModal = defineModel<boolean | undefined>('showModal');
 
-// const isFlawNew = computed(() => modelValue.value === undefined);
-
 const emit = defineEmits<{
   (e: 'update:modelValue', embargoed: boolean): void;
   (e: 'update:showModal', value: boolean): void;

--- a/src/components/IssueFieldEmbargo.vue
+++ b/src/components/IssueFieldEmbargo.vue
@@ -123,8 +123,6 @@ watch(() => showModal.value, () => {
             </Modal>
           </div>
         </div>
-        
-
       </div>
     </template>
   </LabelDiv>

--- a/src/components/IssueFieldEmbargo.vue
+++ b/src/components/IssueFieldEmbargo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useModal } from '@/composables/useModal';
 import LabelInput from './widgets/LabelInput.vue';
 import Modal from '@/components/widgets/Modal.vue';
@@ -9,14 +9,18 @@ import LabelCheckbox from '@/components/widgets/LabelCheckbox.vue';
 const props = defineProps<{
   flawId: string | null | undefined;
   isFlawNew: boolean;
+  isPublic: boolean;
 }>();
 
 const modelValue = defineModel<boolean | undefined>();
+const showModal = defineModel<boolean | undefined>('showModal');
 
 // const isFlawNew = computed(() => modelValue.value === undefined);
 
 const emit = defineEmits<{
   (e: 'update:modelValue', embargoed: boolean): void;
+  (e: 'update:showModal', value: boolean): void;
+  (e: 'updateFlaw'): void;
 }>();
 
 const { isModalOpen, openModal, closeModal } = useModal();
@@ -24,9 +28,22 @@ const confirmationId = ref('');
 const isFlawIdConfirmed = computed(() => confirmationId.value === props.flawId);
 
 function handleConfirm() {
-  emit('update:modelValue', false);
-  closeModal();
+  emit('updateFlaw');
+  handleCloseModal();
 }
+
+function handleCloseModal() {
+  confirmationId.value = '';
+  emit('update:showModal', false);
+}
+
+watch(() => showModal.value, () => { 
+  if(showModal.value) { 
+    openModal();
+  } else {
+    closeModal();
+  }
+});
 </script>
 
 <template>
@@ -34,22 +51,40 @@ function handleConfirm() {
     <template #default>
       <div>
         <div class="d-flex ms-0 p-0 justify-content-between">
-          <LabelCheckbox v-if="isFlawNew" v-model="modelValue" :label="'Embargoed?'" />
+          <LabelCheckbox v-if="isFlawNew" v-model="modelValue" label="Embargoed?" />
           <div v-else class="osim-embargo-label osim-input d-flex align-items-center">
-            <span class="form-control">{{ modelValue ? 'Yes' : 'No' }}</span>
+            <span 
+              class="form-control"
+              :class="{
+                'has-warning': !isPublic && !modelValue,
+                'has-button': !isPublic
+              }"
+            >
+              {{ modelValue ? 'Yes' : 'No' }}
+              <i v-if="!isPublic && !modelValue" class="bi-exclamation-circle"></i>
+            </span>
+            <div
+              v-if="!isPublic && !modelValue"
+              class="warning-tooltip"
+            >The flaw will be unembargoed on save.</div>
           </div>
-          <div v-if="!isFlawNew && modelValue">
+          <div v-if="!isFlawNew && !isPublic">
             <button
               type="button"
-              class="btn ms-2 btn-danger osim-unembargo-button"
-              @click="openModal"
+              class="btn osim-field-button"
+              :class="{
+                'btn-danger osim-unembargo-button': modelValue,
+                'btn-secondary': !modelValue,
+              }"
+              @click="modelValue = !modelValue;"
             >
-              <i class="bi-radioactive ps-0"></i>
-              <i class="bi-eye-fill"></i>
-              <i class="bi-eye-slash-fill"></i>
-              Unembargo
+              <i v-if="modelValue" class="bi-radioactive ps-0"></i>
+              <i v-if="modelValue" class="bi-eye-fill"></i>
+              <i v-if="modelValue" class="bi-eye-slash-fill"></i>
+              <i v-if="!modelValue" class="bi-arrow-counterclockwise"></i>
+              {{ modelValue ? 'Unembargo' : 'Reset' }}
             </button>
-            <Modal :show="isModalOpen" @close="closeModal">
+            <Modal :show="isModalOpen" @close="handleCloseModal">
               <template #header> Set Flaw for Unembargo </template>
               <template #body>
                 <p class="text-danger">
@@ -71,13 +106,13 @@ function handleConfirm() {
                   {{ flawId }} if you wish to proceed.
                 </div>
                 <LabelInput v-model="confirmationId" label="Confirm" />
-                <p v-if="confirmationId" class="alert alert-warning mt-2">
+                <!-- <p v-if="confirmationId" class="alert alert-warning mt-2">
                   <i class="bi-exclamation-triangle-fill"></i> The embargo will only be removed when
                   the Flaw is saved.
-                </p>
+                </p> -->
               </template>
               <template #footer>
-                <button type="button" class="btn btn-info" @click="closeModal">Cancel</button>
+                <button type="button" class="btn btn-info" @click="handleCloseModal">Cancel</button>
                 <button
                   type="button"
                   class="btn btn-danger"
@@ -90,6 +125,8 @@ function handleConfirm() {
             </Modal>
           </div>
         </div>
+        
+
       </div>
     </template>
   </LabelDiv>
@@ -97,8 +134,49 @@ function handleConfirm() {
 
 <style lang="scss" scoped>
 .osim-embargo-label {
+  position: relative;
   flex-grow: 1;
   width: inherit !important;
+  
+  .has-button {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .has-warning {
+    background-color: #fff5d1;
+    display: flex;
+    border-color: #F5C000;
+
+    .bi-exclamation-circle {
+      display: inline !important;
+      color: #F5C000;
+      margin-left: auto;
+    }
+  }
+
+  .warning-tooltip {
+    display: none;
+  }
+
+  &:hover .warning-tooltip {
+    position: absolute;
+    display: block;
+    top: 100%;
+    margin-top: 0.1rem;
+    padding: 0.25rem 0.5rem;
+    z-index: 5;
+    background-color: #F5C000;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+  }
+}
+
+button.osim-field-button {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  width: 138px;
+  height: 38px;
 }
 
 button.osim-unembargo-button {

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -41,6 +41,10 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
   const bugzillaLink = computed(() => getFlawBugzillaLink(flaw.value));
   const osimLink = computed(() => getFlawOsimLink(flaw.value.uuid));
 
+  function isValid() {
+    return ZodFlawSchema.safeParse(flaw.value).success;
+  }
+
   async function createFlaw() {
     isSaving.value = true;
     const validatedFlaw = validate();
@@ -131,6 +135,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
   return {
     flaw,
     isSaving,
+    isValid,
     errors,
     committedFlaw,
     trackerUuids,

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -45,6 +45,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     isSaving.value = true;
     const validatedFlaw = validate();
     if (!validatedFlaw.success) {
+      isSaving.value = false;
       return;
     }
     // Remove any empty fields before request
@@ -87,6 +88,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     isSaving.value = true;
     const validatedFlaw = validate();
     if (!validatedFlaw.success) {
+      isSaving.value = false;
       return;
     }
 

--- a/src/views/FlawEditView.vue
+++ b/src/views/FlawEditView.vue
@@ -7,7 +7,6 @@ import { getDisplayedOsidbError } from '@/services/OsidbAuthService';
 import type { ZodFlawType } from '@/types/zodFlaw';
 
 const flaw = ref<ZodFlawType | null>(null);
-const committedFlaw = ref<ZodFlawType | null>(null);
 const errorLoadingFlaw = ref(false);
 const props = defineProps<{
   id: string;
@@ -24,7 +23,6 @@ function refreshFlaw() {
   getFlaw(props.id)
     .then((theFlaw) => {
       flaw.value = Object.assign({}, theFlaw);
-      committedFlaw.value = Object.assign({}, theFlaw);
       history.replaceState(null, '', `/flaws/${(theFlaw.cve_id || theFlaw.uuid)}`);
     })
     .catch((err) => {


### PR DESCRIPTION
## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated (_N/A_)
- [x] Jira ticket updated

## Summary:

Refactor of unembargo workflow to make the confirmation pop up shown on save flaw.

## Changes:

- Fixed stuck saving state on flaw update/creation (restore `isSaving` variable before return)
- Added a `isValid` method on `useFlawModel` that returns the boolean result of the flaw validation
- Refactored `IssueFieldEmbargo` for the "onSave" confirmation
- Added control of unembargo modal on `FlawForm` 
- Added reset button on embargo field (visible only if going to be unembargoed)
- Added warning tooltip on embargo field (only if going to be unembargoed)
- Other minor style improvements on `IssueFieldEmbargo`
- Removed unused `committedFlaw` var at `FlawEditView

## Considerations:

- `isValid` method purpose is to be able to check the result of the flaw validation without any UI information. For this specific case it was required to show the unembargo modal only if the validation is succeeded so if there are validation errors the modal is not shown and the validation alerts are not duplicated.
- `onSubmit` at `FlawForm` now shows the unembargo confirmation modal if the flaw is gonna be unembargoed and the form is valid (if in edit mode). After a correct confirmation, the flaw is updated from an `update:flaw` emitter sent from the modal to the parent form.
- A non saved unembargoed state can either be reset with the specific reset button on embargo field or reset all on the form. The field button is just to make more obvious and easy to the users to reset the field before saving if needed.
