### PR TITLE
Fix: Use object-specific updated_dt

### DIFF
--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -42,10 +42,9 @@ export async function beforeFetch(options: OsidbFetchOptions) {
       return;
     }
     try {
-      const flaw = await getFlawUpdatedDt(flawId);
-      options.data.updated_dt = flaw.updated_dt;
-      if (!flaw.updated_dt) {
-        console.error('During multi-stage operation, an updated_dt could not be fetched', flaw, flawId);
+      const updated_dt = await getUpdatedDt(options.url);
+      if (!updated_dt) {
+        console.error('During multi-stage operation, an updated_dt could not be fetched');
         throw new Error('During multi-stage operation, an updated_dt could not be fetched');
       }
     } catch (error) {
@@ -96,10 +95,10 @@ export async function getFlaw(uuid: string): Promise<ZodFlawType> {
   }).then((response) => response.data);
 }
 
-export async function getFlawUpdatedDt(uuid: string): Promise<ZodFlawType> {
+export async function getUpdatedDt(url: string): Promise<ZodFlawType> {
   return osidbFetch({
     method: 'get',
-    url: `/osidb/api/v1/flaws/${uuid}`,
+    url: url,
     params: {
       include_fields: 'updated_dt',
     },

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -8,39 +8,9 @@ import {
   type OsidbFetchOptions
 } from '@/services/OsidbAuthService';
 import { createCatchHandler, createSuccessHandler } from '@/composables/service-helpers';
-import { isFlawIdentifierValid } from '@/utils/helpers';
-
-import { ZodFlawSchema } from '@/types/zodFlaw';
-
-
-function isFlaw(data: any) {
-  return !!ZodFlawSchema.safeParse(data).success;
-}
-
-function parseFlawId(options: any) {
-  if (isFlaw(options.data) && options.data.uuid) {
-    return options.data.uuid;
-  }
-
-  // Look for the presence of a flaw id on Affects, CVSS Scores, and other entities 'belonging to' flaws
-  if (options.data?.flaw && isFlawIdentifierValid(options.data.flaw?.toString())) {
-    return options.data.flaw;
-  }
-
-  const flawOsidbIdRegex = /flaws\/(.+?)\/.*/;
-  const maybeFlawId = options.url.match(flawOsidbIdRegex)?.[1];
-  if (maybeFlawId) {
-    return maybeFlawId;
-  }
-  return null;
-}
 
 export async function beforeFetch(options: OsidbFetchOptions) {
   if (options.data && ['PUT', 'POST'].includes(options.method.toUpperCase())) {
-    const flawId = parseFlawId(options);
-    if (flawId === null) {
-      return;
-    }
     try {
       const updated_dt = await getUpdatedDt(options.url);
       if (!updated_dt) {

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -64,14 +64,14 @@ export async function getFlaw(uuid: string): Promise<ZodFlawType> {
   }).then((response) => response.data);
 }
 
-export async function getUpdatedDt(url: string): Promise<ZodFlawType> {
+export async function getUpdatedDt(url: string): Promise<string> {
   return osidbFetch({
     method: 'get',
     url: url,
     params: {
       include_fields: 'updated_dt',
     },
-  }).then((response) => response.data);
+  }).then((response) => response.data.updated_dt);
 }
 
 export async function putFlaw(uuid: string, flawObject: ZodFlawType) {

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -14,12 +14,11 @@ export async function beforeFetch(options: OsidbFetchOptions) {
     try {
       const updated_dt = await getUpdatedDt(options.url);
       if (!updated_dt) {
-        console.error('During multi-stage operation, an updated_dt could not be fetched');
-        throw new Error('During multi-stage operation, an updated_dt could not be fetched');
+        throw new Error('An updated_dt could not be fetched');
       }
     } catch (error) {
-      console.error('Problem fetching flaw for sequential update:', error);
-      throw new Error('Problem fetching flaw for sequential update');
+      console.error('Problem on fetch preparation. ', (error as Error).message);
+      throw new Error('Problem on fetch preparation. ' + (error as Error).message);
     }
   }
 }

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -13,6 +13,7 @@ export async function beforeFetch(options: OsidbFetchOptions) {
   if (options.data && ['PUT', 'POST'].includes(options.method.toUpperCase())) {
     try {
       const updated_dt = await getUpdatedDt(options.url);
+      options.data.updated_dt = updated_dt;
       if (!updated_dt) {
         throw new Error('An updated_dt could not be fetched');
       }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -80,7 +80,4 @@ export const deepMap = (transform: (arg: any) => any, object: DeepMappable): any
   );
 
 export const cveRegex = /^CVE-(?:1999|2\d{3})-(?!0{4})(?:0\d{3}|[1-9]\d{3,})$/;
-export const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-export const isFlawIdentifierValid = (identifier: string) => cveRegex.test(identifier) || uuidRegex.test(identifier);
-
 export const uniques = <T>(array: T[]) => Array.from(new Set(array));


### PR DESCRIPTION
# OSIDB-2697: Error 409 updating a flaw reference

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated (_NA_)
- [x] Test cases added/updated (_NA_)
- [x] Jira ticket updated

## Summary:

This PR aims to address an issue found by @JakubFrejlach where OSIM was sending the `updated_dt` of the flaw, to sub-models (i.e. Acks, Refs, Comments, Affects, etc.), making OSIDB respond with 409 Error "Save operation based on an outdated model instance".

## Changes:

- Renamed `getFlawUpdatedDt` function to `getUpdatedDt` on `FlawService.ts`
- Use the `options.url` on `beforeFetch` to get the specific object `update_dt`
- Removed potentially deprecated

## Considerations:

- This issue was only manifested when OSIDB's BZ Sync was disconnected, in other case the the updated_dt was not compared from OSIDB data but BZ.
- @superbuggy I removed some code that looked deprecated after this changes. Would you mind to have a look on that to ensure nothing essential was removed?
