### PR TITLE
Feat: Support references and acknowledgements on flaw creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Provide time to Public Date field (`OSIDB-1848`)
 * Add neighboring dropdown menu to Flaw Description for its review workflow (`OSIDB-2623`)
 * Add CVE Require Description for AdvancedSearch (`OSIDB-2624`)
+* Support for references and acknowledgements on flaw creation (`OSIDB-2319`)
 
 ### Fixed
 * The session is now shared across tabs

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -79,7 +79,7 @@ const { draftFlaw } = useDraftFlawStore();
 
 onMounted(() => {
   initialFlaw.value = deepCopyFromRaw(props.flaw) as ZodFlawType;
-  if(draftFlaw) {
+  if (draftFlaw) {
     flaw.value = useDraftFlawStore().addDraftFields(flaw.value);
     useDraftFlawStore().$reset();
   }
@@ -87,7 +87,6 @@ onMounted(() => {
 
 watch(() => props.flaw, () => { // Shallow watch so as to avoid reseting on any change (though that shouldn't happen)
   initialFlaw.value = deepCopyFromRaw(props.flaw) as ZodFlawType;
-  console.log(1,useDraftFlawStore().draftFlaw);
   onReset();
 });
 

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -383,6 +383,7 @@ const toggleMitigation = () => {
           <IssueFieldReferences
             v-model="flawReferences"
             class="w-100 my-3"
+            :mode="mode"
             :error="errors.references"
             @reference:update="saveReferences"
             @reference:new="addBlankReference(flaw.embargoed)"
@@ -392,6 +393,7 @@ const toggleMitigation = () => {
           <IssueFieldAcknowledgments
             v-model="flawAcknowledgments"
             class="w-100 my-3"
+            :mode="mode"
             :error="errors.acknowledgments"
             @acknowledgment:update="saveAcknowledgments"
             @acknowledgment:new="addBlankAcknowledgment(flaw.embargoed)"

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -23,6 +23,7 @@ import CvssCalculator from '@/components/CvssCalculator.vue';
 import { useFlawModel } from '@/composables/useFlawModel';
 import { fileTracker, type TrackersFilePost } from '@/services/TrackerService';
 import { type ZodFlawType, summaryRequiredStates } from '@/types/zodFlaw';
+import { useDraftFlawStore } from '@/stores/DraftFlawStore';
 
 const props = defineProps<{
   flaw: any;
@@ -74,13 +75,19 @@ const {
 } = useFlawModel(props.flaw, onSaveSuccess);
 
 const initialFlaw = ref<ZodFlawType>();
+const { draftFlaw } = useDraftFlawStore();
 
 onMounted(() => {
   initialFlaw.value = deepCopyFromRaw(props.flaw) as ZodFlawType;
+  if(draftFlaw) {
+    flaw.value = useDraftFlawStore().addDraftFields(flaw.value);
+    useDraftFlawStore().$reset();
+  }
 });
 
 watch(() => props.flaw, () => { // Shallow watch so as to avoid reseting on any change (though that shouldn't happen)
   initialFlaw.value = deepCopyFromRaw(props.flaw) as ZodFlawType;
+  console.log(1,useDraftFlawStore().draftFlaw);
   onReset();
 });
 

--- a/src/components/IssueFieldAcknowledgments.vue
+++ b/src/components/IssueFieldAcknowledgments.vue
@@ -4,6 +4,7 @@ import LabelInput from './widgets/LabelInput.vue';
 import type { ZodFlawAcknowledgmentType } from '@/types/zodFlaw';
 
 defineProps<{
+  mode: 'create' | 'edit';
   error: Record<string, any>[] | null;
 }>();
 
@@ -27,6 +28,7 @@ function handleDelete(uuid: string, closeModal: () => void) {
   <div>
     <EditableList
       v-model="acknowledgments"
+      :mode="mode"
       entityName="Acknowledgment"
       @item:save="emit('acknowledgment:update', $event)"
       @item:delete="emit('acknowledgment:delete', $event)"

--- a/src/components/IssueFieldReferences.vue
+++ b/src/components/IssueFieldReferences.vue
@@ -9,6 +9,7 @@ import { flawReferenceTypeValues } from '@/types/zodFlaw';
 const references = defineModel<ZodFlawReferenceType[]>({ default: null });
 
 defineProps<{
+  mode: 'create' | 'edit';
   error: Record<string, any>[] | null;
 }>();
 
@@ -40,6 +41,7 @@ function handleDelete(uuid: string, closeModal: () => void) {
   <div>
     <EditableList
       v-model="references"
+      :mode="mode"
       entityName="Reference"
       @item:save="emit('reference:update', $event)"
       @item:delete="emit('reference:delete', $event)"

--- a/src/components/widgets/EditableList.vue
+++ b/src/components/widgets/EditableList.vue
@@ -8,6 +8,7 @@ import LabelCollapsible from './LabelCollapsible.vue';
 
 const items = defineModel<any[]>({ default: [] });
 const props = defineProps<{
+  mode: 'create' | 'edit';
   entityName: string;
   entitiesName?: string;
 }>();
@@ -175,6 +176,7 @@ function commitEdit(index: number) {
     </LabelCollapsible>
     <form>
       <button
+        v-if="props.mode !== 'create'"
         type="button"
         class="btn btn-primary me-2"
         :class="{ disabled: itemsToSave.length === 0 }"

--- a/src/composables/useFlawAttributionsModel.ts
+++ b/src/composables/useFlawAttributionsModel.ts
@@ -112,8 +112,8 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<b
       flaw: '',
       uuid: '',
       embargoed: isEmbargoed,
-      created_dt: '',
-      updated_dt: '',
+      created_dt: null,
+      updated_dt: null,
     });
   }
 

--- a/src/composables/useFlawAttributionsModel.ts
+++ b/src/composables/useFlawAttributionsModel.ts
@@ -28,19 +28,22 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<b
 
   async function updateReference(reference: ZodFlawReferenceType & { uuid: string }) {
     isSaving.value = true;
-    await putFlawReference(flaw.value.uuid, reference.uuid, reference as any);
+    await putFlawReference(flaw.value.uuid, reference.uuid, reference as any)
+      .finally(() => isSaving.value = false);
     afterSaveSuccess();
   }
 
   async function createReference(reference: ZodFlawReferenceType) {
     isSaving.value = true;
-    await postFlawReference(flaw.value.uuid, reference);
+    await postFlawReference(flaw.value.uuid, reference)
+      .finally(() => isSaving.value = false);
     afterSaveSuccess();
   }
 
   async function deleteReference(referenceId: string) {
     isSaving.value = true;
-    await deleteFlawReference(flaw.value.uuid, referenceId);
+    await deleteFlawReference(flaw.value.uuid, referenceId)
+      .finally(() => isSaving.value = false);
     afterSaveSuccess();
   }
 
@@ -72,19 +75,22 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<b
 
   async function createAcknowledgment(acknowlegdment: any) {
     isSaving.value = true;
-    await postFlawAcknowledgment(flaw.value.uuid, acknowlegdment);
+    await postFlawAcknowledgment(flaw.value.uuid, acknowlegdment)
+      .finally(() => isSaving.value = false);
     afterSaveSuccess();
   }
 
   async function deleteAcknowledgment(acknowledgmentId: string) {
     isSaving.value = true;
-    await deleteFlawAcknowledgment(flaw.value.uuid, acknowledgmentId);
+    await deleteFlawAcknowledgment(flaw.value.uuid, acknowledgmentId)
+      .finally(() => isSaving.value = false);
     afterSaveSuccess();
   }
 
   async function updateAcknowledgment(acknowlegdment: any) {
     isSaving.value = true;
-    await putFlawAcknowledgment(flaw.value.uuid, acknowlegdment.uuid, acknowlegdment as any);
+    await putFlawAcknowledgment(flaw.value.uuid, acknowlegdment.uuid, acknowlegdment as any)
+      .finally(() => isSaving.value = false);
     afterSaveSuccess();
   }
 

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -63,7 +63,6 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
       Object.entries(validatedFlaw.data).filter(([, value]) => value !== '')
     );
     try {
-
       await postFlaw(flawForPost)
         .then(createSuccessHandler({ title: 'Success!', body: 'Flaw created' }))
         .then(async (response: any) => {
@@ -73,15 +72,11 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
           });
           flaw.value.uuid = response.uuid;
           saveDraftFlaw(flaw.value);
-          try {
-            if (flaw.value.acknowledgments.length > 0) {
-              await flawAttributionsModel.saveAcknowledgments(flaw.value.acknowledgments);
-            }
-            if (flaw.value.references.length > 0) {
-              await flawAttributionsModel.saveReferences(flaw.value.references);
-            }
-          } catch(error: any) {
-            createCatchHandler('Error creating Flaw attributions');
+          if (flaw.value.acknowledgments.length > 0) {
+            await flawAttributionsModel.saveAcknowledgments(flaw.value.acknowledgments);
+          }
+          if (flaw.value.references.length > 0) {
+            await flawAttributionsModel.saveReferences(flaw.value.references);
           }
         })
         .catch(createCatchHandler('Error creating Flaw'));

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -287,7 +287,7 @@ export function postFlawReference(flawId: string, requestBody: FlawReferencePost
     method: 'post',
     url: `/osidb/api/v1/flaws/${flawId}/references`,
     data: requestBody,
-  }, { beforeFetch })
+  })
     .then(createSuccessHandler({ title: 'Success!', body: 'Reference created.' }))
     .catch(createCatchHandler('Error creating Reference:'));
 }
@@ -335,7 +335,7 @@ export async function postFlawAcknowledgment(flawId: string, requestBody: FlawAc
     method: 'post',
     url: `/osidb/api/v1/flaws/${flawId}/acknowledgments`,
     data: requestBody,
-  }, { beforeFetch })
+  })
     .then(createSuccessHandler({ title: 'Success!', body: 'Acknowledgment created.' }))
     .catch(createCatchHandler('Error creating Acknowledgment:'));
 }

