### PR TITLE
Fix: Unable to save new cvss scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@
 * Show only allowed sources for Flaw Edit (`OSIDB-2395`)
 * Fixed deleted affects message after flaw save (`OSIDB-2693`)
 * Recover from save errors during flaw creation, show saving animation (`OSIDB-2765`)
-* * Prevent saving of unmodified affects
-(`OSIDB-2754`)
+* Prevent saving of unmodified affects (`OSIDB-2754`)
+* Unable to save first cvss score on flaws (`OSIDB-2769`)
+* Unable to save new references and ackowledgments on flaws (`OSIDB-2206`)
 
 ## [Unreleased] (TODO update for 2024.1.1 and 2024.2.0 releases)
 

--- a/features/advance_search.feature
+++ b/features/advance_search.feature
@@ -26,7 +26,6 @@ Feature: Flaw advance search testing
         |                                   source |                                     CUSTOMER |
         |                                  team_id |                                       teamid |
         |                                    title |                                 sample title |
-        |                                     type |                                VULNERABILITY |
         |                                     uuid |         3025ba93-b962-4553-b785-c9da27c9dec7 |
         |                           workflow_state |                                          NEW |
         |                                embargoed |                                         true |

--- a/src/components/AffectedOfferingForm.vue
+++ b/src/components/AffectedOfferingForm.vue
@@ -9,7 +9,6 @@ import {
   affectAffectedness,
   affectImpacts,
   affectResolutions,
-  affectTypes,
   type ZodAffectCVSSType,
   type ZodAffectType,
 } from '@/types/zodAffect';
