### PR TITLE
✨ Improve collapsing logic in Affected Offerings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Renamed Flaw Status to Flaw State (`OSIDB-2899`)
 * Improve reporting on tracker filing errors (`OSIDB-2909`)
 * Added timezone to Public Date field (UTC) (`OSIDB-2790`)
+* Don't collapse affected modules automatically after deleting a component (only occurred when no other components were expanded) (`OSIDB-2757`)
 
 ### Fixed
 * The session is now shared across tabs

--- a/src/components/AffectedOfferings.vue
+++ b/src/components/AffectedOfferings.vue
@@ -45,7 +45,7 @@ updateAffectsExpandedState(theAffects.value);
 
 watch(theAffects, (nextValue) => {
   expandedModules.value = affectedModules.value.reduce((modules: Record<string, boolean>, moduleName: string) => {
-    modules[moduleName] = areAnyComponentsExpandedIn(moduleName) ?? false;
+    modules[moduleName] = areAnyComponentsExpandedIn(moduleName) || expandedModules.value[moduleName] || false;
     return modules;
   }, {});
   updateAffectsExpandedState(nextValue);


### PR DESCRIPTION
# [OSIDB-2757][OSIM: Deleting a component collapses the whole affect]
## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- ~~Test cases added/updated~~
- [x] Jira ticket updated

## Summary:

- Within the Affected Offerings accordion UI, when deleting a component, the module would collapse when there were no other expanded components, even if the Module Accordion UI was expanded. 
## Changes:

The Module Accordion UI will no longer collapses deleting a component when no other components in that expanded Module are expanded

[Replace with a detailed description of the changes made in this PR, including any new features, enhancements, bug fixes, or refactorings.]

## Considerations:

[Replace with any additional considerations, notes, or instructions for reviewers.]