### PR TITLE
🐛 Save CVSS on Flaw Creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * Fixed Scroll bar on `Flaws` list
 * Fixed 'outdated Flaw' error when updating affects, references, acknowlegdements, CVSS scores, flaw
 * The session is now shared across tabs
+* Fixed CVSS scores not being saved after flaw creation
 
 
 

--- a/src/composables/useCvssScoresModel.ts
+++ b/src/composables/useCvssScoresModel.ts
@@ -1,10 +1,6 @@
 import { putFlawCvssScores, postFlawCvssScores } from '@/services/FlawService';
-import { createSuccessHandler, createCatchHandler } from './service-helpers';
 import { computed, ref, watch, type Ref } from 'vue';
 import type { ZodFlawType } from '@/types/zodFlaw';
-
-const onSucceed = createSuccessHandler({ title: 'Success!', body: 'Saved CVSS Scores' });
-const onError = createCatchHandler('Error updating Flaw CVSS data');
 
 // TODO: This composable should be ideally refactored into a more modular
 // solution when CVSSv4 starts being used
@@ -72,13 +68,7 @@ export function useCvssScoresModel(flaw: Ref<ZodFlawType>) {
 
   async function saveCvssScores() {
     if (flawRhCvss3.value.created_dt) {
-      return putFlawCvssScores(
-        flaw.value.uuid,
-        flawRhCvss3.value.uuid || '',
-        flawRhCvss3.value as unknown,
-      )
-        .then(onSucceed)
-        .catch(onError);
+      return putFlawCvssScores(flaw.value.uuid, flawRhCvss3.value.uuid || '', flawRhCvss3.value as unknown);
     }
 
     const requestBody = {
@@ -89,9 +79,7 @@ export function useCvssScoresModel(flaw: Ref<ZodFlawType>) {
       vector: flawRhCvss3.value.vector,
       embargoed: flaw.value.embargoed,
     };
-    return postFlawCvssScores(flaw.value.uuid, requestBody as unknown)
-      .then(onSucceed)
-      .catch(onError);
+    return postFlawCvssScores(flaw.value.uuid, requestBody as unknown);
   }
 
   return {

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -140,8 +140,9 @@ export async function putFlawCvssScores(
     url: `/osidb/api/v1/flaws/${flawId}/cvss_scores/${cvssScoresId}`,
     data: putObject,
   }, { beforeFetch })
+    .then(createSuccessHandler({ title: 'Success!', body: 'Saved CVSS Scores' }))
     .then((response) => response.data)
-    .catch(createCatchHandler('Problem updating flaw CVSS scores:'));
+    .catch(createCatchHandler('CVSS Scores Update Error'));
 }
 
 // {
@@ -159,8 +160,9 @@ export async function postFlawCvssScores(flawId: string, cvssScoreObject: unknow
     url: `/osidb/api/v1/flaws/${flawId}/cvss_scores`,
     data: postObject,
   }, { beforeFetch })
+    .then(createSuccessHandler({ title: 'Success!', body: 'Saved CVSS Scores' }))
     .then((response) => response.data)
-    .catch(createCatchHandler('Problem updating flaw CVSS scores:'));
+    .catch(createCatchHandler('CVSS scores Update Error'));
 }
 
 export async function postFlawPublicComment(uuid: string, comment: string, embargoed: boolean) {


### PR DESCRIPTION
# [OSIDB-2613] OSIM: RH CVSSv3 is not saved upon Flaw creation

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [ ] Test cases added/updated
- [x] Jira ticket updated

## Summary:

CVSS scores are now saved after flaw creation by interacting with the dedicated endpoint.

## Changes:

- Adds additional request after flaw creation to save CVSS scores.
- Grabs flaw UUID after creation.

## Considerations:

[Replace with any additional considerations, notes, or instructions for reviewers.]