### PR TITLE
✨ Update and delete affects with single requests, in bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add Incident State for AdvancedSearch (`OSIDB-2892`)
 * Manage adding mulitple trackers (`OSIDB-2673`, `OSIDB-2811`)
 * Hide references description when it is not set (`OSIDB-2846`)
+* Create and delete Affects in single request (`OSIDB-2821`)
 
 ### Changed
 * Switch Flaw.component to Flaw.components (`OSIDB-2777`)

--- a/src/components/FlawAlert.vue
+++ b/src/components/FlawAlert.vue
@@ -12,11 +12,11 @@ const emit = defineEmits<{
 }>();
 
 const isWarning = computed(() => {
-  return props.alert.alert_type === 'WARNING';
+  return props.alert?.alert_type === 'WARNING';
 });
 
 const isError = computed(() => {
-  return props.alert.alert_type === 'ERROR';
+  return props.alert?.alert_type === 'ERROR';
 });
 
 function scrollToComponent(parent_uuid: string) {
@@ -33,12 +33,17 @@ function scrollToComponent(parent_uuid: string) {
 </script>
 
 <template>
-  <div class="alert my-1" :class="{'alert-warning': isWarning, 'alert-danger': isError}" role="alert">
+  <div
+    v-if="alert"
+    class="alert my-1"
+    :class="{'alert-warning': isWarning, 'alert-danger': isError}"
+    role="alert"
+  >
     <LabelCollapsible>
       <template #label>
         <span class="badge mx-2" :class="{'text-bg-warning': isWarning, 'text-bg-danger': isError}">
           <i class="bi" :class="{'bi-exclamation-triangle-fill': isWarning, 'bi-x-circle-fill': isError}" />
-          {{ alert.alert_type.charAt(0) + alert.alert_type.slice(1).toLowerCase() + " " + alert.name }}
+          {{ alert?.alert_type.charAt(0) + alert?.alert_type.slice(1).toLowerCase() + " " + alert?.name }}
         </span>
       </template>
       <div class="my-2 pt-1 px-2 container text-left">
@@ -52,14 +57,14 @@ function scrollToComponent(parent_uuid: string) {
           <strong>How To Resolve</strong>
         </div>
         <div class="row mx-auto mt-1">
-          {{ alert.resolution_steps || "No resolution steps are defined." }}
+          {{ alert?.resolution_steps || "No resolution steps are defined." }}
         </div>
         <div class="row mt-3">
           <div class="col">
             <button
               type="button"
               class="btn btn-sm btn-secondary"
-              @click.prevent="scrollToComponent(alert.parent_uuid)"
+              @click.prevent="scrollToComponent(alert?.parent_uuid)"
             >
               Scroll To Origin
               <i class="bi bi-arrow-down-circle"></i>

--- a/src/components/FlawAlertsSection.vue
+++ b/src/components/FlawAlertsSection.vue
@@ -48,7 +48,7 @@ const emitExpandFocusedComponent = (parent_uuid: string) => {
 
     <div v-for="alerts,alertType in alertSet" :key="alertType">
       <div v-if="alerts.length">
-        <span v-for="alert in alerts" :key="alert.uuid">
+        <span v-for="(alert, index) in alerts" :key="alert?.uuid || `alert-${index}-${alertType}`">
           <FlawAlert :alert="alert" @expandFocusedComponent="emitExpandFocusedComponent" />
         </span>
       </div>

--- a/src/components/__tests__/AffectedOfferings.spec.ts
+++ b/src/components/__tests__/AffectedOfferings.spec.ts
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils';
 import AffectedOfferings from '@/components/AffectedOfferings.vue';
-
 import { mockAffect } from './test-suite-helpers';
 
 // const mockError = () => ({

--- a/src/components/__tests__/CveRequestForm.spec.ts
+++ b/src/components/__tests__/CveRequestForm.spec.ts
@@ -53,9 +53,7 @@ describe('CveRequestForm', () => {
       },
     });
     const button = wrapper.get('button');
-    console.log(button);
     await button.trigger('click');
-    // const currentComponent = wrapper.getCurrentComponent();
     expect(wrapper.find('div.modal-content').exists()).toBe(true);
   });
 });

