### PR TITLE
Fix OSIDB-2904: Unembargoed btn not shown

### DIFF
--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -81,6 +81,7 @@ let initialFlaw: ZodFlawType;
 
 onMounted(() => {
   initialFlaw = deepCopyFromRaw(props.flaw) as ZodFlawType;
+  isEmbargoed.value = initialFlaw?.embargoed;
   if (draftFlaw) {
     flaw.value = useDraftFlawStore().addDraftFields(flaw.value);
     useDraftFlawStore().$reset();
@@ -89,10 +90,11 @@ onMounted(() => {
 
 watch(() => props.flaw, () => { // Shallow watch so as to avoid reseting on any change (though that shouldn't happen)
   initialFlaw = deepCopyFromRaw(props.flaw) as ZodFlawType;
+  isEmbargoed.value = initialFlaw?.embargoed;
   onReset();
 });
 
-const isEmbargoed = computed(() => initialFlaw?.embargoed);
+const isEmbargoed = ref();
 const showUnembargoingModal = ref(false);
 const unembargoing = computed(() => isEmbargoed.value && !flaw.value.embargoed);
 

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { DateTime } from 'luxon';
-import { computed, ref, watch, onMounted, reactive } from 'vue';
+import { computed, ref, watch, onMounted } from 'vue';
 import { deepCopyFromRaw } from '@/utils/helpers';
 
 import LabelEditable from '@/components/widgets/LabelEditable.vue';
@@ -115,7 +115,8 @@ const showStatement = ref(flaw.value.statement && flaw.value.statement.trim() !=
 const showMitigation = ref(flaw.value.mitigation && flaw.value.mitigation.trim() !== '');
 
 const onReset = () => {
-  flaw.value = reactive(deepCopyFromRaw(initialFlaw));
+  // is deepCopyFromRaw needed?
+  flaw.value = deepCopyFromRaw(initialFlaw);
 };
 
 const allowedSources = [


### PR DESCRIPTION
# OSIDB-2904 Unembargo button not shown on embargoed flaws

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [-] No changelog updated
- [-] No test cases added/updated
- [x] Jira ticket updated

## Summary:

Fix the bug where unembargo button was not appearing on flaw form of embargoed flaws.
The problem was that removing the ref on `initialFlaw` made the `isEmbargo` not being reactive, so the embargoed component was reviving undefined for that `isEmbargoed` property.

## Changes:

- Make isEmbargoed a ref and edit the values every time `initialFlaw` changes
- Remove non required `reactive` on `initialFlaw` as it is nor reactive anymore

## Considerations:

- isEmbargoed need to be reactive as it is required to make the embargoed field changing after the flaw refresh