### PR TITLE
💬 Rename Flaw Status to State to be consistent with Flaw index

### DIFF
--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -11,7 +11,7 @@ import LabelCollapsable from '@/components/widgets/LabelCollapsable.vue';
 import AffectedOfferings from '@/components/AffectedOfferings.vue';
 import IssueFieldEmbargo from '@/components/IssueFieldEmbargo.vue';
 import CveRequestForm from '@/components/CveRequestForm.vue';
-import IssueFieldStatus from './IssueFieldStatus.vue';
+import IssueFieldState from './IssueFieldState.vue';
 
 import IssueFieldReferences from './IssueFieldReferences.vue';
 import IssueFieldAcknowledgments from './IssueFieldAcknowledgments.vue';
@@ -219,7 +219,7 @@ const onReset = () => {
         </div>
 
         <div class="col-6">
-          <IssueFieldStatus
+          <IssueFieldState
             v-if="mode === 'edit'"
             :classification="flaw.classification"
             :flawId="flaw.uuid"

--- a/src/components/IssueFieldState.vue
+++ b/src/components/IssueFieldState.vue
@@ -15,15 +15,15 @@ const emit = defineEmits<{ 'refresh:flaw': [] }>();
 const shouldShowRejectionModal = ref(false);
 const rejectionReason = ref('');
 
-const workflowStatuses = ZodFlawClassification.shape.state.enum;
+const workflowStates = ZodFlawClassification.shape.state.enum;
 
-type WorkflowPhases = (typeof workflowStatuses)[keyof typeof workflowStatuses];
+type WorkflowPhases = (typeof workflowStates)[keyof typeof workflowStates];
 
-const DONE_STATUS = workflowStatuses.Done as string;
-const REJECTED_STATUS = workflowStatuses.Rejected as string;
+const DONE_STATE = workflowStates.Done as string;
+const REJECTED_STATE = workflowStates.Rejected as string;
 
 const shouldShowWorkflowButtons = computed(
-  () => ![DONE_STATUS, REJECTED_STATUS].includes(props.classification.state),
+  () => ![DONE_STATE, REJECTED_STATE].includes(props.classification.state),
 );
 
 function openModal() {
@@ -43,16 +43,16 @@ function onPromote(flawId: string) {
   promoteFlaw(flawId).then(() => emit('refresh:flaw'));
 }
 
-function nextPhase(flawStatus: WorkflowPhases) {
-  const [labels, phases] = [Object.keys(workflowStatuses), Object.values(workflowStatuses)];
-  const index = phases.indexOf(flawStatus);
+function nextPhase(workflowState: WorkflowPhases) {
+  const [labels, phases] = [Object.keys(workflowStates), Object.values(workflowStates)];
+  const index = phases.indexOf(workflowState);
   return labels[index + 1] || labels.slice(-1)[0];
 }
 </script>
 
 <template>
-  <div class="osim-workflow-status-container mb-3">
-    <LabelDiv label="Status" type="text" class="osim-workflow-status-display">
+  <div class="osim-workflow-state-container mb-3">
+    <LabelDiv label="State" type="text" class="osim-workflow-state-display">
       <span class="form-control">{{ classification.state }}</span>
       <Modal :show="shouldShowRejectionModal" @close="closeModal">
         <template #title> Reject Flaw </template>
@@ -73,7 +73,7 @@ function nextPhase(flawStatus: WorkflowPhases) {
     <div class="row">
       <div class="col-lg-3 col-md-1"></div>
       <div class="col-lg-9 col-md-11">
-        <div v-if="shouldShowWorkflowButtons" class="osim-workflow-status-buttons mb-3">
+        <div v-if="shouldShowWorkflowButtons" class="osim-workflow-state-buttons mb-3">
           <button
             type="button"
             class="btn btn-warning ms-2 osim-workflow-button"
@@ -96,7 +96,7 @@ function nextPhase(flawStatus: WorkflowPhases) {
 </template>
 
 <style lang="scss" scoped>
-.osim-workflow-status-container {
+.osim-workflow-state-container {
   button.osim-workflow-button {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
@@ -106,7 +106,7 @@ function nextPhase(flawStatus: WorkflowPhases) {
     display: block;
   }
 
-  .osim-workflow-status-display {
+  .osim-workflow-state-display {
     margin-bottom: 0 !important;
   }
 }

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -7,7 +7,7 @@ import { mount, VueWrapper } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
 import { useToastStore } from '@/stores/ToastStore';
 import LabelEditable from '@/components/widgets/LabelEditable.vue';
-import IssueFieldStatus from '@/components/IssueFieldStatus.vue';
+import IssueFieldState from '@/components/IssueFieldState.vue';
 import FlawForm from '../FlawForm.vue';
 import { useRouter } from 'vue-router';
 import { DateTime } from 'luxon';
@@ -155,10 +155,10 @@ describe('FlawForm', () => {
       .find((component) => component.props().label === 'CVE Source');
     expect(sourceField?.exists()).toBe(true);
 
-    const statusField = subject
+    const workflowStateField = subject
       .findAllComponents(LabelDiv)
-      .find((component) => component.props().label === 'Status');
-    expect(statusField?.exists()).toBe(true);
+      .find((component) => component.props().label === 'State');
+    expect(workflowStateField?.exists()).toBe(true);
 
     const incidentStateField = subject
       .findAllComponents(LabelSelect)
@@ -304,25 +304,25 @@ describe('FlawForm', () => {
     expect(assigneeField?.html()).toContain('test owner');
   });
 
-  it('displays correct Status field value from props', async () => {
-    const statusField = subject.findComponent(IssueFieldStatus);
+  it('displays correct State field value from props', async () => {
+    const workflowStateField = subject.findComponent(IssueFieldState);
 
-    expect(statusField?.findComponent(LabelDiv).props().label).toBe('Status');
-    expect(statusField?.props().classification.state).toBe('NEW');
+    expect(workflowStateField?.findComponent(LabelDiv).props().label).toBe('State');
+    expect(workflowStateField?.props().classification.state).toBe('NEW');
   });
 
-  it('displays promote and reject buttons for status', async () => {
-    const statusField = subject
-      .findAllComponents(IssueFieldStatus)
-      .find((component) => component.text().includes('Status'));
+  it('displays promote and reject buttons for state', async () => {
+    const workflowStateField = subject
+      .findAllComponents(IssueFieldState)
+      .find((component) => component.text().includes('State'));
     expect(
-      statusField
+      workflowStateField
         ?.findAll('button')
         ?.find((el) => el.text() === 'Reject')
         ?.text(),
     ).toBe('Reject');
     expect(
-      statusField
+      workflowStateField
         ?.findAll('button')
         ?.find((el) => el.text().includes('Promote to'))
         ?.text(),
@@ -330,10 +330,10 @@ describe('FlawForm', () => {
   });
 
   it('shows a modal for reject button clicks', async () => {
-    const statusField = subject
-      .findAllComponents(IssueFieldStatus)
-      .find((component) => component.text().includes('Status'));
-    const rejectButton = statusField?.findAll('button')?.find((el) => el.text() === 'Reject');
+    const workflowStateField = subject
+      .findAllComponents(IssueFieldState)
+      .find((component) => component.text().includes('State'));
+    const rejectButton = workflowStateField?.findAll('button')?.find((el) => el.text() === 'Reject');
     await rejectButton?.trigger('click');
     expect(subject.find('.modal-dialog').exists()).toBe(true);
   });


### PR DESCRIPTION
# [OSIDB-2509] OSIM: State vs Status--Who will win? It's State; State wins. 🪦 Status

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [ ] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Well, we changed that dang ol field name.

## Changes:

Flaw `Status` was renamed to `State` to be consistent with Flaw index column `State`.

## Considerations:

The children. and also everyone else.