### PR TITLE
Change description to comment zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 * Advanced search on emptiness for CVE ID (`OSIDB-2806`)
 * Embedded Alerts on top of the Flaw form (`OSIDB-1211`)
 
+### Changed
+* Use comment_zero instead of description from OSIDB (`OSIDB-2784`)
+
 ### Fixed
 * The session is now shared across tabs
 * CVSS scores on affects can be added (`OSIDB-2573`)

--- a/features/quick_search.feature
+++ b/features/quick_search.feature
@@ -9,8 +9,8 @@ Feature: Flaw quick search testing
     
     Scenario: Quick search flaw with text
       Then I search the flaw with text and I am able to view flaws list matching the search
-        |       field |             text |
-        |       title |    title-test-sw |
-        |   comment#0 | description-test |
-        |   statement |   statement-test |
-        | description |     summary-test |
+        |       field |             text  |
+        |       title |    title-test-sw  |
+        |   comment#0 | comment_zero-test |
+        |   statement |   statement-test  |
+        | description |     summary-test  |

--- a/src/components/CvssNISTForm.vue
+++ b/src/components/CvssNISTForm.vue
@@ -8,7 +8,7 @@ import { useModal } from '@/composables/useModal';
 
 const props = defineProps<{
   cveid?: string | null;
-  flawSummary?: string | null;
+  summary?: string | null;
   bugzilla?: string;
   cvss?: string;
   nistcvss?: string;
@@ -35,7 +35,7 @@ Red Hat CVSS: ${props.cvss}
 NIST CVSS: ${props.nistcvss}
 
 Flaw Summary: 
-${props.flawSummary}
+${props.summary}
 
 Red Hat's CVSS Justification:
 ____

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -294,7 +294,7 @@ const expandFocusedComponent = (parent_uuid: string) => {
             <div v-if="shouldDisplayEmailNistForm" class="col-auto align-self-center mb-3">
               <CvssNISTForm
                 :cveid="flaw.cve_id"
-                :flaw-summary="flaw.description"
+                :flawSummary="flaw.comment_zero"
                 :bugzilla="bugzillaLink"
                 :cvss="rhCvss3String"
                 :nistcvss="nvdCvss3String"
@@ -365,10 +365,10 @@ const expandFocusedComponent = (parent_uuid: string) => {
       </div>
       <div class="osim-flaw-form-section border-top">
         <LabelTextarea
-          v-model="flaw.description"
+          v-model="flaw.comment_zero"
           label="Comment#0"
           placeholder="Comment#0 ..."
-          :error="errors.description"
+          :error="errors.comment_zero"
           :disabled="mode === 'edit'"
         />
         <LabelTextarea

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -294,7 +294,7 @@ const expandFocusedComponent = (parent_uuid: string) => {
             <div v-if="shouldDisplayEmailNistForm" class="col-auto align-self-center mb-3">
               <CvssNISTForm
                 :cveid="flaw.cve_id"
-                :flawSummary="flaw.comment_zero"
+                :summary="flaw.comment_zero"
                 :bugzilla="bugzillaLink"
                 :cvss="rhCvss3String"
                 :nistcvss="nvdCvss3String"

--- a/src/components/__tests__/CvssNISTForm.spec.ts
+++ b/src/components/__tests__/CvssNISTForm.spec.ts
@@ -15,7 +15,7 @@ describe('CvssNISTForm', () => {
       props: {
         flaw: 'any',
         cveid: 'string',
-        flawSummary: 'string',
+        summary: 'string',
         bugzilla: 'string',
         nvdpage: 'string',
         cvss: 'string',
@@ -42,7 +42,7 @@ describe('CvssNISTForm', () => {
       props: {
         flaw: 'any',
         cveid: 'string',
-        flawSummary: 'string',
+        summary: 'string',
         bugzilla: 'string',
         nvdpage: 'string',
         cvss: 'string',
@@ -69,7 +69,7 @@ describe('CvssNISTForm', () => {
       props: {
         flaw: 'any',
         cveid: 'string',
-        flawSummary: 'string',
+        summary: 'string',
         bugzilla: 'string',
         nvdpage: 'string',
         cvss: 'string',
@@ -106,7 +106,7 @@ describe('CvssNISTForm', () => {
       props: {
         flaw: 'any',
         cveid: 'string',
-        flawSummary: 'string',
+        summary: 'string',
         bugzilla: 'string',
         nvdpage: 'string',
         cvss: 'string',
@@ -141,7 +141,7 @@ describe('CvssNISTForm', () => {
       props: {
         flaw: 'any',
         cveid: 'string',
-        flawSummary: 'string',
+        summary: 'string',
         bugzilla: 'string',
         nvdpage: 'string',
         cvss: 'string',

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -318,7 +318,7 @@ describe('FlawForm', () => {
     expect(vm.errors.component).not.toBe(null);
     expect(vm.errors.impact).not.toBe(null);
     expect(vm.errors.source).not.toBe(null);
-    expect(vm.errors.description).not.toBe(null);
+    expect(vm.errors.comment_zero).not.toBe(null);
 
     const titleField = subject
       .findAllComponents(LabelEditable)

--- a/src/components/__tests__/SampleData.ts
+++ b/src/components/__tests__/SampleData.ts
@@ -9,7 +9,7 @@ export function sampleFlaw(): ZodFlawType {
     component: 'reality.',
     title: 'sample title',
     trackers: [],
-    description: 'comment',
+    comment_zero: 'Comment Zero == Patient Zero',
     summary: 'I am a spooky CVE',
     requires_summary: 'APPROVED',
     statement: 'Statement for None',

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -99,10 +99,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     const validatedFlaw = ZodFlawSchema.safeParse(flaw.value);
     if (!validatedFlaw.success) {
 
-      const temporaryFieldRenaming = (fieldName: string | number) =>
-        fieldName === 'description' ? 'Comment#0' : fieldName;
-
-      const errorMessage = ({ message, path }: ZodIssue) => `${path.map(temporaryFieldRenaming).join('/')}: ${message}`;
+      const errorMessage = ({ message, path }: ZodIssue) => `${path.join('/')}: ${message}`;
 
       addToast({
         title: 'Flaw validation failed before submission',
@@ -203,7 +200,7 @@ export function blankFlaw(): ZodFlawType {
     cve_id: '',
     cvss_scores: [],
     cwe_id: '',
-    description: '',
+    comment_zero: '',
     embargoed: false,
     impact: '',
     major_incident_state: '',

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -233,7 +233,7 @@ export async function postFlaw(requestBody: any) {
   //   "impact": "LOW",
   //   "component": "string",
   //   "title": "string",
-  //   "description": "string",
+  //   "comment_zero": "string",
   //   "summary": "string",
   //   "statement": "string",
   //   "cwe_id": "string",

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -148,8 +148,8 @@ export const ZodFlawSchema = z.object({
   team_id: z.string().nullish(),
   trackers: z.array(z.string()).nullish(), // read-only
   classification: ZodFlawClassification.nullish(),
-  description: z.string().refine(
-    description => description.trim().length > 0,
+  comment_zero: z.string().refine(
+    comment_zero => comment_zero.trim().length > 0,
     { message: 'Comment#0 cannot be empty.' }
   ),
   summary: z.string().nullish(),


### PR DESCRIPTION
# [OSIDB-2784][Change description to comment zero]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

We are already showing `Flaw.description` as `Comment#0` field. This PR is a final step to ditch `Flaw.description` usage completely and start using `Flaw.comment_zero` which will be introduced in the OSIDB 4.0.0

## Changes:
* complete transition to `Flaw.comment_zero` usage
* minor - changed `flawSummary` prop to `summary` in CVSS NIST Form for less ambiguity.

## Considerations:

This PR needs to be merged only after OSIDB-2740 is addressed!