### PR TITLE
OSIDB-2898: Rename assignee to owner in flaw detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Use comment_zero instead of description from OSIDB (`OSIDB-2784`)
 * Support internal flaw comments using Jira (`OSIDB-828`)
 * Redesign flaw comments section (`OSIDB-2536`)
+* Rename assignee to owner in flaw filter and detail pages (`OSIDB-2898`)
 
 ### Fixed
 * The session is now shared across tabs

--- a/features/pages/flaw_detail_page.py
+++ b/features/pages/flaw_detail_page.py
@@ -73,8 +73,8 @@ class FlawDetailPage(BasePage):
         "publicDateText": ("XPATH", "//span[text()='Public Date']"),
         "publicDateValue": ("XPATH", "(//span[@class='osim-editable-date-value form-control text-start form-control'])[2]"),
 
-        "assigneeText": ("XPATH", "//span[contains(text(), 'Assignee')]"),
-        "assignee": ("XPATH", "//span[contains(text(), 'Assignee')]"),
+        "ownerText": ("XPATH", "//span[contains(text(), 'Owner')]"),
+        "owner": ("XPATH", "//span[contains(text(), 'Owner')]"),
         "selfAssignBtn": ("XPATH", "//button[contains(text(), 'Self Assign')]"),
 
         "referenceCountLabel": ("XPATH", '//label[contains(text(), "References:")]'),

--- a/features/steps/flaw_detail.py
+++ b/features/steps/flaw_detail.py
@@ -260,9 +260,9 @@ def step_impl(context):
 @when('I click self assign button and save changes')
 def step_impl(context):
     flaw_detail_page = FlawDetailPage(context.browser)
-    cur_value = flaw_detail_page.get_current_value_of_field("assignee")
+    cur_value = flaw_detail_page.get_current_value_of_field("owner")
     if cur_value:
-        flaw_detail_page.set_field_value('assignee', '')
+        flaw_detail_page.set_field_value('owner', '')
         flaw_detail_page.click_btn('saveBtn')
         flaw_detail_page.wait_msg('flawSavedMsg')
     go_to_specific_flaw_detail_page(context.browser)
@@ -274,7 +274,7 @@ def step_impl(context):
 @then("The flaw is assigned to me")
 def step_impl(context):
     flaw_detail_page = FlawDetailPage(context.browser)
-    assignee = flaw_detail_page.get_current_value_of_field("assignee")
+    assignee = flaw_detail_page.get_current_value_of_field("owner")
     home_page = HomePage(context.browser)
     login_user = home_page.userBtn.get_text()
     assert assignee == login_user.strip(), f'Self assign failed: {assignee}'

--- a/features/steps/flaw_filter.py
+++ b/features/steps/flaw_filter.py
@@ -104,7 +104,7 @@ def step_impl(context):
     # Go to a specific flaw detail page
     go_to_specific_flaw_detail_page(context.browser)
     # Assign this flaw to the current user
-    detail_page.set_input_field("assignee", context.user_name)
+    detail_page.set_input_field("owner", context.user_name)
     detail_page.click_btn('saveBtn')
     detail_page.wait_msg('flawSavedMsg')
 

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -12,7 +12,7 @@ import AffectedOfferings from '@/components/AffectedOfferings.vue';
 import IssueFieldEmbargo from '@/components/IssueFieldEmbargo.vue';
 import CveRequestForm from '@/components/CveRequestForm.vue';
 import IssueFieldState from './IssueFieldState.vue';
-import FlawFormAssignee from '@/components/FlawFormAssignee.vue';
+import FlawFormOwner from '@/components/FlawFormOwner.vue';
 import IssueFieldReferences from './IssueFieldReferences.vue';
 import IssueFieldAcknowledgments from './IssueFieldAcknowledgments.vue';
 import CvssNISTForm from '@/components/CvssNISTForm.vue';
@@ -361,7 +361,7 @@ const formDisabled = ref(false);
             :flawId="flaw.cve_id || flaw.uuid"
             @updateFlaw="updateFlaw"
           />
-          <FlawFormAssignee v-model="flaw.owner" />
+          <FlawFormOwner v-model="flaw.owner" />
         </div>
       </div>
       <div class="osim-flaw-form-section border-top">

--- a/src/components/FlawFormOwner.vue
+++ b/src/components/FlawFormOwner.vue
@@ -9,7 +9,7 @@ function selfAssign() {
   owner.value = userStore.userName;
 }
 
