### PR TITLE
🐛 Fix inconsistent column widths on flaw queue

### DIFF
--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -332,7 +332,7 @@ watch(params, () => {
         // max-width: 12ch;
         // min-width: 32%;
         // max-width: 32%;
-        width: 32%;
+        width: 42.5%;
       }
       
       &:nth-of-type(6) {
@@ -343,12 +343,12 @@ watch(params, () => {
         width: 8.5%;
       }
       
-      &:nth-of-type(8) {
+      &:nth-of-type(7) {
         // min-width: 20ch;
         // max-width: 20ch;
         // min-width: 17%;
         // max-width: 17%;
-        width: 17%;
+        width: 17.5%;
       }
     }
 


### PR DESCRIPTION
## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated (_N/A_)
- [x] Test cases added/updated (_N/A_)
- [x] Jira ticket updated (_N/A_)

## Summary:

Adjust column sizes on `IssueQueue` to address the inconsistency width on the table after removing the `Source` column.

## Changes:

Adjust column sizes on `IssueQueue`.

## Considerations:

The new space available has been given mostly to `Title` column as it is the one that requires more inline space.