### PR TITLE
OSIDB-2055: Add Default Filter on Index Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * `Source` column hidden on flaw lists
 * `Source` field renamed to `CVE Source` on flaw form and advanced search
 * Added Total count for IndexView and AdvancedSearch Page
+* Add Default Filter on IndexView Page
 
 ### Fixed
 * Fixed overlap on edit buttons at References and Acknowledgements items

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -20,7 +20,10 @@ const props = defineProps<{
   issues: any[];
   isLoading: boolean;
   isFinalPageFetched: boolean;
+  showFilter?: boolean
 }>();
+
+const isDefaultFilterSelected = defineModel<boolean>('isDefaultFilterSelected', { default: true });
 
 const issues = computed<any[]>(() => props.issues.map(relevantFields));
 const selectedSortField = ref<ColumnField>('created_dt');
@@ -148,6 +151,12 @@ watch(params, () => {
     <div class="osim-incident-filter">
       <LabelCheckbox v-model="isMyIssuesSelected" label="My Issues" class="d-inline-block" />
       <LabelCheckbox v-model="isOpenIssuesSelected" label="Open Issues" class="d-inline-block" />
+      <LabelCheckbox
+        v-if="showFilter"
+        v-model="isDefaultFilterSelected"
+        label="Default Filters"
+        class="d-inline-block"
+      />
 
       <span
         v-if="isLoading"

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -158,7 +158,7 @@ watch(params, () => {
       <LabelCheckbox
         v-if="showFilter"
         v-model="isDefaultFilterSelected"
-        label="Default Filters"
+        label="Default Filter"
         class="d-inline-block"
       />
 

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -13,6 +13,8 @@ const props = defineProps<{
 
 const route = useRoute();
 
+const emit = defineEmits(['filter:save']);
+
 const nameForOption = (fieldName: string) => {
   const mappings: Record<string, string> = {
     uuid: 'UUID',
@@ -100,6 +102,14 @@ const shouldShowAdvanced = ref(route.query.mode === 'advanced');
       <button class="btn btn-primary me-3" type="submit" :disabled="props.isLoading">
         <div v-if="props.isLoading" class="spinner-border spinner-border-sm"></div>
         Search
+      </button>
+      <button
+        class="btn btn-primary me-3"
+        type="button"
+        :disabled="isLoading"
+        @click="emit('filter:save')"
+      >
+        Save as Default
       </button>
     </form>
   </details>

--- a/src/components/__tests__/App.spec.ts
+++ b/src/components/__tests__/App.spec.ts
@@ -23,6 +23,11 @@ describe('App', async () => {
               },
             },
           },
+          SearchStore: {
+            value: defaults || {
+              searchFilters: { 'test':'test' }
+            }
+          }
         }[key];
       }),
       useElementBounding: vi.fn(() => ({

--- a/src/components/__tests__/FlawSearchView.spec.ts
+++ b/src/components/__tests__/FlawSearchView.spec.ts
@@ -4,6 +4,8 @@ import { useRoute, useRouter } from 'vue-router';
 import { createTestingPinia } from '@pinia/testing';
 import FlawSearchView from '@/views/FlawSearchView.vue';
 import { useFlaws }  from '../../composables/useFlaws';
+import { useSearchStore } from '@/stores/SearchStore';
+import { useToastStore } from '@/stores/ToastStore';
 
 vi.mock('@vueuse/core', () => ({
   useLocalStorage: vi.fn((key: string, defaults) => {
@@ -18,6 +20,11 @@ vi.mock('@vueuse/core', () => ({
             username: 'testuser',
           },
         },
+        SearchStore: {
+          value: defaults || {
+            searchFilters: { 'test':'test' }
+          }
+        }
       },
     }[key];
   }),
@@ -122,5 +129,52 @@ describe('FlawSearchView', () => {
     expect(useRouter().replace).toHaveBeenCalled();
     expect(useRouter().replace.mock.calls[0][0])
       .toStrictEqual({ query: { query: 'search', acknowledgments__name: 'test' } });
+  });
+  
+  it('should call saveFilter on save filter button click', async () => {
+    (useRoute as Mock).mockReturnValue({
+      'query': { 
+        mode: 'advanced', 
+        query: 'search',
+        'affects__ps_component': 'test'
+      },
+    });
+    const pinia = createTestingPinia({
+      createSpy: vitest.fn,
+      stubActions: true,
+    });
+    wrapper = mount(FlawSearchView, {
+      props,
+      global: {
+        mocks: { useRoute },
+        plugins:[pinia]
+      }
+    });
+    const searchStore = useSearchStore();
+    const toastStore = useToastStore();
+    const saveButton = wrapper.find('button[type="button"].btn-primary.me-3');
+    expect(saveButton.exists()).toBeTruthy();
+    expect(saveButton.text()).toBe('Save as Default');
+    await saveButton.trigger('click');
+    await flushPromises();
+    expect(searchStore.saveFilter).toHaveBeenCalledOnce();
+    expect(searchStore.saveFilter.mock.calls[0][0]).toStrictEqual({ 'affects__ps_component': 'test' });
+    expect(toastStore.addToast).toHaveBeenCalledOnce();
+  });
+
+  it('should call with correct filters from route on mounted', async () => {
+    (useRoute as Mock).mockReturnValue({
+      'query': { 
+        mode: 'advanced', 
+        query: 'search',
+        'affects__ps_component': 'test'
+      },
+    });
+    await flushPromises();
+    expect(useFlaws().loadFlaws).toHaveBeenCalledOnce();
+    expect(useFlaws().loadFlaws.mock.calls[0][0]._value).toStrictEqual({ 'affects__ps_component': 'test',
+      'order': '-created_dt',
+      'search': 'search',
+    });
   });
 });

--- a/src/components/__tests__/IndexView.spec.ts
+++ b/src/components/__tests__/IndexView.spec.ts
@@ -1,0 +1,117 @@
+import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import IndexView from '@/views/IndexView.vue';
+import { useFlaws }  from '../../composables/useFlaws';
+import LabelCheckbox from '../widgets/LabelCheckbox.vue';
+
+vi.mock('@vueuse/core', () => ({
+  useLocalStorage: vi.fn((key: string, defaults) => {
+    return {
+      UserStore: {
+        value: defaults || {
+          // Set your fake user data here
+          refresh: 'mocked_refresh_token',
+          env: 'mocked_env',
+          whoami: {
+            email: 'test@example.com',
+            username: 'testuser',
+          },
+        },
+      },
+      SearchStore: {
+        value: {
+          searchFilters: { 'affects__ps_component':'test' }
+        }
+      }
+    }[key];
+  }),
+  useStorage: vi.fn((key: string, defaults) => {
+    return {
+      'OSIM::API-KEYS': {
+        value: defaults || {
+          bugzillaApiKey: '',
+          jiraApiKey: '',
+          showNotifications: false,
+        },
+      },
+    }[key];
+  }),
+}));
+
+vi.mock('jwt-decode', () => ({
+  default: vi.fn(() => ({
+    sub: '1234567890',
+    name: 'Test User',
+    exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365,
+  })),
+}));
+
+vi.mock('../../composables/useFlaws',  () => ({
+  useFlaws: vi.fn(() => ({
+    issues: [],
+    isLoading: false,
+    isFinalPageFetched: false,
+    loadFlaws: vi.fn(),
+    loadMoreFlaws: vi.fn(),
+  })),
+}));
+
+describe('IndexView', () => {
+  let wrapper: VueWrapper<any>;
+  const props: typeof IndexView.props = {};
+
+  beforeEach(() => {
+    vi.mocked(useFlaws).mockReturnValue({
+      issues: [],
+      isLoading: false,
+      isFinalPageFetched: false,
+      loadFlaws: vi.fn(),
+      loadMoreFlaws: vi.fn(),
+    });
+    const pinia = createTestingPinia({
+      createSpy: vitest.fn,
+      stubActions: true,
+    });
+    wrapper = mount(IndexView, {
+      props,
+      global: {
+        plugins:[pinia]
+      }
+    });
+  });
+
+  afterAll(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('should call Load on mounted with default filters', async () => {
+    await flushPromises();
+    expect(useFlaws().loadFlaws).toHaveBeenCalledOnce();
+    expect(useFlaws().loadFlaws.mock.calls[0][0]._value).toStrictEqual({
+      'order': '-created_dt',
+      'affects__ps_component': 'test'
+    });
+  });
+
+  it('shoud call without default filter when checkbox off', async () => {
+    expect(useFlaws().loadFlaws).toHaveBeenCalledOnce();
+    expect(useFlaws().loadFlaws.mock.calls[0][0]._value).toStrictEqual({
+      'order': '-created_dt',
+      'affects__ps_component': 'test'
+    });
+    const filterEl = wrapper.find('div.osim-incident-filter');
+    expect(filterEl.exists()).toBeTruthy();
+    const defaultFilterCheckbox = filterEl.findAllComponents(LabelCheckbox)[2];
+    expect(defaultFilterCheckbox.exists()).toBeTruthy();
+    await defaultFilterCheckbox.setValue(false);
+    await wrapper.vm.$nextTick();
+    expect(useFlaws().loadFlaws.mock.calls[1][0]._value).toStrictEqual({
+      'order': '-created_dt',
+    });
+  });
+});

--- a/src/components/__tests__/IndexView.spec.ts
+++ b/src/components/__tests__/IndexView.spec.ts
@@ -89,7 +89,7 @@ describe('IndexView', () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-  it('should call Load on mounted with default filters', async () => {
+  it('should call Load on mounted with default filter', async () => {
     await flushPromises();
     expect(useFlaws().loadFlaws).toHaveBeenCalledOnce();
     expect(useFlaws().loadFlaws.mock.calls[0][0]._value).toStrictEqual({

--- a/src/components/__tests__/IssueQueue.spec.ts
+++ b/src/components/__tests__/IssueQueue.spec.ts
@@ -186,4 +186,44 @@ describe('IssueQueue', () => {
       order: '-impact',
     });
   });
+
+  it('shouldn\'t render useDefault filter button', async () => {
+    const pinia = createTestingPinia({
+      createSpy: vitest.fn,
+      stubActions: false,
+    });
+    const wrapper = mount(IssueQueue, {
+      props: {
+        issues: mockData,
+        isLoading: false,
+        isFinalPageFetched: false,
+        showFilter: false
+      },
+      global: {
+        plugins: [pinia, router],
+      },
+    });
+    const defaultFilterCheckbox = wrapper.findAllComponents(LabelCheckbox)[2];
+    expect(defaultFilterCheckbox).toBeFalsy();
+  });
+
+  it('should render useDefault filter button', async () => {
+    const pinia = createTestingPinia({
+      createSpy: vitest.fn,
+      stubActions: false,
+    });
+    const wrapper = mount(IssueQueue, {
+      props: {
+        issues: mockData,
+        isLoading: false,
+        isFinalPageFetched: false,
+        showFilter: true
+      },
+      global: {
+        plugins: [pinia, router],
+      },
+    });
+    const defaultFilterCheckbox = wrapper.findAllComponents(LabelCheckbox)[2];
+    expect(defaultFilterCheckbox.exists()).toBeTruthy();
+  });
 });

--- a/src/components/__tests__/IssueSearchAdvanced.spec.ts
+++ b/src/components/__tests__/IssueSearchAdvanced.spec.ts
@@ -62,4 +62,15 @@ describe('IssueSearchAdvanced', () => {
     const uniqueValues = [...new Set(allValues)];
     expect(allValues).toStrictEqual(uniqueValues);
   });
+
+  it('should render save filter button', async () => {
+    let filterSaveEvents = wrapper.emitted('filter:save');
+    expect(filterSaveEvents).toBeFalsy();
+    const saveButton = wrapper.find('button[type="button"].btn-primary.me-3');
+    expect(saveButton.exists()).toBeTruthy();
+    expect(saveButton.text()).toBe('Save as Default');
+    await saveButton.trigger('click');
+    filterSaveEvents = wrapper.emitted('filter:save');
+    expect(filterSaveEvents.length).toBe(1);
+  });
 });

--- a/src/stores/SearchStore.ts
+++ b/src/stores/SearchStore.ts
@@ -1,0 +1,33 @@
+import { defineStore } from 'pinia';
+import { z } from 'zod';
+import { useLocalStorage } from '@vueuse/core';
+import { computed } from 'vue';
+
+export const SearchSchema = z.object({
+  searchFilters: z.record(z.string())
+});
+
+export type SearchType = z.infer<typeof SearchSchema>;
+const defaultValues: SearchType = { searchFilters: {} };
+
+const _searchStoreKey = 'SearchStore';
+const search = useLocalStorage(_searchStoreKey, defaultValues);
+
+export const useSearchStore = defineStore('SearchStore', () => {
+  const searchFilters = computed(() => search.value.searchFilters || {});
+
+  function saveFilter(filters: Record<string, string>) {
+    search.value.searchFilters = filters;
+  }
+
+  function resetFilter() {
+    search.value.searchFilters = {};
+  }
+
+  return {
+    searchFilters,
+    saveFilter,
+    resetFilter
+  };
+});
+

--- a/src/stores/__tests__/SearchStore.spec.ts
+++ b/src/stores/__tests__/SearchStore.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import { createPinia, setActivePinia } from 'pinia';
+import { useSearchStore } from '../SearchStore';
+import { useLocalStorage } from '@vueuse/core';
+
+const initialState = {
+  searchFilters: {}
+};
+
+export const mockSearchStore = createTestingPinia({
+  initialState
+});
+
+vi.mock('@vueuse/core', () => ({
+  useLocalStorage: vi.fn((key: string, defaults) => {
+    return {
+      SearchStore: {
+        value: defaults || {
+          searchFilters: { 'test':'test' }
+        }
+      }
+    }[key];
+  }),
+}));
+
+describe('SettingsStore', () => {
+  let searchStore: ReturnType<typeof useSearchStore>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    searchStore = useSearchStore();
+  });
+
+
+  it('initializes', () => {
+    expect(searchStore.searchFilters).toEqual({});
+  });
+
+  it('saveFilter', () => {
+    (useLocalStorage as Mock).mockReturnValue({
+      SearchStore: {
+        value: {
+          searchFilters: { 'test':'test' }
+        }
+      }
+    });
+    searchStore.saveFilter({ 'component':'test' });
+    expect(searchStore.searchFilters).toEqual({ 'component':'test' });
+  });
+
+  it('resetFilter', () => {
+    (useLocalStorage as Mock).mockReturnValue({
+      SearchStore: {
+        value: {
+          searchFilters: { 'test':'test' }
+        }
+      }
+    });
+    searchStore.resetFilter();
+    expect(searchStore.searchFilters).toEqual({});
+  });
+});

--- a/src/views/FlawSearchView.vue
+++ b/src/views/FlawSearchView.vue
@@ -10,7 +10,6 @@ import { useToastStore } from '@/stores/ToastStore';
 const { issues, isLoading, isFinalPageFetched, total, loadFlaws, loadMoreFlaws } = useFlaws();
 const { getSearchParams, facets } = useSearchParams();
 
-const filters = ref<Record<string, string>>({});
 const searchStore = useSearchStore();
 const { addToast } = useToastStore();
 const tableFilters = ref<Record<string, string>>({});

--- a/src/views/IndexView.vue
+++ b/src/views/IndexView.vue
@@ -1,19 +1,57 @@
 <script setup lang="ts">
+import { computed, ref, watch, type Ref } from 'vue';
 import IssueQueue from '../components/IssueQueue.vue';
 import { useFlaws }  from '../composables/useFlaws';
+import { useSearchStore } from '@/stores/SearchStore';
 
+const searchStore = useSearchStore();
 const { issues, isLoading, isFinalPageFetched, loadFlaws, loadMoreFlaws } = useFlaws();
+const tableFilters = ref<Record<string, string>>({});
+
+const showFilter = computed(() => 
+  Object.keys(searchStore.searchFilters).length > 0 
+);
+
+const isDefaultFilterSelected = ref<boolean>(showFilter.value);
+
+const params = computed(() => {
+  const paramsObj = {
+    ...tableFilters.value,
+    ...isDefaultFilterSelected.value && searchStore.searchFilters
+  };
+
+  return paramsObj;
+});
+
+watch(() => params, () => {
+  loadFlaws(params);
+}, {
+  deep: true
+});
+
+function fetchMoreFlaws() {
+  loadMoreFlaws(params);
+}
+
+function setTableFilters(newFilters: Ref<Record<string, string>>) {
+  tableFilters.value = {
+    ...newFilters.value
+  };
+}
+
 
 </script>
 
 <template>
   <main class="mt-3">
     <IssueQueue
+      v-model:isDefaultFilterSelected="isDefaultFilterSelected"
       :issues="issues"
       :isLoading="isLoading"
       :isFinalPageFetched="isFinalPageFetched"
-      @flaws:fetch="loadFlaws"
-      @flaws:load-more="loadMoreFlaws"
+      :showFilter="showFilter"
+      @flaws:fetch="setTableFilters"
+      @flaws:load-more="fetchMoreFlaws"
     />
   </main>
 </template>


### PR DESCRIPTION
# [OSIDB-2055] [Allow user to specify default search criteria for the Flaw list on the index page]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Add default filters on Index Page

## Changes:

- Add Save Default filter button on AdvancedSearch Page
- Show default filter checkbox on IndexView Page
- Hide default filter checkbox when default filter is empty

## Considerations:
- Do we need to show default filters always when filter is empty?
- Default Filter reset functionality

[Screencast from 2024-05-01 19-39-55.webm](https://github.com/RedHatProductSecurity/osim/assets/156366006/8507c675-4467-456d-9e49-4819dd5c9182)
