### PR TITLE
OSIDB-2780: Remove affect type

### DIFF
--- a/src/components/AffectedOfferingForm.vue
+++ b/src/components/AffectedOfferingForm.vue
@@ -9,7 +9,6 @@ import {
   affectAffectedness,
   affectImpacts,
   affectResolutions,
-  affectTypes,
   type ZodAffectCVSSType,
   type ZodAffectType,
 } from '@/types/zodAffect';
@@ -76,14 +75,6 @@ const hiddenResolutionOptions = computed(() => {
         :error="error?.ps_component"
         type="text"
         label="Affected Component"
-      />
-      <!--Hiding the Type field until we have more options to choose from-->
-      <LabelSelect
-        v-model="modelValue.type"
-        :error="error?.type"
-        class="col-6 visually-hidden"
-        label="Type"
-        :options="affectTypes"
       />
       <LabelSelect
         v-model="modelValue.affectedness"

--- a/src/components/__tests__/AffectExpandableForm.spec.ts
+++ b/src/components/__tests__/AffectExpandableForm.spec.ts
@@ -153,9 +153,9 @@ describe('AffectExpandableForm', () => {
     const formComponent = subject.findAllComponents(AffectedOfferingForm);
     expect(formComponent.length).toBe(1);
     const selectComponents = formComponent[0].findAllComponents(LabelSelect);
-    expect(selectComponents.length).toBe(4);
-    const affectednessSelectEl = selectComponents[1];
-    const resolutionSelectEL = selectComponents[2];
+    expect(selectComponents.length).toBe(3);
+    const affectednessSelectEl = selectComponents[0];
+    const resolutionSelectEL = selectComponents[1];
     const affectednessOptions = affectednessSelectEl.props('options');
     expect(affectednessOptions).toStrictEqual(affectAffectedness);
     const resolutionOptions = resolutionSelectEL.props('options');

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -643,7 +643,6 @@ function sampleFlaw(): ZodFlawType {
       {
         uuid: 'bff95399-ef12-43fe-878d-4629297c2aa8',
         flaw: '3ede0314-a6c5-4462-bcf3-b034a15cf106',
-        type: 'DEFAULT',
         affectedness: 'AFFECTED',
         resolution: 'FIX',
         ps_module: 'openshift-4',

--- a/src/composables/useFlawAffectsModel.ts
+++ b/src/composables/useFlawAffectsModel.ts
@@ -149,7 +149,6 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
       const requestBody = affectsToUpdate.value.map((affect) => ({
         flaw: flaw.value?.uuid,
         uuid: affect.uuid,
-        type: affect.type,
         affectedness: affect.affectedness,
         resolution: affect.resolution,
         ps_module: affect.ps_module,
@@ -166,7 +165,6 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
       const affect = affectsToCreate.value[index];
       const requestBody = {
         flaw: flaw.value?.uuid,
-        type: affect.type,
         affectedness: affect.affectedness,
         resolution: affect.resolution,
         delegated_resolution: affect.delegated_resolution,

--- a/src/types/zodAffect.ts
+++ b/src/types/zodAffect.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import {
-  AffectType,
   AffectednessEnum,
   ResolutionEnum,
   IssuerEnum,
@@ -68,7 +67,6 @@ export type ZodAffectType = z.infer<typeof ZodAffectSchema>;
 const affectBlueprint = {
   uuid: z.string().uuid().nullish(),
   flaw: z.string().nullish(),
-  type: z.nativeEnum(AffectType).nullish(),
   affectedness: z.nativeEnum(AffectednessEnumWithBlank).nullish(),
   resolution: z.nativeEnum(ResolutionEnumWithBlank).nullish(),
   ps_module: z.string().max(100),
@@ -104,10 +102,8 @@ const {
   impact: zodAffectImpact,
   resolution: zodAffectResolution,
   affectedness: zodAffectAffectedness,
-  type: zodAffectType,
 } = ZodAffectSchema.shape;
 
 export const affectImpacts = extractEnum(zodAffectImpact);
 export const affectResolutions = extractEnum(zodAffectResolution);
 export const affectAffectedness = extractEnum(zodAffectAffectedness);
-export const affectTypes = extractEnum(zodAffectType);


### PR DESCRIPTION
# OSIDB-2780 Remove Affect.type usage

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [ ] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Remove `type` field from `Affect` type

## Changes:

`Affect.type` only has one possible value `DEFAULT` and for that was removed from OSIDB in OSIDB-2743

## Considerations:

Openapi client should be re-generated once OSIDB 4.0 is released