### PR TITLE
👽 Use empty string for unimplemented CVSS comment field

### DIFF
--- a/src/composables/useFlawCvssScores.ts
+++ b/src/composables/useFlawCvssScores.ts
@@ -18,7 +18,7 @@ export function useFlawCvssScores(flaw: Ref<ZodFlawType>) {
     || {
       score: null,
       vector: null,
-      comment: null,
+      comment: '',
       created_dt: null,
       uuid: null,
     }


### PR DESCRIPTION
# [OSIDB-ID] [Title]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [ ] Changelog updated
- ~~Test cases added/updated~~
- [ ] Jira ticket updated

## Summary:

[Replace with a brief summary of the changes introduced by this PR.]

## Changes:

Send `''` instead of `null` value for key `comment` of CVSS score POST request body.

## Considerations:

It makes OSIDB sad (it triggers validations that reject the parsed CVSS score POST request body) when you send `null` and it's apparently annoying to change on the OSIDB end, if I understand correctly.