### PR TITLE
OSIDB-2774: Remove flaw state field

### DIFF
--- a/features/flaw_filter.feature
+++ b/features/flaw_filter.feature
@@ -12,10 +12,6 @@ Feature: Flaw filter testing
       When I input a filter keyword "cve_id" in the "Filter Issues/Flaws" input box
       Then I am able to view flaws matching "cve_id" and the flaws "count" is correct
 
-    Scenario: Filter the flaws with state keyword
-      When I input a filter keyword "state" in the "Filter Issues/Flaws" input box
-      Then I am able to view flaws matching "state" and the flaws "count" is correct
-
     Scenario: Filter the flaws with source keyword
       When I input a filter keyword "source" in the "Filter Issues/Flaws" input box
       Then I am able to view flaws matching "source" and the flaws "count" is correct

--- a/features/steps/flaw_filter.py
+++ b/features/steps/flaw_filter.py
@@ -15,12 +15,10 @@ from features.utils import (
 
 FLAW_TITLE_TEXT_XPATH = "//tr[1]/td[6]"
 FLAW_CVE_ID_TEXT_XPATH = "//tr[1]/td[2]/a"
-FLAW_STATE_TEXT_XPATH = '//tr[1]/td[7]'
 FLAW_SOURCE_TEXT_XPATH = '//tr[1]/td[4]'
 
 # The following constants are related to flaw filter that should be updated
 # according to the imported test database in the future
-COUNT_FLAWS_SAME_STATE = 20
 COUNT_FLAWS_SAME_SOURCE = 10
 
 
@@ -35,8 +33,6 @@ def catch_one_existing_flaw_text_and_locator(context, text_type):
         context.element_locator = FLAW_TITLE_TEXT_XPATH
     elif text_type == "cve_id":
         context.element_locator = FLAW_CVE_ID_TEXT_XPATH
-    elif text_type == "state":
-        context.element_locator = FLAW_STATE_TEXT_XPATH
     elif text_type == "source":
         context.element_locator = FLAW_SOURCE_TEXT_XPATH
     else:
@@ -89,15 +85,6 @@ def step_impl(context):
 @then('I am able to view flaws matching "cve_id" and the flaws "count" is correct')
 def step_impl(context):
     then_step_mathcher(context, 1)
-
-@when('I input a filter keyword "state" in the "Filter Issues/Flaws" input box')
-def step_impl(context):
-    when_step_mathcher(context, "state")
-
-@then('I am able to view flaws matching "state" and the flaws "count" is correct')
-def step_impl(context):
-    flaws_count = COUNT_FLAWS_SAME_STATE
-    then_step_mathcher(context, flaws_count)
 
 @when('I input a filter keyword "source" in the "Filter Issues/Flaws" input box')
 def step_impl(context):

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -34,7 +34,6 @@ const FLAW_LIST_FIELDS = [
   'classification',
   // 'is_major_incident', TODO: replace with major_incident_state?
   'title',
-  'state', // not to be confused with classification.state
   'unembargo_dt',
   'embargoed',
   'owner',


### PR DESCRIPTION
# [OSIDB-2774] OSIM: Remove Flaw.state usage

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [ ] Commits consolidated
- [ ] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

`Flaw.state` (not to confuse with `Flaw.classification.state`) is deprecated and OSIDB is going to remove it as per https://github.com/RedHatProductSecurity/osidb/pull/543. OSIM should make sure to not to use it.

## Changes:

Removed `Flaw.state` usage from the special keyword search as well as not asking for the field in `include_fields` param of `FlawService` since this field is not longer provided by OSIDB

## Considerations:

OpenApi client should be generated once OSIDB 4.0 is  released