### PR TITLE
Remove is_major_incident field usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 * * Prevent saving of unmodified affects
 (`OSIDB-2754`)
 
+###
+* Removed is_major_incident usage (`OSIDB-2778`)
+
 ## [Unreleased] (TODO update for 2024.1.1 and 2024.2.0 releases)
 
 ### Added

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -659,7 +659,6 @@ function sampleFlaw(): ZodFlawType {
     cvss3: '',
     cvss3_score: null,
     nvd_cvss3: '',
-    // is_major_incident: true,
     major_incident_state: 'APPROVED',
     nist_cvss_validation: '',
     affects: [

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -32,7 +32,6 @@ const FLAW_LIST_FIELDS = [
   'created_dt',
   'updated_dt',
   'classification',
-  // 'is_major_incident', TODO: replace with major_incident_state?
   'title',
   'state', // not to be confused with classification.state
   'unembargo_dt',
@@ -248,7 +247,6 @@ export async function postFlaw(requestBody: any) {
   //   "cvss3": "string",
   //   "cvss3_score": 0,
   //   "nvd_cvss3": "string",
-  //   "is_major_incident": true,
   //   "embargoed": true
   // }
   return osidbFetch({

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -23,7 +23,6 @@ export async function getTrackers() {
           'created_dt',
           'updated_dt',
           'classification',
-          'is_major_incident', // XXX deprecated: replace with major_incident_state?
           'title',
           'state',
           'unembargo_dt'
@@ -43,7 +42,6 @@ export async function getTrackers() {
         'created_dt',
         'updated_dt',
         'classification',
-        'is_major_incident', // XXX deprecated: replace with major_incident_state?
         'title',
         'state',
         'unembargo_dt'


### PR DESCRIPTION
# [OSIDB-2778] [Remove is_major_incident field usage]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Apparently OSIM already does use the new `major_incident_state` and thus this whole PR is just about removing the old field.

## Changes:

Any remaining usage of the `is_major_incident` field has been removed

## Considerations:

n/a