### PR TITLE
Task: Remap comments based on OSIDB changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Unable to save first cvss score on flaws (`OSIDB-2769`)
 * Unable to save new references and ackowledgments on flaws (`OSIDB-2206`)
 * Reset affects when flaw is reset (`OSIDB-2793`)
+* New public comments are not displayed (`OSIDB-2700`)
 
 ### Removed
 * Removed is_major_incident usage (`OSIDB-2778`)

--- a/src/components/CveRequestForm.vue
+++ b/src/components/CveRequestForm.vue
@@ -64,7 +64,7 @@ function addPublicCveRequestComment() {
     // new Promise((resolve, reject) => {
     //   setTimeout(resolve, 5000);
     // })
-    postFlawPublicComment(flawUuidMatch[1], 'New CVE Requested', props.embargoed)
+    postFlawPublicComment(flawUuidMatch[1], 'New CVE Requested', userStore.userName, props.embargoed)
       .then(() => {
         commentSaved.value = true;
         savingComment.value = false;

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -26,20 +26,6 @@ function handleClick() {
   isAddingNewComment.value = false;
 }
 
-function parseGroups(serializedJson: string) {
-  try {
-    return JSON.parse(serializedJson.replace(/'/g, '\\"'));
-  } catch (e) {
-    return [];
-  }
-}
-
-function parseIsPrivate(isPrivate: string) {
-  return isPrivate?.constructor === String
-    ? isPrivate.toLowerCase() === 'true'
-    : Boolean(isPrivate);
-}
-
 type CommentFilter = 'public' | 'private' | 'system';
 type CommentActiveFilters = Record<CommentFilter, boolean>;
 type CommentFilterFunctions = Record<CommentFilter, (comment: any) => boolean>;
@@ -71,7 +57,6 @@ const activeFilters = computed(() => {
       false,
     );
 });
-console.log(props.comments)
 const filteredComments = computed(() => props.comments.filter(activeFilters.value));
 
 

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -4,6 +4,7 @@ import LabelTextarea from '@/components/widgets/LabelTextarea.vue';
 import sanitizeHtml from 'sanitize-html';
 import { osimRuntime } from '@/stores/osimRuntime';
 import { useUserStore } from '@/stores/UserStore';
+import { DateTime } from 'luxon';
 
 const userStore = useUserStore();
 
@@ -113,10 +114,7 @@ function linkify(text: string) {
             >
               System
             </span>
-            {{ comment.creator }} /
-            <a :href="'#' + comment.type + '/' + comment.external_system_id">
-              {{ comment.time }}
-            </a>
+            {{ comment.creator }} - {{ DateTime.fromISO(comment.created_dt).toFormat('yyyy-MM-dd hh:mm a ZZZZ') }}
           </p>
           <p class="osim-flaw-comment" v-html="linkify(comment.text)" />
         </li>

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -3,6 +3,9 @@ import { computed, ref } from 'vue';
 import LabelTextarea from '@/components/widgets/LabelTextarea.vue';
 import sanitizeHtml from 'sanitize-html';
 import { osimRuntime } from '@/stores/osimRuntime';
+import { useUserStore } from '@/stores/UserStore';
+
+const userStore = useUserStore();
 
 const props = defineProps<{
   comments: any[];
@@ -12,14 +15,14 @@ const newPublicComment = ref('');
 const isAddingNewComment = ref(false);
 
 const emit = defineEmits<{
-  'comment:addPublicComment': [value: any];
+  'comment:addPublicComment': [value: any, value: any];
 }>();
 
 const SYSTEM_EMAIL = 'bugzilla@redhat.com';
 
 
 function handleClick() {
-  emit('comment:addPublicComment', newPublicComment.value);
+  emit('comment:addPublicComment', newPublicComment.value, userStore.userName);
   isAddingNewComment.value = false;
 }
 

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -37,17 +37,6 @@ function parseIsPrivate(isPrivate: string) {
     : Boolean(isPrivate);
 }
 
-const transformedComments = computed(() =>
-  props.comments.map((comment) => ({
-    ...comment,
-    meta_attr: {
-      ...comment.meta_attr,
-      is_private: parseIsPrivate(comment.meta_attr?.is_private),
-      private_groups: parseGroups(comment.meta_attr?.private_groups),
-    },
-  })),
-);
-
 type CommentFilter = 'public' | 'private' | 'system';
 type CommentActiveFilters = Record<CommentFilter, boolean>;
 type CommentFilterFunctions = Record<CommentFilter, (comment: any) => boolean>;
@@ -59,9 +48,9 @@ const selectedFilters = ref<CommentActiveFilters>({
 });
 
 const filterFunctions: CommentFilterFunctions = {
-  public: (comment: any) => !comment.meta_attr.is_private,
-  private: (comment: any) => comment.meta_attr.is_private,
-  system: (comment: any) => comment.meta_attr.creator === SYSTEM_EMAIL,
+  public: (comment: any) => !comment.is_private,
+  private: (comment: any) => comment.is_private,
+  system: (comment: any) => comment.creator === SYSTEM_EMAIL,
 };
 
 const activeFilters = computed(() => {
@@ -79,8 +68,8 @@ const activeFilters = computed(() => {
       false,
     );
 });
-
-const filteredComments = computed(() => transformedComments.value.filter(activeFilters.value));
+console.log(props.comments)
+const filteredComments = computed(() => props.comments.filter(activeFilters.value));
 
 
 const filters: CommentFilter[] = ['public', 'private', 'system'];
@@ -127,18 +116,21 @@ function linkify(text: string) {
           class="bg-light p-2 mt-3 rounded-2"
         >
           <p class="border-bottom pb-2">
-            <span v-if="comment.meta_attr.is_private" class="badge bg-warning rounded-pill">
+            <span v-if="comment.is_private" class="badge bg-warning rounded-pill">
               Bugzilla Internal
             </span>
             <span
-              v-if="comment.meta_attr.creator === SYSTEM_EMAIL"
+              v-if="comment.creator === SYSTEM_EMAIL"
               class="badge bg-info rounded-pill"
             >
               System
             </span>
-            {{ comment.meta_attr?.creator }} / {{ comment.meta_attr?.time }}
+            {{ comment.creator }} /
+            <a :href="'#' + comment.type + '/' + comment.external_system_id">
+              {{ comment.time }}
+            </a>
           </p>
-          <p class="osim-flaw-comment" v-html="linkify(comment.meta_attr?.text)" />
+          <p class="osim-flaw-comment" v-html="linkify(comment.text)" />
         </li>
       </ul>
       <div v-if="!isAddingNewComment">

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -157,9 +157,9 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     isSaving.value = false;
   }
 
-  function addPublicComment(comment: string) {
+  function addPublicComment(comment: string, creator: string) {
     isSaving.value = true;
-    postFlawPublicComment(flaw.value.uuid, comment, flaw.value.embargoed)
+    postFlawPublicComment(flaw.value.uuid, comment, creator, flaw.value.embargoed)
       .then(createSuccessHandler({ title: 'Success!', body: 'Comment saved.' }))
       .then(afterSaveSuccess)
       .catch(createCatchHandler('Error saving comment'))

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -132,12 +132,14 @@ export async function postFlawCvssScores(flawId: string, cvssScoreObject: unknow
     .catch(createCatchHandler('CVSS scores Update Error'));
 }
 
-export async function postFlawPublicComment(uuid: string, comment: string, embargoed: boolean) {
+export async function postFlawPublicComment(uuid: string, comment: string, creator: string, embargoed: boolean) {
   return osidbFetch({
     method: 'post',
     url: `/osidb/api/v1/flaws/${uuid}/comments`,
     data: {
       text: comment,
+      creator: creator,
+      type: 'BUGZILLA',
       embargoed,
     },
   }).then((response) => response.data);

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -107,30 +107,14 @@ export const FlawCVSSSchema = z.object({
 export const ZodFlawCommentSchema = z.object({
   uuid: z.string(),
   external_system_id: z.string(),
-  order: z.number(),
-  // meta_attr: z.record(z.string(), z.string().nullish()).nullish(),
-  meta_attr: z.object({
-    id: z.string().nullish(),
-    tags: z.string().nullish(),
-    text: z.string().nullish(),
-    time: z.string().nullish(),
-    count: z.string().nullish(),
-    bug_id: z.string().nullish(),
-    creator: z.string().nullish(),
-    creator_id: z.string().nullish(),
-    is_private: z
-      .string()
-      .transform((booleanString) => booleanString === 'True')
-      .or(z.boolean())
-      .nullish(),
-    attachment_id: z.string().nullish(),
-    creation_time: z.string().nullish(),
-    private_groups: z
-      .string()
-      // .transform((jsonString: string) => JSON.parse(jsonString.replace(/'/g, '"')))
-      .or(z.array(z.string()))
-      .nullish(),
-  }).nullish(),
+  order: z.number(),  
+  text: z.string().nullish(),
+  creator: z.string().nullish(),
+  is_private: z
+    .string()
+    .transform((booleanString) => booleanString === 'True')
+    .or(z.boolean())
+    .nullish(),  
   created_dt: zodOsimDateTime().nullish(),
   updated_dt: zodOsimDateTime().nullish(),
 });

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -107,14 +107,14 @@ export const FlawCVSSSchema = z.object({
 export const ZodFlawCommentSchema = z.object({
   uuid: z.string(),
   external_system_id: z.string(),
-  order: z.number(),  
+  order: z.number(),
   text: z.string().nullish(),
   creator: z.string().nullish(),
   is_private: z
     .string()
     .transform((booleanString) => booleanString === 'True')
     .or(z.boolean())
-    .nullish(),  
+    .nullish(),
   created_dt: zodOsimDateTime().nullish(),
   updated_dt: zodOsimDateTime().nullish(),
 });


### PR DESCRIPTION
# OSIDB-2700: Comments features do not work in UAT because BZ is disconnected

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [-] No test cases added/updated
- [X] Jira ticket updated

## Summary:

OSIDB has changed the comments fields to be independent from BZ, i.e. meta_attr comment fields (`text`, `creator` and `is_private`) are now moved into the comment model.
This PR address the corresponding modifications on OSIM for those API changes.
Additionally both OSIDB and OSIM changes address the bug of comments not being  correctly displayed on instances that are disconnected from BZ (i.e. Local & UAT).

## Changes:

- Update `ZodFlawCommentSchema` for OSIDB API changes
- Update `FlawComments` component to use new model fields
- Add creator as parameter on `postFlawPublicComment`
- Remove deprecated code
- Changed format on comments datetime
- Removes link to source on comments datetime

## Considerations:

- Link to comment source will be added in the incoming redesign PR