### PR TITLE
OSIDB-2899: Rename Flaw Status to Flaw State in Advanced search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   * Filter trackers by stream or component name
   * Shows recommended tracker icon
 * Make `Impact`, `Public Date` and `Component` optional for a `Rejected` flaw (`OSIDB-2849`)
+* Renamed Flaw Status to Flaw State (`OSIDB-2899`)
 
 ### Fixed
 * The session is now shared across tabs

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -161,7 +161,7 @@ const nameForOption = (fieldName: string) => {
     acknowledgments__name: 'Acknowledgment Author',
     affects__trackers__errata__advisory_name: 'Errata Advisory Name',
     affects__trackers__external_system_id: 'Tracker External System ID',
-    workflow_state: 'Flaw Status',
+    workflow_state: 'Flaw State',
     cwe_id: 'CWE ID',
     cve_id: 'CVE ID',
     source: 'CVE Source',

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -28,7 +28,7 @@ const nameForOption = (fieldName: string) => {
     acknowledgments__name: 'Acknowledgment Author',
     affects__trackers__errata__advisory_name: 'Errata Advisory Name',
     affects__trackers__external_system_id: 'Tracker External System ID',
-    workflow_state: 'Flaw Status',
+    workflow_state: 'Flaw State',
     cwe_id: 'CWE ID',
     cve_id: 'CVE ID',
     source: 'CVE Source',


### PR DESCRIPTION
# [OSIDB-2899] Rename Flaw Status to Flaw State in Advanced search

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

In advanced searching we call it "flaw status", in the api we call it "state" and in the detail page we call it "state". So we should update the advanced search field to call it "State".

|Before|After|
|---|---|
|![image](https://github.com/RedHatProductSecurity/osim/assets/4268580/4a3d642f-6e23-459b-8659-1a8ac5dba5f5)|![image](https://github.com/RedHatProductSecurity/osim/assets/4268580/15f51fc0-77e2-4681-a7c7-c0059e58da9a)|

Closes OSIDB-2899