### PR TITLE
Fix: Attributions form bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## [Unreleased]
 ### Added
 * Self-Assign button for Flaws
-* Time to Public Date field
+* Provide time to Public Date field
 
 ### Fixed
 * The session is now shared across tabs
 * CVSS scores on affects can be added
+* Disable form on references and acknowledgments save actions
+* References and acknowledgments disappear after save actions
+* References and acknowledgments are not refreshed after save actions
 
 
 ## [Unreleased] (TODO update for 2024.1.1 and 2024.2.0 releases)

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -31,8 +31,6 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'refresh:flaw'): void;
-  (e: 'add-blank-affect'): void;
-  (e: 'comment:addPublicComment', value: string): void;
 }>();
 
 function onSaveSuccess() {
@@ -316,7 +314,6 @@ const onReset = () => {
         <div class="d-flex gap-3">
           <IssueFieldReferences
             v-model="flawReferences"
-            :isEmbargoed="flaw.embargoed"
             class="w-100 my-3"
             :error="errors.references"
             @reference:update="saveReferences"

--- a/src/components/widgets/EditableList.vue
+++ b/src/components/widgets/EditableList.vue
@@ -18,10 +18,10 @@ const emit = defineEmits<{
   'item:delete': [value: string];
 }>();
 
-const modals = Object.fromEntries(items.value.map((item) => [item.uuid, useModal()]));
+const modals = computed(() => Object.fromEntries(items.value.map((item) => [item.uuid, useModal()])));
 
 function useModalForItem(uuid: string) {
-  return modals[uuid];
+  return modals.value[uuid];
 }
 
 const entityNamePlural = computed(() => props.entitiesName || `${props.entityName}s`);

--- a/src/components/widgets/EditableList.vue
+++ b/src/components/widgets/EditableList.vue
@@ -45,6 +45,11 @@ function addItem() {
   emit('item:new');
 }
 
+function saveItems() {
+  emit('item:save', itemsToSave.value);
+  modifiedItemIndexes.value = [];
+}
+
 function cancelEdit(index: number) {
   items.value[index] = deepCopyFromRaw(priorValues.value[index]);
   indexBeingEdited.value = null;
@@ -173,7 +178,7 @@ function commitEdit(index: number) {
         type="button"
         class="btn btn-primary me-2"
         :class="{ disabled: itemsToSave.length === 0 }"
-        @click.prevent="emit('item:save', itemsToSave)"
+        @click.prevent="saveItems()"
       >
         Save Changes to {{ entityNamePlural }}
       </button>

--- a/src/composables/useFlawAttributionsModel.ts
+++ b/src/composables/useFlawAttributionsModel.ts
@@ -11,12 +11,20 @@ import {
   putFlawAcknowledgment,
   deleteFlawAcknowledgment,
 } from '@/services/FlawService';
-import { ref, type Ref } from 'vue';
+import { toRef, watch, type Ref } from 'vue';
 
 export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, afterSaveSuccess: () => void) {
 
-  const flawReferences = ref<ZodFlawReferenceType[]>(flaw.value.references);
-  const flawAcknowledgments = ref<ZodFlawAcknowledgmentType[]>(flaw.value.acknowledgments);
+  const flawReferences: Ref<ZodFlawReferenceType[]> = toRef(flaw.value, 'references');
+  const flawAcknowledgments: Ref<ZodFlawAcknowledgmentType[]> = toRef(flaw.value, 'acknowledgments');
+  
+  watch(() => flaw.value.references, () => {
+    flawReferences.value = flaw.value.references;
+  });
+
+  watch(() => flaw.value.acknowledgments, () => {
+    flawAcknowledgments.value = flaw.value.acknowledgments;
+  });
 
   async function updateReference(reference: ZodFlawReferenceType & { uuid: string }) {
     await putFlawReference(flaw.value.uuid, reference.uuid, reference as any);

--- a/src/composables/useFlawAttributionsModel.ts
+++ b/src/composables/useFlawAttributionsModel.ts
@@ -13,7 +13,7 @@ import {
 } from '@/services/FlawService';
 import { toRef, watch, type Ref } from 'vue';
 
-export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, afterSaveSuccess: () => void) {
+export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<boolean>, afterSaveSuccess: () => void) {
 
   const flawReferences: Ref<ZodFlawReferenceType[]> = toRef(flaw.value, 'references');
   const flawAcknowledgments: Ref<ZodFlawAcknowledgmentType[]> = toRef(flaw.value, 'acknowledgments');
@@ -27,16 +27,19 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, afterSaveSucces
   });
 
   async function updateReference(reference: ZodFlawReferenceType & { uuid: string }) {
+    isSaving.value = true;
     await putFlawReference(flaw.value.uuid, reference.uuid, reference as any);
     afterSaveSuccess();
   }
 
   async function createReference(reference: ZodFlawReferenceType) {
+    isSaving.value = true;
     await postFlawReference(flaw.value.uuid, reference);
     afterSaveSuccess();
   }
 
   async function deleteReference(referenceId: string) {
+    isSaving.value = true;
     await deleteFlawReference(flaw.value.uuid, referenceId);
     afterSaveSuccess();
   }
@@ -46,6 +49,7 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, afterSaveSucces
   }
 
   async function saveReferences(references: ZodFlawReferenceType[]) {
+    isSaving.value = true;
     for (const reference of references) {
       if (reference.uuid) {
         await updateReference(reference);
@@ -67,16 +71,19 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, afterSaveSucces
   }
 
   async function createAcknowledgment(acknowlegdment: any) {
+    isSaving.value = true;
     await postFlawAcknowledgment(flaw.value.uuid, acknowlegdment);
     afterSaveSuccess();
   }
 
   async function deleteAcknowledgment(acknowledgmentId: string) {
+    isSaving.value = true;
     await deleteFlawAcknowledgment(flaw.value.uuid, acknowledgmentId);
     afterSaveSuccess();
   }
 
   async function updateAcknowledgment(acknowlegdment: any) {
+    isSaving.value = true;
     await putFlawAcknowledgment(flaw.value.uuid, acknowlegdment.uuid, acknowlegdment as any);
     afterSaveSuccess();
   }

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -168,7 +168,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     afterSaveSuccess,
     ...cvssScoresModel,
     ...flawAffectsModel,
-    ...useFlawAttributionsModel(flaw, afterSaveSuccess),
+    ...useFlawAttributionsModel(flaw, isSaving, afterSaveSuccess),
   };
 }
 


### PR DESCRIPTION
# OSIDB-2645 References disappear

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated (_NA_)
- [x] Jira ticket updated

## Summary:

Fix some bugs in attributions section, remove unused code and implements form disabling on attributions save actions.

## Changes:

- Removes unused code on `FlawForm`
- Fix attributions reactivity loss by adding a watcher to the model `useAttributionsModel`
- Fix modal index issues on `EditableList` by making it a computed property
- Add a cleanup of modified items array after save actions on `EditableList`
- Implements the form disabled state for attributions saving actions

## Considerations:

`flawReferences` and `flawAcknowledgments` were not being updated after performing the `flaw:refresh`, the reactivity was being lost the way they are implemented, making the next actions on the attributions form inconsistent. 
I added a watcher cause it looked to me the simpler working solution for this, however I think we could avoid using `flawReferences` and `flawAcknowledgments` by using direct references to the flaw being passed from `FlawModel` on the nested composable. Just a though might be interesting to discuss.