### PR TITLE
Task OSIDB-2790: Use timezone on public date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Make `Impact`, `Public Date` and `Component` optional for a `Rejected` flaw (`OSIDB-2849`)
 * Renamed Flaw Status to Flaw State (`OSIDB-2899`)
 * Improve reporting on tracker filing errors (`OSIDB-2909`)
+* Added timezone to Public Date field (UTC) (`OSIDB-2790`)
 
 ### Fixed
 * The session is now shared across tabs

--- a/src/components/widgets/EditableDate.vue
+++ b/src/components/widgets/EditableDate.vue
@@ -26,7 +26,7 @@ const elInput = ref<HTMLInputElement>();
 const elDiv = ref<HTMLDivElement>();
 const editing = ref<boolean>(props.editing ?? false);
 
-const pattern = props.includesTime ? 'yyyy-MM-dd hh:mm ZZZZ' : 'yyyy-MM-dd';
+const pattern = props.includesTime ? 'yyyy-MM-dd hh:mm Z' : 'yyyy-MM-dd';
 const maskLayer = {
   mask: Date,
   pattern,
@@ -65,7 +65,7 @@ const maskLayer = {
       to: 59,
       maxLength: 2,
     },
-    ZZZZ: {
+    Z: {
       mask: 'UTC',
     },
   },


### PR DESCRIPTION
# OSIDB-2790: Use timezone on public date

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [-] No test cases added/updated
- [x] Jira ticket updated

## Summary:

Adds UTC to the public date field so users have clear what timezone is being used when either setting or reading that field.

## Changes:

- Adds UTC on EditableDate component for editing and displaying

