### PR TITLE
OSIDB-2829: Auto set the public date when unembargo a flaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Hide references description when it is not set (`OSIDB-2846`)
 * Create and delete Affects in single request (`OSIDB-2821`)
 * Add link to bugzilla tracker on Flaw form (`OSIDB-2897`)
+* Set public date to current date on unembargo (`OSIDB-2829`)
 
 ### Changed
 * Switch Flaw.component to Flaw.components (`OSIDB-2777`)

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -119,6 +119,12 @@ const onReset = () => {
   flaw.value = deepCopyFromRaw(initialFlaw);
 };
 
+const onUnembargoed = (isEmbargoed: boolean) => {
+  if (!isEmbargoed && !flaw.value.unembargo_dt) {
+    flaw.value.unembargo_dt = DateTime.now().toUTC().toISO();
+  }
+};
+
 const allowedSources = [
   '',
   'ADOBE',
@@ -373,6 +379,7 @@ const formDisabled = ref(false);
             :isEmbargoed="isEmbargoed"
             :flawId="flaw.cve_id || flaw.uuid"
             @updateFlaw="updateFlaw"
+            @update:model-value="onUnembargoed"
           />
           <FlawFormOwner v-model="flaw.owner" />
         </div>

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -9,7 +9,7 @@ import { useRouter } from 'vue-router';
 import { DateTime } from 'luxon';
 
 import { LoadingAnimationDirective } from '@/directives/LoadingAnimationDirective.js';
-import { mount, VueWrapper } from '@vue/test-utils';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
 import { useToastStore } from '@/stores/ToastStore';
 import LabelEditable from '@/components/widgets/LabelEditable.vue';
@@ -24,6 +24,7 @@ import FlawFormOwner from '@/components/FlawFormOwner.vue';
 import LabelTagsInput from '@/components/widgets/LabelTagsInput.vue';
 import { blankFlaw } from '@/composables/useFlawModel';
 import { sampleFlaw } from './SampleData';
+import IssueFieldEmbargo from '../IssueFieldEmbargo.vue';
 
 
 const FLAW_BASE_URI = '/osidb/api/v1/flaws';
@@ -529,6 +530,17 @@ describe('FlawForm', () => {
     mountWithProps({ flaw, mode: 'edit' });
     expect((subject.vm as any).errors.unembargo_dt)
       .toBe(null);
+  });
+
+  it('sets public date if empty when unembargo button is clicked', async () => {
+    const flaw = sampleFlaw();
+    flaw.embargoed = true;
+    flaw.unembargo_dt = null;
+    mountWithProps({ flaw, mode: 'edit' });
+    await flushPromises();
+    subject.findComponent(IssueFieldEmbargo).find('.osim-unembargo-button').trigger('click');
+
+    expect(flaw.unembargo_dt).not.toBe(null);
   });
 
   it('show set description, statement, mitigation values correctly after clicking remove buttons', async () => {

--- a/src/components/widgets/EditableDate.vue
+++ b/src/components/widgets/EditableDate.vue
@@ -6,7 +6,7 @@
 // Pressing escape or clicking the abort button aborts the change
 
 import { DateTime } from 'luxon';
-import { ref, nextTick, reactive, toValue } from 'vue';
+import { ref, nextTick, reactive, watch } from 'vue';
 import { IMask } from 'vue-imask';
 
 const props = defineProps<{
@@ -16,12 +16,11 @@ const props = defineProps<{
   editing?: boolean,
   error?: string | null,
 }>();
-const initialValue = toValue(props.modelValue);
+
 const emit = defineEmits<{
   'update:modelValue': [value: string | undefined],
   'update:editing': [value: boolean],
 }>();
-
 
 const elInput = ref<HTMLInputElement>();
 const elDiv = ref<HTMLDivElement>();
@@ -83,10 +82,10 @@ function formatDate(date: Date | string): string {
 function parseDate(dateString: string): Date {
   return DateTime.fromFormat(dateString, formatString, { zone: 'utc' }).toJSDate();
 }
-
 const maskState = reactive({
   completed: false,
-  masked: '',
+  // Force caret to start of input
+  masked: ' ',
   unmasked: '',
 });
 
@@ -143,8 +142,8 @@ function commit() {
 
 function abort() {
   editing.value = false;
-  maskState.masked = initialValue || '';
-  maskState.unmasked = initialValue || '';
+  maskState.masked = props.modelValue || '';
+  maskState.unmasked = props.modelValue || '';
 }
 
 function onBlur(e: FocusEvent | null) {
@@ -189,7 +188,9 @@ function osimFormatDate(date?: string | null): string {
   return formattedDate;
 }
 
-
+watch(() => props.modelValue, () => {
+  maskState.masked = props.modelValue || '';
+});
 
 </script>
 
@@ -217,7 +218,7 @@ function osimFormatDate(date?: string | null): string {
     </div>
 
     <div
-      v-if="editing"
+      v-show="editing"
       ref="elDiv"
       class="input-group osim-date-edit-field"
       @blur="onBlur($event)"

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -193,7 +193,7 @@ export function blankFlaw(): ZodFlawType {
       workflow: '',
     },
     components: [],
-    unembargo_dt: '',
+    unembargo_dt: null,
     reported_dt: new Date().toISOString(),
     uuid: '',
     cve_id: '',


### PR DESCRIPTION
# [OSIDB-2829] [Auto set the public date when unembargo a flaw]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Changed the embargo  component to listen to model updates and added a callback to set the current datetime when unembargoing

## Considerations:

Requires the changes in #271 