### PR TITLE
Feature: Tracker's external links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add CVE Require Description for AdvancedSearch (`OSIDB-2624`)
 * Support for references and acknowledgements on flaw creation (`OSIDB-2319`)
 * Sort Advanced Search Options alphabetically (`OSIDB-2805`)
+* Add tracker links on affects and flaw form (`OSIDB-2630`)
 
 ### Fixed
 * The session is now shared across tabs

--- a/src/components/AffectedOfferingForm.vue
+++ b/src/components/AffectedOfferingForm.vue
@@ -5,6 +5,7 @@ import { useWindowSize } from '@vueuse/core';
 import LabelEditable from '@/components/widgets/LabelEditable.vue';
 import LabelSelect from '@/components/widgets/LabelSelect.vue';
 import { osimRuntime } from '@/stores/osimRuntime';
+import { trackerUrl } from '@/services/TrackerService';
 import {
   affectAffectedness,
   affectImpacts,
@@ -122,9 +123,12 @@ const hiddenResolutionOptions = computed(() => {
               <tr>
                 <th>Type</th>
                 <td>
-                  <RouterLink :to="{ path: `/tracker/${tracker.uuid}` }">
-                    <i class="bi bi-link"></i>{{ tracker.type }}
-                  </RouterLink>
+                  <a
+                    :href="trackerUrl(tracker.type, tracker.external_system_id)"
+                    target="_blank"
+                  >
+                    <i class="bi bi-link" />{{ tracker.type }}
+                  </a>
                 </td>
                 <th>Product Stream</th>
                 <td>

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { DateTime } from 'luxon';
 import { computed, ref, watch, onMounted } from 'vue';
-import { RouterLink } from 'vue-router';
 import { deepCopyFromRaw } from '@/utils/helpers';
 
 import LabelEditable from '@/components/widgets/LabelEditable.vue';
@@ -21,7 +20,7 @@ import LabelDiv from '@/components/widgets/LabelDiv.vue';
 import CvssCalculator from '@/components/CvssCalculator.vue';
 
 import { useFlawModel } from '@/composables/useFlawModel';
-import { fileTracker, type TrackersFilePost } from '@/services/TrackerService';
+import { fileTracker, trackerUrl, type TrackersFilePost } from '@/services/TrackerService';
 import { type ZodFlawType, summaryRequiredStates } from '@/types/zodFlaw';
 import { useDraftFlawStore } from '@/stores/DraftFlawStore';
 
@@ -406,14 +405,17 @@ const toggleMitigation = () => {
         </div>
         <LabelCollapsible
           v-if="mode === 'edit'"
-          :label="`Trackers: ${trackerUuids.length}`"
-          :isExpandable="trackerUuids.length !== 0"
+          :label="`Trackers: ${trackersDisplay.length}`"
+          :isExpandable="trackersDisplay.length !== 0"
         >
           <ul>
-            <li v-for="(tracker, trackerIndex) in trackerUuids" :key="trackerIndex">
-              <RouterLink :to="{ name: 'tracker-details', params: { id: tracker.uuid } }">
-                {{ tracker.display }}
-              </RouterLink>
+            <li v-for="(tracker, trackerIndex) in trackersDisplay" :key="trackerIndex">
+              <a
+                :href="trackerUrl(tracker.type, tracker.external_system_id)"
+                target="_blank"
+              >
+                <i class="bi bi-link" />{{ tracker.display }}
+              </a>
             </li>
           </ul>
         </LabelCollapsible>

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -40,7 +40,7 @@ function onSaveSuccess() {
 
 const {
   flaw,
-  trackerUuids,
+  trackersDisplay,
   flawSources,
   flawImpacts,
   flawIncidentStates,

--- a/src/components/__tests__/AffectExpandableForm.spec.ts
+++ b/src/components/__tests__/AffectExpandableForm.spec.ts
@@ -13,10 +13,10 @@ vi.mock('@/stores/osimRuntime', async () => {
   const osimRuntimeValue = {
     env: 'unittest',
     backends: {
-      osidb: 'osidb-backend',
-      bugzilla: 'bugzilla-backend',
-      jira: 'jira-backend',
-      errata: 'errata'
+      osidb: 'http://osidb-backend',
+      bugzilla: 'http://bugzilla-backend',
+      jira: 'http://jira-backend',
+      errata: 'http://errata'
     },
     osimVersion: {
       rev: 'osimrev', tag: 'osimtag', timestamp: '1970-01-01T00:00:00Z', dirty: true
@@ -176,6 +176,6 @@ describe('AffectExpandableForm', () => {
     const linkEl = errataEl.find('td a');
     expect(linkEl.exists()).toBeTruthy();
     expect(linkEl.element?.textContent).toBe('advisory_name');
-    expect(linkEl.attributes('href')).toBe('errata/advisory/et_id');
+    expect(linkEl.attributes('href')).toBe('http://errata/advisory/et_id');
   });
 });

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -40,6 +40,8 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
       .flatMap((affect: any) => affect.trackers ?? [])
       .flatMap((tracker: any) => ({
         uuid: tracker.uuid,
+        type: tracker.type,
+        external_system_id: tracker.external_system_id,
         display: tracker.type + ' ' + tracker.external_system_id,
       }));
   });

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -35,7 +35,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
   const committedFlaw = ref<ZodFlawType | null>(null);
   const { saveDraftFlaw } = useDraftFlawStore();
 
-  const trackerUuids = computed(() => {
+  const trackersDisplay = computed(() => {
     return (flaw.value.affects ?? [])
       .flatMap((affect: any) => affect.trackers ?? [])
       .flatMap((tracker: any) => ({
@@ -174,7 +174,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     isValid,
     errors,
     committedFlaw,
-    trackerUuids,
+    trackersDisplay,
     flawSources,
     flawImpacts,
     flawIncidentStates,

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -112,9 +112,9 @@ export async function fileTracker(requestBody: TrackersFilePost) {
 export function trackerUrl(type: string, id: string): string {
   switch (type) {
   case 'JIRA':
-    return osimRuntime.value.backends.jira + '/browse/' + id;
+    return (new URL(`/browse/${id}`, osimRuntime.value.backends.jira)).href;
   case 'BUGZILLA':
-    return osimRuntime.value.backends.bugzilla + '/' + id;
+    return (new URL(`/${id}`, osimRuntime.value.backends.bugzilla)).href;
   default:
     return '#';
   }

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { osidbFetch } from '@/services/OsidbAuthService';
+import { osimRuntime } from '@/stores/osimRuntime';
 import { createCatchHandler, createSuccessHandler } from '@/composables/service-helpers';
 
 export async function getTrackers() {
@@ -106,4 +107,15 @@ export async function fileTracker(requestBody: TrackersFilePost) {
   })
     .then(({ data }) => data)
     .catch(createCatchHandler('Failed to file tracker'));
+}
+
+export function trackerUrl(type: string, id: string): string {
+  switch (type) {
+  case 'JIRA':
+    return osimRuntime.value.backends.jira + '/browse/' + id;
+  case 'BUGZILLA':
+    return osimRuntime.value.backends.bugzilla + '/' + id;
+  default:
+    return '#';
+  }
 }


### PR DESCRIPTION
# OSIDB-2630: Trackers should link to the ticket in the bug system

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [-] No test cases added/updated
- [x] Jira ticket updated

## Summary:

Implements external links on trackers.

## Changes:

- Added a `trackerUrl` function on `TrackerService`
- Modified `trackerUuids` function  to provide `type` and `external_id`
- Renamed `trackerUuids` function to  `trackersDisplay`
- Used all above to implement trackers links on Affects and Flaw form


## Considerations:

-