### PR TITLE
OSIDB-2773: Remove flaw type

### DIFF
--- a/features/advance_search.feature
+++ b/features/advance_search.feature
@@ -26,7 +26,6 @@ Feature: Flaw advance search testing
         |                                   source |                                     CUSTOMER |
         |                                  team_id |                                       teamid |
         |                                    title |                                 sample title |
-        |                                     type |                                VULNERABILITY |
         |                                     uuid |         3025ba93-b962-4553-b785-c9da27c9dec7 |
         |                           workflow_state |                                          NEW |
         |                                embargoed |                                         true |

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -40,7 +40,6 @@ function onSaveSuccess() {
 const {
   flaw,
   trackerUuids,
-  flawTypes, // Visually hidden field
   flawSources,
   flawImpacts,
   flawIncidentStates,
@@ -151,13 +150,6 @@ const toggleMitigation = () => {
             label="Component"
             type="text"
             :error="errors.component"
-          />
-          <LabelSelect
-            v-model="flaw.type"
-            label="Type"
-            :options="flawTypes"
-            :error="errors.type"
-            class="visually-hidden"
           />
           <div class="row">
             <div class="col">

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { flawImpacts, flawTypes, flawSources } from '@/types/zodFlaw';
+import { flawImpacts, flawSources } from '@/types/zodFlaw';
 import { useRoute } from 'vue-router';
 import { flawFields } from '@/constants/flawFields';
 import { useSearchParams } from '@/composables/useSearchParams';
@@ -46,7 +46,6 @@ const unchosenFields = (chosenField: string) =>
 
 const optionsFor = (field: string) =>
   ({
-    type: flawTypes,
     source: flawSources,
     impact: flawImpacts,
     embargoed: ['true', 'false'],

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -614,7 +614,6 @@ function mockedPutFlaw(uuid: string, flawObject: Record<any, any>) {
 function sampleFlaw(): ZodFlawType {
   return {
     uuid: '3ede0314-a6c5-4462-bcf3-b034a15cf106',
-    type: 'VULNERABILITY',
     cve_id: 'CVE-2007-97239',
     // resolution: '',
     impact: 'LOW',

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -14,13 +14,13 @@ import {
 } from '@/services/FlawService';
 
 import { useToastStore } from '@/stores/ToastStore';
-import { flawTypes, flawSources, flawImpacts, flawIncidentStates } from '@/types/zodFlaw';
+import { flawSources, flawImpacts, flawIncidentStates } from '@/types/zodFlaw';
 import { modifyPath } from 'ramda';
 import { deepMap } from '@/utils/helpers';
 import type { ZodIssue } from 'zod';
 import { useNetworkQueue } from './useNetworkQueue';
 
-export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: () => void){
+export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: () => void) {
   const isSaving = ref(false);
   const { addToast } = useToastStore();
   const flaw = ref<ZodFlawType>(forFlaw);
@@ -77,7 +77,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     isSaving.value = false;
   }
 
-  function validate(){
+  function validate() {
     const validatedFlaw = ZodFlawSchema.safeParse(flaw.value);
     if (!validatedFlaw.success) {
 
@@ -156,7 +156,6 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     errors,
     committedFlaw,
     trackerUuids,
-    flawTypes,
     flawSources,
     flawImpacts,
     flawIncidentStates,
@@ -195,7 +194,6 @@ export function blankFlaw(): ZodFlawType {
     nvd_cvss3: '',
     source: '',
     title: '',
-    type: 'VULNERABILITY', // OSIDB only supports Vulnerabilities at present
     owner: '',
     team_id: '',
     summary: '',

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -230,7 +230,6 @@ export async function advancedSearchFlaws(params: Record<string, string>) {
 
 export async function postFlaw(requestBody: any) {
   // {
-  //   "type": "VULNERABILITY",
   //   "cve_id": "string",
   //   "impact": "LOW",
   //   "component": "string",

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import {
-  FlawType,
   MajorIncidentStateEnum,
   NistCvssValidationEnum,
   RequiresSummaryEnum,
@@ -14,13 +13,11 @@ import { cveRegex } from '@/utils/helpers';
 import { zodOsimDateTime, ImpactEnumWithBlank, ZodFlawClassification } from './zodShared';
 import { ZodAffectSchema, type ZodAffectType } from './zodAffect';
 
-export const FlawTypeWithBlank = { '': '', ...FlawType } as const;
 export const RequiresSummaryEnumWithBlank = { '': '', ...RequiresSummaryEnum } as const;
 export const Source642EnumWithBlank = { '': '', ...Source642Enum } as const;
 export const MajorIncidentStateEnumWithBlank = { '': '', ...MajorIncidentStateEnum } as const;
 export const NistCvssValidationEnumWithBlank = { '': '', ...NistCvssValidationEnum } as const;
 
-export const flawTypes = Object.values(FlawTypeWithBlank);
 export const flawSources = Object.values(Source642EnumWithBlank);
 export const flawImpacts = Object.values(ImpactEnumWithBlank);
 export const flawIncidentStates = Object.values(MajorIncidentStateEnumWithBlank);
@@ -140,13 +137,10 @@ export const ZodFlawMetaSchema = z.object({
   updated_dt: zodOsimDateTime().nullish(), // $date-time,
 });
 
-// const flawTypes: string[] = Object.values(FlawType);
 export type ZodFlawType = z.infer<typeof ZodFlawSchema>;
 export type FlawSchemaType = typeof ZodFlawSchema;
 
 export const ZodFlawSchema = z.object({
-  // type: z.nativeEnum(FlawType).optional(),
-  type: z.nativeEnum(FlawTypeWithBlank).nullish(),
   uuid: z.string().default(''),
   cve_id: z.string().nullable().refine(
     (cve) => !cve || cveRegex.test(cve),


### PR DESCRIPTION
# [OSIDB-2773] OSIM: Remove Flaw.type usage

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [ ] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Remove `type` field from `Flaw` type

## Changes:

`Flaw.type` only had one used value `VULNERABILITY` and for that was removed from OSIDB in OSIDB-2735

## Considerations:

Openapi client should be re-generated once OSIDB 4.0 is released