-function handleClick(fn: (arg?: any) => any){
+function handleClick(fn: (arg?: any) => any) {
   selfAssign();
   nextTick(fn);
 }
@@ -22,26 +22,18 @@ const isAssignedToMe = computed(() => owner.value === userStore.userName);
   <label class="ps-3 mb-3 input-group osim-input">
     <div class="row">
       <span class="form-label col-3 pe-3 ">
-        Assignee
+        Owner
       </span>
-      <EditableText
-        v-model="owner"
-        label="Assignee"
-        type="text"
-      >
+      <EditableText v-model="owner">
         <template v-if="!isAssignedToMe" #buttons-out-of-editing-mode="{ onBlur }">
-          <button
-            type="button"
-            class="btn btn-primary osim-self-assign"
-            @click.prevent.stop="handleClick(onBlur)"
-          >Self Assign</button>
+          <button type="button" class="btn btn-primary osim-self-assign" @click.prevent.stop="handleClick(onBlur)">
+            Self Assign
+          </button>
         </template>
         <template v-if="!isAssignedToMe" #buttons-in-editing-mode="{ onBlur }">
-          <button
-            type="button"
-            class="btn btn-primary osim-self-assign"
-            @click.prevent.stop="handleClick(onBlur)"
-          >Self Assign</button>
+          <button type="button" class="btn btn-primary osim-self-assign" @click.prevent.stop="handleClick(onBlur)">
+            Self Assign
+          </button>
         </template>
       </EditableText>
     </div>

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -20,7 +20,7 @@ import LabelSelect from '@/components/widgets/LabelSelect.vue';
 import LabelCollapsible from '@/components/widgets/LabelCollapsible.vue';
 import LabelTextarea from '@/components/widgets/LabelTextarea.vue';
 import CvssCalculator from '@/components/CvssCalculator.vue';
-import FlawFormAssignee from '@/components/FlawFormAssignee.vue';
+import FlawFormOwner from '@/components/FlawFormOwner.vue';
 import LabelTagsInput from '@/components/widgets/LabelTagsInput.vue';
 import { blankFlaw } from '@/composables/useFlawModel';
 import { sampleFlaw } from './SampleData';
@@ -224,7 +224,7 @@ describe('FlawForm', () => {
       .find((component) => component.props().label === 'Embargoed');
     expect(embargoedField?.exists()).toBe(true);
 
-    const assigneeField = subject.findComponent(FlawFormAssignee);
+    const assigneeField = subject.findComponent(FlawFormOwner);
     expect(assigneeField?.exists()).toBe(true);
 
     const trackers = subject
@@ -401,12 +401,12 @@ describe('FlawForm', () => {
     expect(vm.errors.cve_description).toBe('Description must be approved for Major Incidents.');
   });
 
-  it('displays correct Assignee field value from props', async () => {
+  it('displays correct Owner field value from props', async () => {
     const flaw = sampleFlaw();
     flaw.owner = 'test owner';
     mountWithProps({ flaw, mode: 'edit' });
-    const assigneeField = subject.findComponent(FlawFormAssignee);
-    expect(assigneeField?.find('span.form-label').text()).toBe('Assignee');
+    const assigneeField = subject.findComponent(FlawFormOwner);
+    expect(assigneeField?.find('span.form-label').text()).toBe('Owner');
     expect(assigneeField?.props().modelValue).toBe('test owner');
     expect(assigneeField?.html()).toContain('test owner');
   });

--- a/src/components/__tests__/FlawFormAssignee.spec.ts
+++ b/src/components/__tests__/FlawFormAssignee.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
-import FlawFormAssignee from '../FlawFormAssignee.vue';
+import FlawFormOwner from '../FlawFormOwner.vue';
 import { mount, VueWrapper } from '@vue/test-utils';
 
 
@@ -40,15 +40,15 @@ vi.mock('jwt-decode', () => ({
 }));
 
 
-describe('Assignee field renders', () => {
-  let subject: VueWrapper<InstanceType<typeof FlawFormAssignee>>;
+describe('Owner field renders', () => {
+  let subject: VueWrapper<InstanceType<typeof FlawFormOwner>>;
   beforeAll(() => {
     createTestingPinia();
   });
   beforeEach(() => {
-    subject = mount(FlawFormAssignee, {});
+    subject = mount(FlawFormOwner, {});
   });
-  it('should render the assignee field', () => {
+  it('should render the owner field', () => {
     expect(subject.exists()).toBe(true);
   });
 


### PR DESCRIPTION
# [OSIDB-2898] [Rename assignee to owner in flaw detail pages]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Field is called `owner` in the API and the advanced search, so it should be called `Owner` in the details page as well

|Before|After|
|---|---|
|![image](https://github.com/RedHatProductSecurity/osim/assets/4268580/9a7d1b90-93dd-4c92-8bca-b56dfac8baf2)|![image](https://github.com/RedHatProductSecurity/osim/assets/4268580/e93636f8-c12e-43b9-a23e-f6d29a0ada03)|

Closes OSIDB-2898