### PR TITLE
Feature: Button to expand all affects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Support for references and acknowledgements on flaw creation (`OSIDB-2319`)
 * Sort Advanced Search Options alphabetically (`OSIDB-2805`)
 * Add tracker links on affects and flaw form (`OSIDB-2630`)
+* Add button to expand all affects (`OSIDB-2817`)
 
 ### Fixed
 * The session is now shared across tabs

--- a/src/components/AffectedOfferings.vue
+++ b/src/components/AffectedOfferings.vue
@@ -50,6 +50,10 @@ const isAnythingExpanded = computed(() => (
   || Object.values(expandedModules.value).some(Boolean)
 ));
 
+const areAllModulesCollapsed = computed(() => (
+  !Object.values(expandedModules.value).every(Boolean)
+));
+
 function areAnyComponentsExpandedIn (moduleName: string) {
   return affectsWithModuleName(moduleName).some(isExpanded);
 }
@@ -79,6 +83,12 @@ function collapseAll() {
   }
 }
 
+function expandAll() {
+  for (const moduleName in expandedModules.value) {
+    expandedModules.value[moduleName] = true;
+  }
+}
+
 function togglePsComponentExpansion(affect: ZodAffectType) {
   const isExpanded = expandedAffects.value.get(affect);
   isExpanded.value = !isExpanded.value;
@@ -102,6 +112,14 @@ function moduleComponentName(moduleName: string = '<module not set>', componentN
   <div v-if="theAffects" class="osim-affects">
     <h4 class="mb-4">
       Affected Offerings
+      <button
+        v-if="areAllModulesCollapsed"
+        type="button"
+        class="btn btn-sm btn-secondary me-2"
+        @click="expandAll()"
+      >
+        Expand All
+      </button>
       <button
         v-if="isAnythingExpanded"
         type="button"

--- a/src/components/AffectedOfferings.vue
+++ b/src/components/AffectedOfferings.vue
@@ -50,7 +50,7 @@ const isAnythingExpanded = computed(() => (
   || Object.values(expandedModules.value).some(Boolean)
 ));
 
-const areAllModulesCollapsed = computed(() => (
+const isAnythingCollapsed = computed(() => (
   !Object.values(expandedModules.value).every(Boolean)
 ));
 
@@ -113,7 +113,7 @@ function moduleComponentName(moduleName: string = '<module not set>', componentN
     <h4 class="mb-4">
       Affected Offerings
       <button
-        v-if="areAllModulesCollapsed"
+        v-if="isAnythingCollapsed"
         type="button"
         class="btn btn-sm btn-secondary me-2"
         @click="expandAll()"


### PR DESCRIPTION
# OSIDB-2817: Button to expand all affects
## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [-] No test cases added/updated
- [x] Jira ticket updated

## Summary:

 Adds a new button that conditionally renders to allow the users expand all affect modules

## Changes:

- Adds`areAllModulesCollapsed` computed property on `AffectedOfferings`.
- Adds `expandAll` function on `AffectedOfferings`.
- Adds a `Expand All` new button  on the affects section

## Considerations:

- Was confirmed that only Modules (and not component details) should be expanded
- Credits to @superbuggy as this PR is just a rework from 'CollapseAll' functionality