--- a/src/components/widgets/OsimButton.vue
+++ b/src/components/widgets/OsimButton.vue
@@ -27,7 +27,6 @@ const foregroundColor = ref<string>('');
 
 onMounted(() => {
   const computedStyle = osimButton.value ? window.getComputedStyle(osimButton.value) : null;
-  console.log(computedStyle?.backgroundColor);
   if (computedStyle?.backgroundColor){
     foregroundColor.value = computedStyle.backgroundColor;
   }

--- a/src/composables/useFlawAffectsModel.ts
+++ b/src/composables/useFlawAffectsModel.ts
@@ -1,4 +1,4 @@
-import { type Ref, ref, computed, watch, toRaw } from 'vue';
+import { type Ref, ref, computed, watch } from 'vue';
 import {
   postAffects,
   putAffects,

--- a/src/composables/useFlawAffectsModel.ts
+++ b/src/composables/useFlawAffectsModel.ts
@@ -1,13 +1,12 @@
-import { type Ref, ref, computed, watch } from 'vue';
+import { type Ref, ref, computed, watch, toRaw } from 'vue';
 import {
-  postAffect,
-  putAffect,
+  postAffects,
   putAffects,
-  deleteAffect,
+  deleteAffects,
   putAffectCvssScore,
   postAffectCvssScore,
 } from '@/services/AffectService';
-import { getDisplayedOsidbError } from '@/services/OsidbAuthService';
+// import { getDisplayedOsidbError } from '@/services/OsidbAuthService';
 import { useToastStore } from '@/stores/ToastStore';
 import type { ZodFlawType } from '@/types/zodFlaw';
 import type { ZodAffectType, ZodAffectCVSSType } from '@/types/zodAffect';
@@ -151,64 +150,48 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
 
   flaw.value.affects.forEach((affect) => watch(affect, trackAffectChange, { deep: true }));
 
-  async function deleteAffects() {
-    for (const affect of affectsToDelete.value) {
-      if (affect.uuid) {
-        await deleteAffect(affect.uuid);
-      }
-    }
+  async function removeAffects() {
+    await deleteAffects(affectsToDelete.value.map(({ uuid }) => uuid as string).filter(Boolean));
     resetAffectsForDeletion();
   }
 
   async function saveAffects() {
-    if (wereAffectsModified.value && modifiedAffectIds.value.length) {
-      const requestBody = affectsToUpdate.value.map((affect) => ({
-        flaw: flaw.value?.uuid,
-        uuid: affect.uuid,
-        affectedness: affect.affectedness,
-        resolution: affect.resolution,
-        ps_module: affect.ps_module,
-        ps_component: affect.ps_component,
-        impact: affect.impact,
-        embargoed: affect.embargoed || false,
-        updated_dt: affect.updated_dt,
-      }));
+    const savedAffects: ZodAffectType[] = [];
+    const requestBodyFromAffect = (affect: ZodAffectType) => ({
+      flaw: flaw.value?.uuid,
+      uuid: affect.uuid,
+      affectedness: affect.affectedness,
+      resolution: affect.resolution,
+      delegated_resolution: affect.delegated_resolution,
+      ps_module: affect.ps_module,
+      ps_component: affect.ps_component,
+      impact: affect.impact,
+      embargoed: affect.embargoed || false,
+      updated_dt: affect.updated_dt,
+    });
+
+    if (wereAffectsModified.value) {
+      const requestBody = affectsToUpdate.value.map(requestBodyFromAffect);
       await putAffects(requestBody);
+      savedAffects.push(...affectsToUpdate.value);
       resetModifiedAffects();
     }
-    const affectsToCreateQuantity = affectsToCreate.value.length;
-    for (let index = 0; index < affectsToCreateQuantity; index++) {
-      const affect = affectsToCreate.value[index];
-      const requestBody = {
-        flaw: flaw.value?.uuid,
-        affectedness: affect.affectedness,
-        resolution: affect.resolution,
-        delegated_resolution: affect.delegated_resolution,
-        ps_module: affect.ps_module,
-        ps_component: affect.ps_component,
-        impact: affect.impact,
-        embargoed: affect.embargoed || false,
-        updated_dt: affect.updated_dt,
-      };
-      if (affect.uuid != null) {
-        try {
-          await putAffect(affect.uuid, requestBody);
-        } catch (error: unknown) {
-          const displayedError = getDisplayedOsidbError(error);
-          addToast({
-            title: 'Error updating Affect',
-            body: displayedError,
-            css: 'warning',
-          });
-          throw error;
+
+    if (affectsToCreate.value.length) {
+      await postAffects(affectsToCreate.value.map(requestBodyFromAffect));
+      savedAffects.push(...affectsToUpdate.value);
+    }
+
+    const affectCvssScoresToSave = savedAffects.filter((affect) => shouldSaveCvss(affect.uuid as string));
+    if (affectCvssScoresToSave.length) {
+      for (const affect of affectCvssScoresToSave) {
+        if (!affect.uuid) {
+          console.error('Error following affect save: Saved affect is missing uuid', affect);
+          console.error('Data from response of affect saved has unexpected content.');
+          continue;
         }
-      } else {
-        await postAffect(requestBody);
-      }
 
-      if (affect?.uuid && shouldSaveCvss(affect.uuid)) {
         const cvssScores = cvssScoresToSave(affect.uuid);
-
         for (const cvssScore of cvssScores) {
           if (isCvssNew(cvssScore)) {
             await postAffectCvssScore(affect.uuid, cvssScore);
@@ -218,6 +201,10 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
         }
       }
     }
+    addToast({
+      title: 'Success!',
+      body: 'Affects CVSS scores saved.',
+    });
   }
 
   return {
@@ -225,9 +212,10 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
     removeAffect,
     recoverAffect,
     saveAffects,
-    deleteAffects,
+    removeAffects,
     wereAffectsModified,
     affectsToDelete,
     affectsToSave,
   };
 }
+

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -29,7 +29,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
   const flawAffectsModel = useFlawAffectsModel(flaw);
   const flawAttributionsModel = useFlawAttributionsModel(flaw, isSaving, afterSaveSuccess);
   const { wasCvssModified, saveCvssScores } = cvssScoresModel;
-  const { affectsToSave, saveAffects, deleteAffects, affectsToDelete } = flawAffectsModel;
+  const { affectsToSave, saveAffects, removeAffects, affectsToDelete } = flawAffectsModel;
 
   const router = useRouter();
   const committedFlaw = ref<ZodFlawType | null>(null);
@@ -106,7 +106,6 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
         body: validatedFlaw.error.issues.map(errorMessage).join('\n '),
         css: 'warning',
       });
-      console.log(validatedFlaw.error);
     }
     return validatedFlaw;
   }
@@ -128,7 +127,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     }
 
     if (affectsToDelete.value.length) {
-      queue.push(deleteAffects);
+      queue.push(removeAffects);
     }
 
     if (wasCvssModified.value) {

--- a/src/services/AffectService.ts
+++ b/src/services/AffectService.ts
@@ -27,22 +27,23 @@ export async function putAffects(affectObjects: any[]) {
 }
 
 // export async function postAffect(affectObject: ZodAffectType) {
-export async function postAffect(affectObject: any) {
+export async function postAffects(affectObjects: any[]) {
   return osidbFetch({
     method: 'post',
-    url: '/osidb/api/v1/affects',
-    data: affectObject,
+    url: '/osidb/api/v1/affects/bulk',
+    data: affectObjects,
   })
-    .then(createSuccessHandler({ title: 'Success!', body: 'Affect Created.' }))
-    .catch(createCatchHandler('Error creating Affect:'));
+    .then(createSuccessHandler({ title: 'Success!', body: 'Affects Created.' }))
+    .catch(createCatchHandler('Error creating Affects:'));
 }
 
-export async function deleteAffect(uuid: string) {
+export async function deleteAffects(affectUuids: string[]) {
   return osidbFetch({
     method: 'delete',
-    url: `/osidb/api/v1/affects/${uuid}`,
+    url: '/osidb/api/v1/affects/bulk',
+    data: affectUuids,
   })
-    .then(createSuccessHandler({ title: 'Success!', body: 'Affect Deleted.' }))
+    .then(createSuccessHandler({ title: 'Success!', body: `${affectUuids.length} Affect(s) Deleted.` }))
     .catch(createCatchHandler('Error deleting Affect:'));
 }
 

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -13,7 +13,10 @@ export async function beforeFetch(options: OsidbFetchOptions) {
   if (options.data && ['PUT'].includes(options.method.toUpperCase())) {
     try {
       const updated_dt = await getUpdatedDt(options.url);
-      options.data.updated_dt = updated_dt;
+
+      if (Array.isArray(options.data)){
+        (options.data as Record<string, any>).updated_dt = updated_dt;
+      }
       if (!updated_dt) {
         throw new Error('An updated_dt could not be fetched');
       }

--- a/src/services/OsidbAuthService.ts
+++ b/src/services/OsidbAuthService.ts
@@ -30,7 +30,7 @@ export type OsidbPutPostFetchOptions = {
 export type OsidbDeleteFetchOptions = {
   url: string;
   method: 'DELETE' | 'delete';
-  data?: never;
+  data?: Record<string, any> | string[] | Record<string, any>[];
   params?: never;
 };
 

--- a/src/stores/osimRuntime.ts
+++ b/src/stores/osimRuntime.ts
@@ -111,6 +111,10 @@ function fetchRuntime() {
         runtime.value = OsimRuntime.parse(json);
       } catch (e) {
         console.error('Unable to parse OsimRuntime', e);
+        console.log(OsimRuntime.safeParse(json).error?.issues.map(
+          // Provides additional helpful context for zod parsing errors
+          issue => issue.path.join('/') + ': ' + issue.message
+        ));
         runtime.value.error = 'Backends are not correctly configured. Please try again later.';
         status.value = OsimRuntimeStatus.ERROR;
       }


### PR DESCRIPTION
# [OSIDB-ID] [Title]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Allows affects to be created and deleted with a single request, using the new `POST affects/bulk` and `DELETE affects/bulk` endpoints in OSIDB.

## Changes:

- No longer uses `POST affects` and `DELETE affects` endpoints in OSIDB.

## Considerations:

Depends on #243, includes #264