### PR TITLE
🐛 Recover from save errors during flaw creation, show saving animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Save affects all at once (`OSIDB-2206`)
 * Show only allowed sources for Flaw Edit (`OSIDB-2395`)
 * Fixed deleted affects message after flaw save (`OSIDB-2693`)
+* Recover from save errors during flaw creation, show saving animation (`OSIDB-2765`)
 
 ## [Unreleased] (TODO update for 2024.1.1 and 2024.2.0 releases)
 

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -465,8 +465,15 @@ const toggleMitigation = () => {
           Save Changes
         </button>
       </div>
-      <div v-else>
-        <button type="submit" class="btn btn-primary col">Create New Flaw</button>
+      <div v-if="mode === 'create'">
+        <button
+          v-osim-loading.grow="isSaving"
+          type="submit"
+          class="btn btn-primary ms-3"
+          :disabled="isSaving"
+        >
+          Create New Flaw
+        </button>
       </div>
     </div>
   </form>

--- a/src/composables/service-helpers.ts
+++ b/src/composables/service-helpers.ts
@@ -2,7 +2,7 @@ import { getDisplayedOsidbError } from '@/services/OsidbAuthService';
 import { useToastStore } from '@/stores/ToastStore';
 
 
-export function createCatchHandler(title: string = 'Error', callback?: () => void, shouldThrow: boolean = true) {
+export function createCatchHandler(title: string = 'Error', shouldThrow: boolean = true) {
   return (error: any) => {
     const displayedError = getDisplayedOsidbError(error);
     const { addToast } = useToastStore();
@@ -12,10 +12,6 @@ export function createCatchHandler(title: string = 'Error', callback?: () => voi
       css: 'warning',
     });
     console.error('❌ ', error);
-
-    if (callback) {
-      callback();
-    }
 
     if (shouldThrow) {
       throw error;


### PR DESCRIPTION
# [OSIDB-ID] [Title]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [-] no tests added 
- [x] Jira ticket updated

## Summary:

Flaw creation did not recover from errors while saving. It does now.

## Changes:

- Added saving animation
- Recover from save failures

## Considerations:

The user's finite patience.