--- a/src/stores/DraftFlawStore.ts
+++ b/src/stores/DraftFlawStore.ts
@@ -12,24 +12,24 @@ export const useDraftFlawStore = defineStore('DraftFlawStore', () => {
   }
 
   function addDraftFields(fetchedFlaw: ZodFlawType) {
-    if(draftFlaw.value?.acknowledgments) {
+    if (draftFlaw.value?.acknowledgments) {
       fetchedFlaw.acknowledgments = mergeAcks(fetchedFlaw.acknowledgments, draftFlaw.value.acknowledgments);
     }
-    if(draftFlaw.value?.references) {
+    if (draftFlaw.value?.references) {
       fetchedFlaw.references = mergeRefs(fetchedFlaw.references, draftFlaw.value.references);
     }
-  
+
     return fetchedFlaw;
   }
 
-  const mergeRefs = 
+  const mergeRefs =
     (a: ZodFlawReferenceType[], b: ZodFlawReferenceType[]) => unionWith(refsComparator, a, b);
 
   const refsComparator = (a: ZodFlawReferenceType, b: ZodFlawReferenceType): boolean => {
     return a.url === b.url && a.description === b.description;
   };
 
-  const mergeAcks = 
+  const mergeAcks =
     (a: ZodFlawAcknowledgmentType[], b: ZodFlawAcknowledgmentType[]) => unionWith(ackComparator, a, b);
 
   const ackComparator = (a: ZodFlawAcknowledgmentType, b: ZodFlawAcknowledgmentType): boolean => {
@@ -44,7 +44,7 @@ export const useDraftFlawStore = defineStore('DraftFlawStore', () => {
     $reset,
     draftFlaw,
     saveDraftFlaw,
-    addDraftFields
+    addDraftFields,
   };
 });
 

--- a/src/stores/DraftFlawStore.ts
+++ b/src/stores/DraftFlawStore.ts
@@ -28,7 +28,7 @@ export const useDraftFlawStore = defineStore('DraftFlawStore', () => {
   const refsComparator = (a: ZodFlawReferenceType, b: ZodFlawReferenceType): boolean => {
     return a.url === b.url && a.description === b.description;
   };
-
+  // If an element exists in both lists, the first element from the first list will be used.
   const mergeAcks =
     (a: ZodFlawAcknowledgmentType[], b: ZodFlawAcknowledgmentType[]) => unionWith(ackComparator, a, b);
 

--- a/src/stores/DraftFlawStore.ts
+++ b/src/stores/DraftFlawStore.ts
@@ -1,0 +1,50 @@
+import { ref } from 'vue';
+import { defineStore } from 'pinia';
+import type { ZodFlawType } from '@/types/zodFlaw';
+import { unionWith } from 'ramda';
+import type { ZodFlawAcknowledgmentType, ZodFlawReferenceType } from '@/types/zodFlaw';
+
+export const useDraftFlawStore = defineStore('DraftFlawStore', () => {
+  const draftFlaw = ref<ZodFlawType | null>(null);
+
+  function saveDraftFlaw(flaw: ZodFlawType) {
+    draftFlaw.value = flaw;
+  }
+
+  function addDraftFields(fetchedFlaw: ZodFlawType) {
+    if(draftFlaw.value?.acknowledgments) {
+      fetchedFlaw.acknowledgments = mergeAcks(fetchedFlaw.acknowledgments, draftFlaw.value.acknowledgments);
+    }
+    if(draftFlaw.value?.references) {
+      fetchedFlaw.references = mergeRefs(fetchedFlaw.references, draftFlaw.value.references);
+    }
+  
+    return fetchedFlaw;
+  }
+
+  const mergeRefs = 
+    (a: ZodFlawReferenceType[], b: ZodFlawReferenceType[]) => unionWith(refsComparator, a, b);
+
+  const refsComparator = (a: ZodFlawReferenceType, b: ZodFlawReferenceType): boolean => {
+    return a.url === b.url && a.description === b.description;
+  };
+
+  const mergeAcks = 
+    (a: ZodFlawAcknowledgmentType[], b: ZodFlawAcknowledgmentType[]) => unionWith(ackComparator, a, b);
+
+  const ackComparator = (a: ZodFlawAcknowledgmentType, b: ZodFlawAcknowledgmentType): boolean => {
+    return a.name === b.name && a.affiliation === b.affiliation;
+  };
+
+  function $reset() {
+    draftFlaw.value = null;
+  }
+
+  return {
+    $reset,
+    draftFlaw,
+    saveDraftFlaw,
+    addDraftFields
+  };
+});
+


### PR DESCRIPTION
# OSIDB-2319: Ensure that references / acknowledgements are sent with flaw creation

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated (_NA_)
- [x] Jira ticket updated

## Summary:

Add support for references and acknowledgements on flaw creation, fix minor bugs, add draft flaw state.

## Changes:

- Hide save refs/acks button on flaw creation form
- Handle saving refs/acks on flaw creation if present
- Create a store to handle draft flaw data when it is not saved correctly (mainly for concatenated service operations)
- Use the draftFlaw store to keep non saved attributions on the form (as draft)
- Fix some stuck states scenarios on saving flaw/attributions unsuccessfully
- Fix wrong updated_dt initialization on blank attributions
- Fix a bug where updated_dt is fetched for attributions creation

## Considerations:

- References and ackowledgements are saved on flaw creation within the full form submit button
- Flaw is created first, uuid is taken from response and used in the refs/acks to save 
- DraftFlaw store aims to cover the issue where user's draft data on the form is lost. This scenario appears cause of the implementation of sequenced service operations, such as saving/creating multiple affects or attributions.
For the scope in this PR, when creating a flaw with multiple attributions, if one of them fails, the non saved ones will be still on form of the new EditFlaw view.