### PR TITLE
✨ Improve Manage Trackers experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ coverage
 
 # For local development only
 /public/runtime*.json
+.forbidden-data/
 
 *.py[co]
 __pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 * Support internal flaw comments using Jira (`OSIDB-828`)
 * Redesign flaw comments section (`OSIDB-2536`)
 * Rename assignee to owner in flaw filter and detail pages (`OSIDB-2898`)
+* Dramatically enhanced Manage Trackers UI (`OSIDB-????`)
+  * Organize by selected, unselected, and already filed
+  * Limit UI space of element
+  * Filter trackers by stream or component name
+  * Shows recommended tracker icon
 
 ### Fixed
 * The session is now shared across tabs
@@ -32,6 +37,7 @@
 * References and acknowledgments are not refreshed after save actions (`OSIDB-2645`)
 * Fixed FlawForm Remove Summary, Statement, Mitigation Button (`OSIDB-2703`)
 * Restored required field validations to Flaw fields (`OSIDB-2725`)
+* De/Select all button in Trackers Manager (`OSIDB-2908`)
 * Save affects all at once (`OSIDB-2206`)
 * Show only allowed sources for Flaw Create/Edit (`OSIDB-2395`)
 * Fixed deleted affects message after flaw save (`OSIDB-2693`)

--- a/src/components/AffectsTrackers.vue
+++ b/src/components/AffectsTrackers.vue
@@ -8,23 +8,32 @@ const props = defineProps<{
 }>();
 
 const {
-  availableUpdateStreams,
   trackerSelections,
   trackersToFile,
   fileTrackers,
-  setAll
+  setAll,
+  unselectedStreams,
+  selectedStreams,
+  filterString,
+  alreadyFiledTrackers,
 } = useTrackers(props.flawId, props.theAffects);
-
 const emit = defineEmits<{
   'affects-trackers:hide': [];
 }>();
-
 </script>
 
 <template>
   <div class="mt-3">
     <h4 class="mb-2">
       Affected Offerings Trackers
+      <div>
+        <input
+          v-model="filterString"
+          type="text"
+          class="form-control form-control-sm"
+          placeholder="Filter by stream or component name"
+        />
+      </div>
       <button
         type="button"
         class="btn btn-white btn-outline-black btn-sm me-2"
@@ -50,34 +59,96 @@ const emit = defineEmits<{
         Hide Manager
       </button>
     </h4>
-    <div class="osim-trackers-filing">
-
-      <div class="osim-tracker-selections mb-2">
+    <div class="osim-trackers-filing mb-2">
+      <div v-if="alreadyFiledTrackers.length" class="osim-tracker-selections mb-2">
+        <h5>Filed Trackers</h5>
         <label
-          v-for="(tracker, index) in availableUpdateStreams"
+          v-for="(tracker, index) in alreadyFiledTrackers"
           :key="`${tracker.ps_update_stream}:${tracker.ps_component}:${index}`"
         >
           <input
-            :checked="trackerSelections.get(tracker)"
+            checked
+            disabled
             type="checkbox"
             class="osim-tracker form-check-input"
-            @input="trackerSelections.set(tracker, !trackerSelections.get(tracker))"
           />
           {{ `${tracker.ps_update_stream} (${tracker.ps_component})` }}
         </label>
       </div>
-      <button
-        type="button"
-        class="button btn btn-sm btn-black text-white osim-file-trackers"
-        :disabled="!trackersToFile.length"
-        @click="fileTrackers"
-      >
-        <i class="bi bi-archive"></i>
-        File Selected Trackers
-      </button>
+      <div class="row mb-2">
+        <h5>Unfiled Trackers</h5>
+
+      </div>
+      <div class="ms-3">
+        <div class="row">
+          <div class="col-6">
+            <h5 class="me-2 d-inline-block">Unselected</h5>
+            <caption class="ms-4 mt-0">
+              (<span class="fst-italic">
+                <i class="bi bi-box-arrow-in-right" /> indicates a Suggested Tracker
+              </span>)
+            </caption>
+          </div>
+          <div class="col-6">
+            <h5>Selected</h5>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-6">
+            <div class="osim-tracker-selections mb-2">
+              <label
+                v-for="(tracker, index) in unselectedStreams"
+                :key="`${tracker.ps_update_stream}:${tracker.ps_component}:${index}`"
+              >
+                <input
+                  :checked="trackerSelections.get(tracker)"
+                  type="checkbox"
+                  class="osim-tracker form-check-input"
+                  @input="trackerSelections.set(tracker, !trackerSelections.get(tracker))"
+                />
+                <span
+                  v-if="tracker.selected"
+                  title="Suggested Tracker"
+                  class="ps-1"
+                >
+                  <i class="bi bi-box-arrow-in-right">
+                    <span class="visually-hidden"> Suggested Tracker </span>
+                  </i>
+                </span>
+                {{ `${tracker.ps_update_stream} (${tracker.ps_component})` }}
+              </label>
+            </div>
+          </div>
+
+          <div class="col-6">
+            <div class="osim-tracker-selections mb-2">
+              <label
+                v-for="(tracker, index) in selectedStreams"
+                :key="`${tracker.ps_update_stream}:${tracker.ps_component}:${index}`"
+              >
+                <input
+                  :checked="trackerSelections.get(tracker)"
+                  type="checkbox"
+                  class="osim-tracker form-check-input"
+                  @input="trackerSelections.set(tracker, !trackerSelections.get(tracker))"
+                />
+                {{ `${tracker.ps_update_stream} (${tracker.ps_component})` }}
+              </label>
+            </div>
+          </div>
+        </div>
+        <button
+          type="button"
+          class="button btn btn-sm btn-black text-white osim-file-trackers mt-3"
+          :disabled="!trackersToFile.length"
+          @click="fileTrackers"
+        >
+          <i class="bi bi-archive"></i>
+          File Selected Trackers
+        </button>
+      </div>
     </div>
   </div>
-
 </template>
 
 <style lang="scss" scoped>
@@ -87,8 +158,12 @@ const emit = defineEmits<{
 }
 
 .osim-trackers-filing {
-  padding: 1.5rem;
-  padding-top: 0;
+  overflow: hidden;
+
+  .col-6:has(.osim-tracker-selections) {
+    height: 50vh;
+    overflow-y: auto;
+  }
 }
 
 .osim-tracker-selection-disabled {


### PR DESCRIPTION
# [OSIDB-2908] [OSIM: 'Select All' trackers button only selects the top product stream of each module]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- ~~[ ] Test cases added/updated~~
- [x] Jira ticket updated

## Summary:

Dramatically improves tracker manager experience, particularly for flaws with numerous affects

## Changes:

* Organize by selected, unselected, and already filed
* Limit UI space of element
* Filter trackers by stream or component name
* Shows recommended tracker icon
* De/Select all button in Trackers Manager (`OSIDB-2908`)
* Ignore sensitive data directory for use in development


## Considerations:

[Replace with any additional considerations, notes, or instructions for reviewers.]