### PR TITLE
🐛 Restore required field validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 * Self-Assign button for Flaws
 * Provide time to Public Date field
+* Add neighboring dropdown menu to Flaw Description for its review workflow
 
 ### Fixed
 * The session is now shared across tabs
@@ -12,7 +13,7 @@
 * References and acknowledgments disappear after save actions
 * References and acknowledgments are not refreshed after save actions
 * Fixed FlawForm Remove Summary, Statement, Mitigation Button
-
+* Restored required field validations to Flaw fields
 
 ## [Unreleased] (TODO update for 2024.1.1 and 2024.2.0 releases)
 

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -22,7 +22,7 @@ import CvssCalculator from '@/components/CvssCalculator.vue';
 
 import { useFlawModel } from '@/composables/useFlawModel';
 import { fileTracker, type TrackersFilePost } from '@/services/TrackerService';
-import type { ZodFlawType } from '@/types/zodFlaw';
+import { type ZodFlawType, summaryRequiredStates } from '@/types/zodFlaw';
 
 const props = defineProps<{
   flaw: any;
@@ -292,7 +292,21 @@ const toggleMitigation = () => {
           label="Description"
           placeholder="Description Text ..."
           :error="errors.summary"
-        />
+          class="osim-flaw-description-component"
+        >
+          <template #label>
+            <span class="form-label col-3 osim-folder-tab-label">
+              Description
+            </span>
+            <span class="col-3 ps-2">
+              <select v-model="flaw.requires_summary" class="form-select col-3 osim-summary-required">
+                <option disabled :selected="!flaw.requires_summary" value="">Review Status</option>
+                <option v-for="state in summaryRequiredStates" :key="state" :value="state">{{ state }}</option>
+              </select>
+            </span>
+
+          </template>
+        </LabelTextarea>
         <LabelTextarea
           v-if="showStatement"
           v-model="flaw.statement"
@@ -310,7 +324,7 @@ const toggleMitigation = () => {
         <div class="d-flex gap-3 mb-3">
           <button
             type="button"
-            class="btn btn-secondary"
+            class="btn btn-secondary osim-show-summary"
             @click="toggleSummary"
           >
             {{ showSummary ? 'Remove Description' : 'Add Description' }}
@@ -471,7 +485,7 @@ form.osim-flaw-form :deep(*) {
     justify-content: end;
 
     &:has(+ textarea),
-    &:has(+ .osim-static-label-value.osim-top-label-style) {
+    &.osim-folder-tab-label {
       border-top-right-radius: 0.5rem;
       border-bottom-left-radius: 0;
       text-align: left;
@@ -481,9 +495,18 @@ form.osim-flaw-form :deep(*) {
   }
 
   textarea {
+    border-top-right-radius: 0.5rem;
     border-top-left-radius: 0;
   }
+
+  select.osim-summary-required.form-select {
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+    margin-bottom: 0;
+    border-bottom: none;
+  }
 }
+
 
 .span-editable-text {
   cursor: text;

--- a/src/components/widgets/EditableDate.vue
+++ b/src/components/widgets/EditableDate.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
   includesTime?: boolean,
   readOnly?: boolean,
   editing?: boolean,
-  error?: string,
+  error?: string | null,
 }>();
 const initialValue = toValue(props.modelValue);
 const emit = defineEmits<{

--- a/src/components/widgets/EditableText.vue
+++ b/src/components/widgets/EditableText.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
   readOnly?: boolean,
   editing?: boolean,
   placeholder?: string,
-  error?: string,
+  error?: string | null,
 }>();
 
 const emit = defineEmits<{

--- a/src/components/widgets/LabelEditable.vue
+++ b/src/components/widgets/LabelEditable.vue
@@ -4,14 +4,12 @@ import EditableText from './EditableText.vue';
 import EditableDate from './EditableDate.vue';
 
 const props = withDefaults(defineProps<{
-  // modelValue: string,
-  label?: string,
-  type: 'text' | 'date' | 'datetime',
-  // error: string,
-  // required: boolean,
+  label?: string;
+  type: 'text' | 'date' | 'datetime';
+  error?: null | string;
 }>(), {
   label: '',
-  // required: false,
+  error: undefined,
 });
 
 const modelValue = defineModel<string | undefined | null | number | Date>();
@@ -29,12 +27,14 @@ const modelValue = defineModel<string | undefined | null | number | Date>();
         v-if="props.type.includes('date')"
         v-model="modelValue as string"
         :class="$attrs.class"
+        :error="error"
         :includesTime="props.type === 'datetime'"
       />
       <EditableText
         v-else
         v-model="modelValue as string"
         :class="$attrs.class"
+        :error="error"
       />
     </div>
   </label>

--- a/src/components/widgets/LabelTextarea.vue
+++ b/src/components/widgets/LabelTextarea.vue
@@ -33,10 +33,12 @@ const elTextArea = ref();
 <template>
   <label class="osim-input mb-3 ps-3">
     <div class="row">
-      <span class="form-label col-3">
-        {{ label }}
-        <!--attrs: {{ $attrs }}-->
-      </span>
+      <slot name="label">
+        <span class="form-label col-3">
+          {{ label }}
+          <!--attrs: {{ $attrs }}-->
+        </span>
+      </slot>
       <!--    @focus="resizeTextarea"-->
       <!--    @keyup="resizeTextarea"-->
       <textarea

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -322,6 +322,22 @@ export const ZodFlawSchema = z.object({
     return null;
   };
 
+  if (
+    zodFlaw.requires_summary
+    && ['REQUESTED', 'APPROVED'].includes(zodFlaw.requires_summary)
+    && zodFlaw.summary === ''
+  ) {
+    raiseIssue('Description cannot be blank if requested or approved.', ['summary']);
+  }
+
+  if (
+    zodFlaw.requires_summary !== 'APPROVED'
+    && zodFlaw.major_incident_state
+    && ['APPROVED', 'CISA_APPROVED'].includes(zodFlaw.major_incident_state)
+  ) {
+    raiseIssue('Description must be approved for Major Incidents.', ['summary']);
+  }
+
   const unembargo_dt = DateTime.fromISO(`${zodFlaw.unembargo_dt}`).toISODate();
   const reported_dt = DateTime.fromISO(`${zodFlaw.reported_dt}`).toISODate();
 
@@ -360,8 +376,6 @@ export const ZodFlawSchema = z.object({
 
 });
 
-// const ZodFlawSchemaPartial = ZodFlawSchema.partial();
-
 type SchemaType =
   | typeof FlawCVSSSchema
   | typeof AffectCVSSSchema
@@ -384,6 +398,7 @@ export const flawTypes = Object.values(FlawTypeWithBlank);
 export const flawSources = Object.values(Source642EnumWithBlank); // TODO: handle blank in the component
 export const flawImpacts = Object.values(ImpactEnumWithBlank); // TODO: handle blank in the component
 export const flawIncidentStates = Object.values(MajorIncidentStateEnumWithBlank);
+export const summaryRequiredStates = Object.values(RequiresSummaryEnumWithBlank);
 
 const {
   impact: zodAffectImpact,


### PR DESCRIPTION
# [OSIDB-ID] [Title]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Restores display of required field validation results.
## Changes:

Explicitly passing in errors to `EditableDate` and `EditableText` components.

## Considerations:

Broke when only passing `$attrs.class` instead of `$attrs`. May be good to avoid reliance on passing props via `$attrs`