### PR TITLE
Task: Minor calculator code cleanup

### DIFF
--- a/src/components/CvssCalculator.vue
+++ b/src/components/CvssCalculator.vue
@@ -68,7 +68,6 @@ const getFactorColor = computed(() => (weight: number, isHovered: boolean = fals
     : isHovered
       ? 1 
       : 0.75;
-  console.log(hue, alpha);
   const hslForText = `hsla(${hue}, 100%, 35%, ${alpha})`;
   const hslForBackground = `hsla(${hue}, 100%, 95%, ${alpha})`;
   return {

--- a/src/components/CvssCalculator.vue
+++ b/src/components/CvssCalculator.vue
@@ -6,7 +6,6 @@ import {
   getFactors,
   formatFactor,
   calculateScore,
-  // getFactorColor,
   formatFactors,
   factorSeverities,
   validateCvssVector,

--- a/src/composables/useCvssCalculator.ts
+++ b/src/composables/useCvssCalculator.ts
@@ -88,21 +88,6 @@ function calculateBaseScore(factors: Record<string, string>) {
   return baseScore;
 }
 
-// Gets color for factor weight
-// export function getFactorColor(factor: string, value: string) {
-//   const severity = factorSeverities[factor][value];
-//   switch (severity) {
-//   case 'Good':
-//     return '#4CBD52'; // Green
-//   case 'Bad':
-//     return '#FBC94B'; // Yellow
-//   case 'Worse':
-//     return '#FF841F'; // Orange
-//   default:
-//     return '#FF5447'; // Red
-//   }
-// }
-
 // Factors Weights
 export const weights: { [factor: string]: { [value: string]: number } } = {
   AV: { N: 0.85, A: 0.62, L: 0.55, P: 0.2 },


### PR DESCRIPTION
## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated (_NA_)
- [x] Test cases added/updated (_NA_)
- [x] Jira ticket updated (_NA_)

## Summary:

Cleanups small parts of obsolete code related to CvssCalculator.

## Changes:

- Removes deprecated `getFactorColor` code
- Removes obsolete console log

## Considerations:

The `getFactorColor` method from `useCvssCalculator` was substituted with @superbuggy's hue approach.
The console log was used for debugging, not required anymore.