### PR TITLE
🐛 Don't save unmodified affects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 * Show only allowed sources for Flaw Edit (`OSIDB-2395`)
 * Fixed deleted affects message after flaw save (`OSIDB-2693`)
 * Recover from save errors during flaw creation, show saving animation (`OSIDB-2765`)
+* * Prevent saving of unmodified affects
+(`OSIDB-2754`)
 
 ## [Unreleased] (TODO update for 2024.1.1 and 2024.2.0 releases)
 

--- a/src/components/AffectedOfferings.vue
+++ b/src/components/AffectedOfferings.vue
@@ -33,10 +33,6 @@ const expandedAffects = ref(new Map());
 
 updateAffectsExpandedState(theAffects.value);
 
-watch(expandedAffects, (nextValue) => {
-  console.log('ofVisibleComponentsIs', nextValue);
-}, { deep: true });
-
 watch(theAffects, (nextValue) => {
   expandedModules.value = affectedModules.value.reduce((modules: Record<string, boolean>, moduleName: string) => {
     modules[moduleName] = areAnyComponentsExpandedIn(moduleName) ?? false;

--- a/src/composables/useFlawAffectsModel.ts
+++ b/src/composables/useFlawAffectsModel.ts
@@ -12,6 +12,7 @@ import { useToastStore } from '@/stores/ToastStore';
 import type { ZodFlawType } from '@/types/zodFlaw';
 import type { ZodAffectType, ZodAffectCVSSType } from '@/types/zodAffect';
 import { deepCopyFromRaw } from '@/utils/helpers';
+import { equals } from 'ramda';
 
 export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
   const wereAffectsModified = ref(false);
@@ -128,9 +129,14 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
     theAffects.value.push(recoveredAffect);
   }
 
+  function hasAffectChanged(affect: ZodAffectType) {
+    const originalAffect = initialAffects.find((maybeMatch) => maybeMatch.uuid === affect.uuid);
+    return !equals(originalAffect, affect);
+  }
+
   theAffects.value.forEach((affect) => {
     watch(affect, () => {
-      if (affect.uuid) {
+      if (affect.uuid && hasAffectChanged(affect)) {
         reportAffectAsModified(affect.uuid);
       }
     }, { deep: true });


### PR DESCRIPTION
* Add deep equality check to prevent unintentionally tracking affects as modified.

# [OSIDB-2754] [OSIM: Unmodified affects are saved]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Jira ticket updated

## Summary:

Affects were being tracked as modified when they weren't, this fixes that issue.

## Changes:

Added a deep equality check to properly check for modified affects.

## Considerations:

Affects began triggering the watcher when loaded, which marked them as modified erroneously as soon as they loaded.