### PR TITLE
🐛 Fix Remove Summary, Statement, Mitigation Button on FlawForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Disable form on references and acknowledgments save actions
 * References and acknowledgments disappear after save actions
 * References and acknowledgments are not refreshed after save actions
+* Fixed FlawForm Remove Summary, Statement, Mitigation Button
 
 
 ## [Unreleased] (TODO update for 2024.1.1 and 2024.2.0 releases)

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -109,6 +109,27 @@ const onReset = () => {
   flaw.value = deepCopyFromRaw(initialFlaw.value as Record<string, any>) as ZodFlawType;
 };
 
+const toggleSummary = () => {
+  showSummary.value = !showSummary.value;
+  if (!showSummary.value) {
+    flaw.value.summary = '';
+  }
+};
+
+const toggleStatement = () => {
+  showStatement.value = !showStatement.value;
+  if (!showStatement.value) {
+    flaw.value.statement = '';
+  }
+};
+
+const toggleMitigation = () => {
+  showMitigation.value = !showMitigation.value;
+  if (!showMitigation.value) {
+    flaw.value.mitigation = '';
+  }
+};
+
 </script>
 
 <template>
@@ -290,21 +311,21 @@ const onReset = () => {
           <button
             type="button"
             class="btn btn-secondary"
-            @click="showSummary = !showSummary; flaw.summary = '';"
+            @click="toggleSummary"
           >
             {{ showSummary ? 'Remove Description' : 'Add Description' }}
           </button>
           <button
             type="button"
             class="btn btn-secondary"
-            @click="showStatement = !showStatement; flaw.statement = '';"
+            @click="toggleStatement"
           >
             {{ showStatement ? 'Remove Statement' : 'Add Statement' }}
           </button>
           <button
             type="button"
             class="btn btn-secondary"
-            @click="showMitigation = !showMitigation; flaw.mitigation = '';"
+            @click="toggleMitigation"
           >
             {{ showMitigation ? 'Remove Mitigation' : 'Add Mitigation' }}
           </button>

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -290,21 +290,21 @@ const onReset = () => {
           <button
             type="button"
             class="btn btn-secondary"
-            @click="showSummary = !showSummary"
+            @click="showSummary = !showSummary; flaw.summary = '';"
           >
             {{ showSummary ? 'Remove Description' : 'Add Description' }}
           </button>
           <button
             type="button"
             class="btn btn-secondary"
-            @click="showStatement = !showStatement"
+            @click="showStatement = !showStatement; flaw.statement = '';"
           >
             {{ showStatement ? 'Remove Statement' : 'Add Statement' }}
           </button>
           <button
             type="button"
             class="btn btn-secondary"
-            @click="showMitigation = !showMitigation"
+            @click="showMitigation = !showMitigation; flaw.mitigation = '';"
           >
             {{ showMitigation ? 'Remove Mitigation' : 'Add Mitigation' }}
           </button>

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -351,6 +351,7 @@ describe('FlawForm', () => {
       },
     ];
   });
+
   it('displays correct CVSSv3 calculator link for empty value', async () => {
     const flaw = sampleFlaw();
     flaw.cvss_scores = [];
@@ -470,6 +471,27 @@ describe('FlawForm', () => {
     mountWithProps({ flaw, mode: 'edit' });
     expect((subject.vm as any).errors.unembargo_dt)
       .toBe(null);
+  });
+
+  it('show set summary, statement, mitigation values correctly after clicking remove buttons', async () => {
+    const flaw = sampleFlaw();
+    flaw.summary = 'summary';
+    flaw.statement = 'statement';
+    flaw.mitigation = 'mitigation';
+    mountWithProps({ flaw, mode: 'edit' });
+    const buttonGroups = subject.find('div.d-flex.gap-3.mb-3').findAll("button.btn.btn-secondary");
+    const removeSummaryButton = buttonGroups[0];
+    expect(removeSummaryButton.element?.textContent).toBe("Remove Description");
+    const removeStatementButton = buttonGroups[1];
+    expect(removeStatementButton.element?.textContent).toBe("Remove Statement");
+    const removeMitigationButton = buttonGroups[2];
+    expect(removeMitigationButton.element?.textContent).toBe("Remove Mitigation");
+    await removeSummaryButton.trigger('click');
+    await removeStatementButton.trigger('click');
+    await removeMitigationButton.trigger('click');
+    expect((subject.vm as any).flaw.summary).toBe('');
+    expect((subject.vm as any).flaw.statement).toBe('');
+    expect((subject.vm as any).flaw.mitigation).toBe('');
   });
 });
 

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -479,13 +479,13 @@ describe('FlawForm', () => {
     flaw.statement = 'statement';
     flaw.mitigation = 'mitigation';
     mountWithProps({ flaw, mode: 'edit' });
-    const buttonGroups = subject.find('div.d-flex.gap-3.mb-3').findAll("button.btn.btn-secondary");
+    const buttonGroups = subject.find('div.d-flex.gap-3.mb-3').findAll('button.btn.btn-secondary');
     const removeSummaryButton = buttonGroups[0];
-    expect(removeSummaryButton.element?.textContent).toBe("Remove Description");
+    expect(removeSummaryButton.element?.textContent).toBe('Remove Description');
     const removeStatementButton = buttonGroups[1];
-    expect(removeStatementButton.element?.textContent).toBe("Remove Statement");
+    expect(removeStatementButton.element?.textContent).toBe('Remove Statement');
     const removeMitigationButton = buttonGroups[2];
-    expect(removeMitigationButton.element?.textContent).toBe("Remove Mitigation");
+    expect(removeMitigationButton.element?.textContent).toBe('Remove Mitigation');
     await removeSummaryButton.trigger('click');
     await removeStatementButton.trigger('click');
     await removeMitigationButton.trigger('click');


### PR DESCRIPTION
# [[OSIDB-2703](https://issues.redhat.com/browse/OSIDB-2703)] [Can not remove Description, Statement, Mitigation]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Can not remove Description, Statement, Mitigation

## Changes:

[Replace with a detailed description of the changes made in this PR, including any new features, enhancements, bug fixes, or refactorings.]

## Considerations:

[Replace with any additional considerations, notes, or instructions for reviewers.]