### PR TITLE
Fix: Use empty array as default

### DIFF
--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -193,7 +193,7 @@ export function blankFlaw(): ZodFlawType {
       state: 'NEW',
       workflow: '',
     },
-    components: [''],
+    components: [],
     unembargo_dt: '',
     reported_dt: new Date().toISOString(),
     uuid: '',

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -142,7 +142,7 @@ export const ZodFlawSchema = z.object({
       Boolean,
       { message: 'You must select an impact before saving the Flaw.' }
     ),
-  components: z.array(z.string().min(1).max(100)).nonempty(),
+  components: z.array(z.string().min(1).max(100)),
   title: z.string().min(4),
   owner: z.string().nullish(),
   team_id: z.string().nullish(),
@@ -250,5 +250,9 @@ export const ZodFlawSchema = z.object({
       'Affected component cannot be registered on the affected module twice',
       [`Affects/${affect.index}/component`],
     );
+  }
+
+  if (zodFlaw.components.length === 0) {
+    raiseIssue('Components cannot be empty.', ['components']);
   }
 });


### PR DESCRIPTION
## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [ ] Changelog updated
- [x] Test cases added/updated
- [ ] Jira ticket updated

## Summary:

When creating a new flaw, the default value `[""]` added an empty FlawComponent on form mount.
Fixed it by changing the value to `[]` and moving the validation from zod type to refine

|Before|After|
|---|---|
|![image](https://github.com/RedHatProductSecurity/osim/assets/4268580/3e9f31ec-5b6b-4d3d-8373-0c6e9473a161)|![image](https://github.com/RedHatProductSecurity/osim/assets/4268580/de3eb2c0-836a-4ae3-91f8-3abd0e681cc8)|



