### PR TITLE
✨ Restrict affect resolution choices based on affectedness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Support private Bugzilla comments (`OSIDB-2912`)
 * Add Created At on Flaw Edit (`OSIDB-2945`)
 * Add Affect affectedness on Advanced Search (`OSIDB-2951`)
+* Limit Affect resolution options based on affectedness value (`OSIDB-2787`)
 
 ### Fixed
 * Refresh flaw after cvss scores on create (`OSIDB-2981`)

--- a/src/components/AffectedOfferingForm.vue
+++ b/src/components/AffectedOfferingForm.vue
@@ -13,7 +13,13 @@ import {
 } from '@/types/zodAffect';
 
 const { width: screenWidth } = useWindowSize();
-
+const resolutionOptions = computed(() => {
+  return {
+    AFFECTED: affectResolutions,
+    NEW: [''],
+    NOTAFFECTED: [''],
+  }[modelValue.value?.affectedness as string] || [''];
+});
 type NotUndefined<T> = Exclude<T, undefined>;
 
 defineProps<{
@@ -69,7 +75,7 @@ const hiddenResolutionOptions = computed(() => {
         v-model="modelValue.resolution"
         :error="error?.resolution"
         label="Resolution"
-        :options="affectResolutions"
+        :options="resolutionOptions"
         :optionsHidden="hiddenResolutionOptions"
       />
       <LabelSelect

--- a/src/components/__tests__/AffectExpandableForm.spec.ts
+++ b/src/components/__tests__/AffectExpandableForm.spec.ts
@@ -141,7 +141,7 @@ describe('AffectExpandableForm', () => {
   //   expect(button.text()).toBe('File Tracker');
   // });
 
-  it('should render affectedness, resolution select', () => {
+  it('should render affectedness, resolution select', async () => {
     const formComponent = subject.findAllComponents(AffectedOfferingForm);
     expect(formComponent.length).toBe(1);
     const selectComponents = formComponent[0].findAllComponents(LabelSelect);
@@ -150,6 +150,7 @@ describe('AffectExpandableForm', () => {
     const resolutionSelectEL = selectComponents[1];
     const affectednessOptions = affectednessSelectEl.props('options');
     expect(affectednessOptions).toStrictEqual(affectAffectedness);
+    await affectednessSelectEl.find('select').setValue('AFFECTED');
     const resolutionOptions = resolutionSelectEL.props('options');
     expect(resolutionOptions).toStrictEqual(affectResolutions);
     const resolutoinHiddenOptions = resolutionSelectEL.findAll('option[hidden]');


### PR DESCRIPTION
📝 Update change log

# [OSIDB-2787] [OSIM: Affectdness / resolution validation]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

* Limits Affect resolution selections based on affectedness value (`OSIDB-2787`)


## Changes:

- `NEW`, `NOTAFFECTED`  are limited to Empty (`''`)
- `AFFECTED` affectedness affects (lol) can be `DELEGATED`, `OOSS`, or `WONTFIX`
 


## Considerations:

[Replace with any additional considerations, notes, or instructions for reviewers.]