@@ -76,14 +75,6 @@ const hiddenResolutionOptions = computed(() => {
         :error="error?.ps_component"
         type="text"
         label="Affected Component"
-      />
-      <!--Hiding the Type field until we have more options to choose from-->
-      <LabelSelect
-        v-model="modelValue.type"
-        :error="error?.type"
-        class="col-6 visually-hidden"
-        label="Type"
-        :options="affectTypes"
       />
       <LabelSelect
         v-model="modelValue.affectedness"

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -40,7 +40,6 @@ function onSaveSuccess() {
 const {
   flaw,
   trackerUuids,
-  flawTypes, // Visually hidden field
   flawSources,
   flawImpacts,
   flawIncidentStates,
@@ -191,13 +190,6 @@ const toggleMitigation = () => {
             label="Component"
             type="text"
             :error="errors.component"
-          />
-          <LabelSelect
-            v-model="flaw.type"
-            label="Type"
-            :options="flawTypes"
-            :error="errors.type"
-            class="visually-hidden"
           />
           <div class="row">
             <div class="col">

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { flawImpacts, flawTypes, flawSources } from '@/types/zodFlaw';
+import { flawImpacts, flawSources } from '@/types/zodFlaw';
 import { useRoute } from 'vue-router';
 import { flawFields } from '@/constants/flawFields';
 import { useSearchParams } from '@/composables/useSearchParams';
@@ -48,7 +48,6 @@ const unchosenFields = (chosenField: string) =>
 
 const optionsFor = (field: string) =>
   ({
-    type: flawTypes,
     source: flawSources,
     impact: flawImpacts,
     requires_summary: summaryRequiredStates,

--- a/src/components/__tests__/AffectExpandableForm.spec.ts
+++ b/src/components/__tests__/AffectExpandableForm.spec.ts
@@ -153,9 +153,9 @@ describe('AffectExpandableForm', () => {
     const formComponent = subject.findAllComponents(AffectedOfferingForm);
     expect(formComponent.length).toBe(1);
     const selectComponents = formComponent[0].findAllComponents(LabelSelect);
-    expect(selectComponents.length).toBe(4);
-    const affectednessSelectEl = selectComponents[1];
-    const resolutionSelectEL = selectComponents[2];
+    expect(selectComponents.length).toBe(3);
+    const affectednessSelectEl = selectComponents[0];
+    const resolutionSelectEL = selectComponents[1];
     const affectednessOptions = affectednessSelectEl.props('options');
     expect(affectednessOptions).toStrictEqual(affectAffectedness);
     const resolutionOptions = resolutionSelectEL.props('options');

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -667,7 +667,6 @@ function sampleFlaw(): ZodFlawType {
       {
         uuid: 'bff95399-ef12-43fe-878d-4629297c2aa8',
         flaw: '3ede0314-a6c5-4462-bcf3-b034a15cf106',
-        type: 'DEFAULT',
         affectedness: 'AFFECTED',
         resolution: 'FIX',
         ps_module: 'openshift-4',

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -638,7 +638,6 @@ function mockedPutFlaw(uuid: string, flawObject: Record<any, any>) {
 function sampleFlaw(): ZodFlawType {
   return {
     uuid: '3ede0314-a6c5-4462-bcf3-b034a15cf106',
-    type: 'VULNERABILITY',
     cve_id: 'CVE-2007-97239',
     // resolution: '',
     impact: 'LOW',

--- a/src/composables/useFlawAffectsModel.ts
+++ b/src/composables/useFlawAffectsModel.ts
@@ -160,7 +160,6 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
       const requestBody = affectsToUpdate.value.map((affect) => ({
         flaw: flaw.value?.uuid,
         uuid: affect.uuid,
-        type: affect.type,
         affectedness: affect.affectedness,
         resolution: affect.resolution,
         ps_module: affect.ps_module,
@@ -177,7 +176,6 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
       const affect = affectsToCreate.value[index];
       const requestBody = {
         flaw: flaw.value?.uuid,
-        type: affect.type,
         affectedness: affect.affectedness,
         resolution: affect.resolution,
         delegated_resolution: affect.delegated_resolution,

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -14,13 +14,13 @@ import {
 } from '@/services/FlawService';
 
 import { useToastStore } from '@/stores/ToastStore';
-import { flawTypes, flawSources, flawImpacts, flawIncidentStates } from '@/types/zodFlaw';
+import { flawSources, flawImpacts, flawIncidentStates } from '@/types/zodFlaw';
 import { modifyPath } from 'ramda';
 import { deepMap } from '@/utils/helpers';
 import type { ZodIssue } from 'zod';
 import { useNetworkQueue } from './useNetworkQueue';
 
-export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: () => void){
+export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: () => void) {
   const isSaving = ref(false);
   const { addToast } = useToastStore();
   const flaw = ref<ZodFlawType>(forFlaw);
@@ -84,7 +84,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     }
   }
 
-  function validate(){
+  function validate() {
     const validatedFlaw = ZodFlawSchema.safeParse(flaw.value);
     if (!validatedFlaw.success) {
 
@@ -164,7 +164,6 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     errors,
     committedFlaw,
     trackerUuids,
-    flawTypes,
     flawSources,
     flawImpacts,
     flawIncidentStates,
@@ -203,7 +202,6 @@ export function blankFlaw(): ZodFlawType {
     nvd_cvss3: '',
     source: '',
     title: '',
-    type: 'VULNERABILITY', // OSIDB only supports Vulnerabilities at present
     owner: '',
     team_id: '',
     summary: '',

--- a/src/services/AffectService.ts
+++ b/src/services/AffectService.ts
@@ -87,7 +87,7 @@ export async function postAffectCvssScore(affectId: string, cvssScoreObject: unk
     method: 'post',
     url: `/osidb/api/v1/affects/${affectId}/cvss_scores`,
     data: postObject,
-  }, { beforeFetch })
+  })
     .then((response) => response.data)
     .catch(createCatchHandler('Problem updating affect CVSS scores:'));
 }

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -230,7 +230,6 @@ export async function advancedSearchFlaws(params: Record<string, string>) {
 
 export async function postFlaw(requestBody: any) {
   // {
-  //   "type": "VULNERABILITY",
   //   "cve_id": "string",
   //   "impact": "LOW",
   //   "component": "string",

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -10,7 +10,7 @@ import {
 import { createCatchHandler, createSuccessHandler } from '@/composables/service-helpers';
 
 export async function beforeFetch(options: OsidbFetchOptions) {
-  if (options.data && ['PUT', 'POST'].includes(options.method.toUpperCase())) {
+  if (options.data && ['PUT'].includes(options.method.toUpperCase())) {
     try {
       const updated_dt = await getUpdatedDt(options.url);
       options.data.updated_dt = updated_dt;

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -128,7 +128,7 @@ export async function postFlawCvssScores(flawId: string, cvssScoreObject: unknow
     method: 'post',
     url: `/osidb/api/v1/flaws/${flawId}/cvss_scores`,
     data: postObject,
-  }, { beforeFetch })
+  })
     .then(createSuccessHandler({ title: 'Success!', body: 'Saved CVSS Scores' }))
     .then((response) => response.data)
     .catch(createCatchHandler('CVSS scores Update Error'));
@@ -287,7 +287,7 @@ export function postFlawReference(flawId: string, requestBody: FlawReferencePost
     method: 'post',
     url: `/osidb/api/v1/flaws/${flawId}/references`,
     data: requestBody,
-  }, { beforeFetch })
+  })
     .then(createSuccessHandler({ title: 'Success!', body: 'Reference created.' }))
     .catch(createCatchHandler('Error creating Reference:'));
 }
@@ -335,7 +335,7 @@ export async function postFlawAcknowledgment(flawId: string, requestBody: FlawAc
     method: 'post',
     url: `/osidb/api/v1/flaws/${flawId}/acknowledgments`,
     data: requestBody,
-  }, { beforeFetch })
+  })
     .then(createSuccessHandler({ title: 'Success!', body: 'Acknowledgment created.' }))
     .catch(createCatchHandler('Error creating Acknowledgment:'));
 }

--- a/src/types/zodAffect.ts
+++ b/src/types/zodAffect.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import {
-  AffectType,
   AffectednessEnum,
   ResolutionEnum,
   IssuerEnum,
@@ -68,7 +67,6 @@ export type ZodAffectType = z.infer<typeof ZodAffectSchema>;
 const affectBlueprint = {
   uuid: z.string().uuid().nullish(),
   flaw: z.string().nullish(),
-  type: z.nativeEnum(AffectType).nullish(),
   affectedness: z.nativeEnum(AffectednessEnumWithBlank).nullish(),
   resolution: z.nativeEnum(ResolutionEnumWithBlank).nullish(),
   ps_module: z.string().max(100),
@@ -104,10 +102,8 @@ const {
   impact: zodAffectImpact,
   resolution: zodAffectResolution,
   affectedness: zodAffectAffectedness,
-  type: zodAffectType,
 } = ZodAffectSchema.shape;
 
 export const affectImpacts = extractEnum(zodAffectImpact);
 export const affectResolutions = extractEnum(zodAffectResolution);
 export const affectAffectedness = extractEnum(zodAffectAffectedness);
-export const affectTypes = extractEnum(zodAffectType);

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import {
-  FlawType,
   MajorIncidentStateEnum,
   NistCvssValidationEnum,
   RequiresSummaryEnum,
@@ -14,13 +13,11 @@ import { cveRegex } from '@/utils/helpers';
 import { zodOsimDateTime, ImpactEnumWithBlank, ZodFlawClassification } from './zodShared';
 import { ZodAffectSchema, type ZodAffectType } from './zodAffect';
 
-export const FlawTypeWithBlank = { '': '', ...FlawType } as const;
 export const RequiresSummaryEnumWithBlank = { '': '', ...RequiresSummaryEnum } as const;
 export const Source642EnumWithBlank = { '': '', ...Source642Enum } as const;
 export const MajorIncidentStateEnumWithBlank = { '': '', ...MajorIncidentStateEnum } as const;
 export const NistCvssValidationEnumWithBlank = { '': '', ...NistCvssValidationEnum } as const;
 
-export const flawTypes = Object.values(FlawTypeWithBlank);
 export const flawSources = Object.values(Source642EnumWithBlank);
 export const flawImpacts = Object.values(ImpactEnumWithBlank);
 export const flawIncidentStates = Object.values(MajorIncidentStateEnumWithBlank);
@@ -140,13 +137,10 @@ export const ZodFlawMetaSchema = z.object({
   updated_dt: zodOsimDateTime().nullish(), // $date-time,
 });
 
-// const flawTypes: string[] = Object.values(FlawType);
 export type ZodFlawType = z.infer<typeof ZodFlawSchema>;
 export type FlawSchemaType = typeof ZodFlawSchema;
 
 export const ZodFlawSchema = z.object({
-  // type: z.nativeEnum(FlawType).optional(),
-  type: z.nativeEnum(FlawTypeWithBlank).nullish(),
   uuid: z.string().default(''),
   cve_id: z.string().nullable().refine(
     (cve) => !cve || cveRegex.test(cve),


### PR DESCRIPTION
# Fix: Don't fetch updated_dt on object creation

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated (_NA_)
- [x] Jira ticket updated (_NA_)

## Summary:

Fixes a bug where cvss scores couldn't be saved when editing existent flaws.
This was causes by attempting to 

## Changes:

- Removes `beforeFetch` action on `postFlawCvssScores` as if there is no cvss scores (first cvss score creation) fetch would fail.
- [Edit] Removes `beforeFetch` action on `postFlawAcknowledgment` and `postFlawReference`
- [Edit] Removes `beforeFetch` action on `postAffectCvssScore`

## Considerations:

- `beforeFetch` gets the `updated_dt` from the object to be updated, so it shouldn't be used when the object is being created for first time (e.g. Flaw Creations) cause there won't be any `updated_dt` to get from OSIDB side and action would fail.