### PR TITLE
OSIDB-2897: Add bugzilla flaw link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Manage adding mulitple trackers (`OSIDB-2673`, `OSIDB-2811`)
 * Hide references description when it is not set (`OSIDB-2846`)
 * Create and delete Affects in single request (`OSIDB-2821`)
+* Add link to bugzilla tracker on Flaw form (`OSIDB-2897`)
 
 ### Changed
 * Switch Flaw.component to Flaw.components (`OSIDB-2777`)

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -231,6 +231,16 @@ const formDisabled = ref(false);
   <form class="osim-flaw-form" :class="{'osim-disabled': isSaving || formDisabled}" @submit.prevent="onSubmit">
     <div class="osim-content container-lg">
       <div class="row osim-flaw-form-section">
+        <div v-if="flaw.meta_attr?.bz_id" class="col-12 mb-2 text-end">
+          <a
+            :href="bugzillaLink"
+            class="osim-bugzilla-link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Open in Bugzilla <i class="bi-box-arrow-up-right ms-2" />
+          </a>
+        </div>
         <div class="col-12 osim-alerts-banner">
           <FlawAlertsList :flaw="flaw" @expandFocusedComponent="expandFocusedComponent" />
         </div>

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -575,6 +575,22 @@ describe('FlawForm', () => {
     const disabledOptions = sourceField.findAll('option[hidden]');
     expect(disabledOptions.length).not.toBe(0);
   });
+
+  it('should show a link to bugzilla if ID exists', async () => {
+    mountWithProps();
+
+    const bugzillaLink = subject.find('.osim-bugzilla-link');
+    expect(bugzillaLink.exists()).toBe(true);
+  });
+
+  it('should not show a link to bugzilla if ID does not exists', async () => {
+    const flaw = sampleFlaw();
+    flaw.meta_attr = {};
+    mountWithProps({ flaw, mode:'edit' });
+
+    const bugzillaLink = subject.find('.osim-bugzilla-link');
+    expect(bugzillaLink.exists()).toBe(false);
+  });
 });
 
 


### PR DESCRIPTION
# [OSIDB-2897] [Add bugzilla flaw link]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Added a link to the bugzilla bug if the id exists


![image](https://github.com/RedHatProductSecurity/osim/assets/4268580/a6dd7221-d825-44d3-84f3-582af2c7bc02)
