### PR TITLE
OSIDB-2781: Remove comment.type field usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@
 * Unable to save first cvss score on flaws (`OSIDB-2769`)
 * Unable to save new references and ackowledgments on flaws (`OSIDB-2206`)
 
-###
+### Removed
 * Removed is_major_incident usage (`OSIDB-2778`)
+* Removed comment.type usage (`OSIDB-2781`)
 
 ## [Unreleased] (TODO update for 2024.1.1 and 2024.2.0 releases)
 

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -136,10 +136,7 @@ function linkify(text: string) {
             >
               System
             </span>
-            {{ comment.meta_attr?.creator }} /
-            <a :href="'#' + comment.type + '/' + comment.external_system_id">
-              {{ comment.meta_attr?.time }}
-            </a>
+            {{ comment.meta_attr?.creator }} / {{ comment.meta_attr?.time }}
           </p>
           <p class="osim-flaw-comment" v-html="linkify(comment.meta_attr?.text)" />
         </li>

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -738,7 +738,6 @@ function sampleFlaw(): ZodFlawType {
     comments: [
       {
         uuid: '0d90cb33-cbdc-4bd8-bef0-7b5c7f33ece2',
-        type: 'BUGZILLA',
         external_system_id: '15302346',
         order: 0,
         meta_attr: {
@@ -760,7 +759,6 @@ function sampleFlaw(): ZodFlawType {
       },
       {
         uuid: 'b6e8870e-5f7a-46d7-bb2f-40910b75b6a4',
-        type: 'BUGZILLA',
         external_system_id: '15302351',
         order: 1,
         meta_attr: {
@@ -782,7 +780,6 @@ function sampleFlaw(): ZodFlawType {
       },
       {
         uuid: 'dffc4966-3442-46a4-98b8-2fd542addba0',
-        type: 'BUGZILLA',
         external_system_id: '15392392',
         order: 2,
         meta_attr: {
@@ -804,7 +801,6 @@ function sampleFlaw(): ZodFlawType {
       },
       {
         uuid: '7edd4365-d12e-4873-a1ea-1cf2f7110391',
-        type: 'BUGZILLA',
         external_system_id: '15596524',
         order: 3,
         meta_attr: {
@@ -826,7 +822,6 @@ function sampleFlaw(): ZodFlawType {
       },
       {
         uuid: '8f5b04e2-d62e-4330-b42f-634d41457033',
-        type: 'BUGZILLA',
         external_system_id: '15607332',
         order: 4,
         meta_attr: {
@@ -848,7 +843,6 @@ function sampleFlaw(): ZodFlawType {
       },
       {
         uuid: 'cfc38ae1-7afe-41fe-b66a-5b46acbaba3a',
-        type: 'BUGZILLA',
         external_system_id: '15614647',
         order: 5,
         meta_attr: {

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -138,7 +138,6 @@ export async function postFlawPublicComment(uuid: string, comment: string, embar
     url: `/osidb/api/v1/flaws/${uuid}/comments`,
     data: {
       text: comment,
-      type: 'BUGZILLA',
       embargoed,
     },
   }).then((response) => response.data);

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -97,7 +97,6 @@ export const FlawCVSSSchema = z.object({
 
 export const ZodFlawCommentSchema = z.object({
   uuid: z.string(),
-  type: z.string(),
   external_system_id: z.string(),
   order: z.number(),
   // meta_attr: z.record(z.string(), z.string().nullish()).nullish(),


### PR DESCRIPTION
# [OSIDB-2781] [Remove comment.type field usage]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Flaw `Comment.type` is a single value enum (`BUGZILLA`) and will be removed in OSIDB as per https://github.com/RedHatProductSecurity/osidb/pull/552. OSIM should make sure not to use it.

## Changes:

Removed `type` field from the `ZodFlawCommentSchema` as well as the `FlawService`.
Talked with @JakubFrejlach about the link that pointed to `#${comment.type}/${comment.external_system_id}` and decided to remove the whole link since it had no use

## Considerations:

OpenApi client should be re-generated once the **OSIDB 4.0** release comes out