### PR TITLE
Task OSIDB-2912: Support private flaw comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OSIM Changelog
 
+## [2024.6.1]
+### Added
+* Support private Bugzilla comments (`OSIDB-2912`)
+
 ## [2024.6.0]
 ### Added
 * Self-Assign button for Flaws (`OSIDB-2593`)
@@ -169,7 +173,8 @@ The first release for user testing, briefly reaching feature parity with OSIDB
 ### Added
 * Early repo layout & Flaw template
 
-[Unreleased]: https://github.com/RedHatProductSecurity/osim/compare/v2024.6.0...HEAD
+[Unreleased]: https://github.com/RedHatProductSecurity/osim/compare/v2024.6.1...HEAD
+[2024.6.1]: https://github.com/RedHatProductSecurity/osim/compare/2024.6.0...v2024.6.1
 [2024.6.0]: https://github.com/RedHatProductSecurity/osim/compare/v2024.1.0...v2024.6.0
 [2024.1.0]: https://github.com/RedHatProductSecurity/osim/compare/v2023.11.0...v2024.1.0
 [2023.11.0]: https://github.com/RedHatProductSecurity/osim/compare/v2023.7.0...v2023.11.0

--- a/src/components/CveRequestForm.vue
+++ b/src/components/CveRequestForm.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue';
 
 import { useToastStore } from '@/stores/ToastStore';
-import { postFlawPublicComment } from '@/services/FlawService';
+import { postFlawComment } from '@/services/FlawService';
 import { useUserStore } from '@/stores/UserStore';
 
 import Modal from '@/components/widgets/Modal.vue';
@@ -64,7 +64,7 @@ function addPublicCveRequestComment() {
     // new Promise((resolve, reject) => {
     //   setTimeout(resolve, 5000);
     // })
-    postFlawPublicComment(flawUuidMatch[1], 'New CVE Requested', userStore.userName, props.embargoed)
+    postFlawComment(flawUuidMatch[1], 'New CVE Requested', userStore.userName, true, props.embargoed)
       .then(() => {
         commentSaved.value = true;
         savingComment.value = false;

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -18,8 +18,9 @@ const props = defineProps<{
   isSaving: boolean;
 }>();
 
-enum CommentTab {
+enum CommentType {
     Public,
+    Private,
     Internal,
     System,
 }
@@ -47,8 +48,20 @@ const emit = defineEmits<{
 
 const SYSTEM_EMAIL = 'bugzilla@redhat.com';
 
-const tabLabels = ['Public Comments', 'Internal Comments', 'System Comments'];
-const selectedTab = ref(CommentTab.Public);
+const commentLabels = computed(() => {
+  return Object.keys(CommentType)
+    .filter((key) => isNaN(Number(key)))
+    .map((key) => `${key} Comments`);
+});
+
+const commentTooltips: Record<CommentType, string> = {
+  [CommentType.Public]: 'Bugzilla Public - This comments are visible to everyone.',
+  [CommentType.Private]: 'Bugzilla Private - This comments are visible to Red Hat associates.',
+  [CommentType.Internal]: 'Jira Internal - This comments are visible to team members with required permissions.',
+  [CommentType.System]: 'Bugzilla System - This are auto-generated private comments.',
+};
+
+const selectedTab = ref(CommentType.Public);
 const handleTabChange = (index: number) => {
   selectedTab.value = index;
 };
@@ -78,11 +91,13 @@ const systemComments = computed(() => parseOsidbComments(props.comments.filter(f
 
 const displayedComments = computed(() => {
   switch (selectedTab.value) {
-  case CommentTab.Public:
+  case CommentType.Public:
     return publicComments.value;
-  case CommentTab.Internal:
+  case CommentType.Private:
+    return privateComments.value;
+  case CommentType.Internal:
     return internalComments.value;
-  case CommentTab.System:
+  case CommentType.System:
     return systemComments.value;
   default:
     return [];
@@ -128,7 +143,7 @@ function sanitize(text: string) {
   <section class="osim-comments">
     <h4 class="mb-4">Comments</h4>
     <Tabs
-      :labels="tabLabels"
+      :labels="commentLabels"
       :default="0"
       @tab-change="handleTabChange"
     >
@@ -137,18 +152,18 @@ function sanitize(text: string) {
           <button
             v-if="(
               !isAddingNewComment
-              && selectedTab !== CommentTab.System)
-              && (internalCommentsAvailable || selectedTab !== CommentTab.Internal
+              && selectedTab !== CommentType.System)
+              && (internalCommentsAvailable || selectedTab !== CommentType.Internal
               )"
             type="button"
             class="btn btn-secondary tab-btn"
             :disabled="isSaving"
             @click="isAddingNewComment = true"
           >
-            Add {{ tabLabels[selectedTab].slice(0, -1) }}
+            Add {{ CommentType[selectedTab] }} Comment
           </button>
           <a
-            v-if="(selectedTab === CommentTab.Internal && internalCommentsAvailable)"
+            v-if="(selectedTab === CommentType.Internal && internalCommentsAvailable)"
             :href="taskUrl(taskKey ?? '#')"
             target="_blank"
             class="btn btn-secondary tab-btn"
@@ -163,14 +178,14 @@ function sanitize(text: string) {
           <div
             v-if="(
               isAddingNewComment
-              && selectedTab !== CommentTab.System)
+              && selectedTab !== CommentType.System)
               && (internalCommentsAvailable
-                || selectedTab !== CommentTab.Internal
+                || selectedTab !== CommentType.Internal
               )"
           >
-            <LabelTextarea v-model="newComment" :label="`New ${tabLabels[selectedTab].slice(0, -1)}`" />
+            <LabelTextarea v-model="newComment" :label="`New ${CommentType[selectedTab]} Comment`" />
             <button type="button" class="btn btn-primary col" @click="handleCommentSave">
-              Save {{ tabLabels[selectedTab].slice(0, -1) }}
+              Save {{ CommentType[selectedTab] }} Comment
             </button>
             <button type="button" class="btn ms-3 btn-secondary col" @click="isAddingNewComment = false">
               Cancel
@@ -178,17 +193,17 @@ function sanitize(text: string) {
           </div>
           <ul class="comments list-unstyled">
             <span
-              v-if="isLoadingInternalComments && selectedTab === CommentTab.Internal"
+              v-if="isLoadingInternalComments && selectedTab === CommentType.Internal"
               class="spinner-border spinner-border-sm d-inline-block ms-3"
               role="status"
             >
               <span class="visually-hidden">Loading...</span>
             </span>
-            <div v-else-if="!internalCommentsAvailable && selectedTab === CommentTab.Internal" class="ms-3">
+            <div v-else-if="!internalCommentsAvailable && selectedTab === CommentType.Internal" class="ms-3">
               Internal comments not available
             </div>
             <div v-else-if="displayedComments.length === 0" class="ms-3">
-              No {{ tabLabels[selectedTab] }}
+              No {{ CommentType[selectedTab].toLowerCase() }} comments
             </div>
             <li
               v-for="(comment, commentIndex) in displayedComments"
@@ -207,7 +222,7 @@ function sanitize(text: string) {
                     'bg-warning text-black': selectedTab === CommentTab.System,
                   }"
                 >
-                  {{ tabLabels[selectedTab].split(' ')[0] }}
+                  {{ CommentType[selectedTab] }}
                 </span>
               </p>
               <p class="osim-flaw-comment" v-html="sanitize(comment.body)" />

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -42,7 +42,7 @@ const newComment = ref('');
 const isAddingNewComment = ref(false);
 
 const emit = defineEmits<{
-  'comment:addPublicComment': [value: any, value: any];
+  'comment:addFlawComment': [value: string, value: string, value: boolean];
   'disableForm': [value: boolean];
 }>();
 
@@ -110,13 +110,13 @@ onMounted(async () => {
 });
 
 async function handleCommentSave() {
-  if (selectedTab.value === CommentTab.Public) {
-    // Public comment save
-    emit('comment:addPublicComment', newComment.value, userStore.userName);
+  if (selectedTab.value === CommentType.Public || selectedTab.value === CommentType.Private) {
+    // Osidb Bugzilla comment save
+    emit('comment:addFlawComment', newComment.value, userStore.userName, CommentType[selectedTab.value] === 'Private');
     isAddingNewComment.value = false;
     newComment.value = '';
-  } else if (selectedTab.value === CommentTab.Internal && props.taskKey) {
-    // Internal comment save
+  } else if (selectedTab.value === CommentType.Internal && props.taskKey) {
+    // Internal Jira comment save
     await addInternalComment(newComment.value)
       .then(() => {
         isAddingNewComment.value = false;

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -218,9 +218,10 @@ function sanitize(text: string) {
                 <span
                   class="badge rounded-pill float-end"
                   :class="{
-                    'bg-info': selectedTab === CommentTab.Public,
-                    'bg-danger': selectedTab === CommentTab.Internal,
-                    'bg-warning text-black': selectedTab === CommentTab.System,
+                    'bg-info': selectedTab === CommentType.Public,
+                    'bg-secondary': selectedTab === CommentType.Private,
+                    'bg-danger': selectedTab === CommentType.Internal,
+                    'bg-warning text-black': selectedTab === CommentType.System,
                   }"
                 >
                   {{ CommentType[selectedTab] }}

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -72,7 +72,7 @@ type CommentFilterFunctions = Record<CommentFilter, (comment: any) => boolean>;
 
 const filterFunctions: CommentFilterFunctions = {
   public: (comment: any) => !comment.is_private,
-  private: (comment: any) => comment.is_private,
+  private: (comment: any) => comment.is_private && comment.creator !== SYSTEM_EMAIL,
   system: (comment: any) => comment.creator === SYSTEM_EMAIL,
 };
 
@@ -87,6 +87,7 @@ function parseOsidbComments(comments: ZodFlawCommentSchemaType[]) {
 }
 
 const publicComments = computed(() => parseOsidbComments(props.comments.filter(filterFunctions.public)));
+const privateComments = computed(() => parseOsidbComments(props.comments.filter(filterFunctions.private)));
 const systemComments = computed(() => parseOsidbComments(props.comments.filter(filterFunctions.system)));
 
 const displayedComments = computed(() => {

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -42,7 +42,7 @@ const newComment = ref('');
 const isAddingNewComment = ref(false);
 
 const emit = defineEmits<{
-  'comment:addFlawComment': [value: string, value: string, value: boolean];
+  'comment:addFlawComment': [comment: string, creator: string, isPrivate: boolean];
   'disableForm': [value: boolean];
 }>();
 

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -66,7 +66,6 @@ const handleTabChange = (index: number) => {
   selectedTab.value = index;
 };
 
-
 type CommentFilter = 'public' | 'private' | 'system';
 type CommentFilterFunctions = Record<CommentFilter, (comment: any) => boolean>;
 
@@ -146,6 +145,7 @@ function sanitize(text: string) {
     <Tabs
       :labels="commentLabels"
       :default="0"
+      :tooltips="Object.values(commentTooltips)"
       @tab-change="handleTabChange"
     >
       <template #header-actions>
@@ -216,10 +216,10 @@ function sanitize(text: string) {
                 {{ comment.author }}
                 - {{ DateTime.fromISO(comment.timestamp, { setZone: true }).toFormat('yyyy-MM-dd hh:mm a ZZZZ') }}
                 <span
-                  class="badge rounded-pill float-end"
+                  class="badge rounded-pill float-end cursor-pointer"
                   :class="{
-                    'bg-info': selectedTab === CommentType.Public,
-                    'bg-secondary': selectedTab === CommentType.Private,
+                    'bg-success': selectedTab === CommentType.Public,
+                    'bg-info': selectedTab === CommentType.Private,
                     'bg-danger': selectedTab === CommentType.Internal,
                     'bg-warning text-black': selectedTab === CommentType.System,
                   }"

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -64,7 +64,7 @@ const {
   recoverAffect,
   updateFlaw,
   createFlaw,
-  addPublicComment,
+  addFlawComment,
   saveReferences,
   deleteReference,
   cancelAddReference,
@@ -507,7 +507,7 @@ const formDisabled = ref(false);
           :taskKey="flaw.task_key"
           :error="errors.comments"
           :isSaving="isSaving"
-          @comment:addPublicComment="addPublicComment"
+          @comment:addFlawComment="addFlawComment"
           @disableForm="(value) => formDisabled = value"
         />
       </div>

--- a/src/components/__tests__/FlawComments.spec.ts
+++ b/src/components/__tests__/FlawComments.spec.ts
@@ -72,10 +72,11 @@ describe('FlawComments', () => {
 
   it('Shows 3 correct tabs on comments section', () => {
     const navLinks = subject.findAll('.nav-link');
-    expect(navLinks.length).toBe(3);
+    expect(navLinks.length).toBe(4);
     expect(navLinks[0].text()).toBe('Public Comments');
-    expect(navLinks[1].text()).toBe('Internal Comments');
-    expect(navLinks[2].text()).toBe('System Comments');
+    expect(navLinks[1].text()).toBe('Private Comments');
+    expect(navLinks[2].text()).toBe('Internal Comments');
+    expect(navLinks[3].text()).toBe('System Comments');
   });
 
   it('Tab navigation changes correctly', async () => {
@@ -83,12 +84,16 @@ describe('FlawComments', () => {
     // Public comments tab (default)
     let activeTab = subject.find('.nav-link.active');
     expect(activeTab.text()).toContain('Public');
-    // Internal comments tab
+    // Private comments tab
     await navLinks[1].trigger('click');
+    activeTab = subject.find('.nav-link.active');
+    expect(activeTab.text()).toContain('Private');
+    // Internal comments tab
+    await navLinks[2].trigger('click');
     activeTab = subject.find('.nav-link.active');
     expect(activeTab.text()).toContain('Internal');
     // System comments tab
-    await navLinks[2].trigger('click');
+    await navLinks[3].trigger('click');
     activeTab = subject.find('.nav-link.active');
     expect(activeTab.text()).toContain('System');
   });
@@ -109,7 +114,7 @@ describe('FlawComments', () => {
     const commentElements = subject.findAll('ul.comments li');
     expect(commentElements.length).toBe(0);
     const noCommentsMessage = subject.find('ul.comments div');
-    expect(noCommentsMessage.text()).toBe('No Public Comments');
+    expect(noCommentsMessage.text()).toBe('No public comments');
   });
 
   it('Correctly display public comments', () => {
@@ -140,7 +145,7 @@ describe('FlawComments', () => {
 
   it('Show Jira link button on internal comments', async () => {
     const navLinks = subject.findAll('.nav-link');
-    await navLinks[1].trigger('click');
+    await navLinks[2].trigger('click');
     const actionButtons = subject.findAll('.tab-actions > *');
     expect(actionButtons.length).toBe(2);
     expect(actionButtons[0].text()).toBe('Add Internal Comment');
@@ -149,7 +154,7 @@ describe('FlawComments', () => {
 
   it('Correctly display internal comments', async () => {
     const navLinks = subject.findAll('.nav-link');
-    await navLinks[1].trigger('click');
+    await navLinks[2].trigger('click');
     const commentElements = subject.findAll('ul.comments li');
     expect(commentElements.length).toBe(2);
     // First public comment checks
@@ -166,18 +171,18 @@ describe('FlawComments', () => {
 
   it('Don\'Show any action button on system comments', async () => {
     const navLinks = subject.findAll('.nav-link');
-    await navLinks[2].trigger('click');
+    await navLinks[3].trigger('click');
     const actionButtons = subject.findAll('.tab-actions > *');
     expect(actionButtons.length).toBe(0);
   });
 
   it('Show message if no system comments', async () => {
     const navLinks = subject.findAll('.nav-link');
-    await navLinks[2].trigger('click');
+    await navLinks[3].trigger('click');
     const commentElements = subject.findAll('ul.comments li');
     expect(commentElements.length).toBe(0);
     const noCommentsMessage = subject.find('ul.comments div');
-    expect(noCommentsMessage.text()).toBe('No System Comments');
+    expect(noCommentsMessage.text()).toBe('No system comments');
   });
 
   it('Correctly display system comments', async () => {
@@ -193,7 +198,7 @@ describe('FlawComments', () => {
     });
 
     const navLinks = subject.findAll('.nav-link');
-    await navLinks[2].trigger('click');
+    await navLinks[3].trigger('click');
     const commentElements = subject.findAll('ul.comments li');
     expect(commentElements.length).toBe(2);
     // First system comment checks

--- a/src/components/widgets/Tabs.vue
+++ b/src/components/widgets/Tabs.vue
@@ -30,8 +30,6 @@ const selectTab = (index: number) => {
           class="nav-link"
           :class="{ 'active': activeTabIndex === index }"
           :disabled="disabled?.includes(index)"
-          data-bs-toggle="tooltip"
-          data-bs-placement="auto"
           :title="tooltips[index]"
           @click="selectTab(index)"
         >

--- a/src/components/widgets/Tabs.vue
+++ b/src/components/widgets/Tabs.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   labels: string[],
-  default?: number
-  disabled?: number[]
-}>();
+  default?: number,
+  disabled?: number[],
+  tooltips?: string[],
+}>(), {
+  default: 0,
+  disabled: () => [],
+  tooltips: () => [],
+});
 
 const emit = defineEmits(['tab-change']);
 const activeTabIndex = ref(props.default ?? 0);
@@ -25,6 +30,9 @@ const selectTab = (index: number) => {
           class="nav-link"
           :class="{ 'active': activeTabIndex === index }"
           :disabled="disabled?.includes(index)"
+          data-bs-toggle="tooltip"
+          data-bs-placement="auto"
+          :title="tooltips[index]"
           @click="selectTab(index)"
         >
           {{ label }}

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -8,7 +8,7 @@ import { createSuccessHandler, createCatchHandler } from './service-helpers';
 import {
   getFlawBugzillaLink,
   getFlawOsimLink,
-  postFlawPublicComment,
+  postFlawComment,
   postFlaw,
   putFlaw,
 } from '@/services/FlawService';
@@ -152,10 +152,11 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     isSaving.value = false;
   }
 
-  function addPublicComment(comment: string, creator: string) {
+  function addFlawComment(comment: string, creator: string, isPrivate: boolean) {
     isSaving.value = true;
-    postFlawPublicComment(flaw.value.uuid, comment, creator, flaw.value.embargoed)
-      .then(createSuccessHandler({ title: 'Success!', body: 'Public comment saved.' }))
+    const type = isPrivate ? 'Private' : 'Public';
+    postFlawComment(flaw.value.uuid, comment, creator, isPrivate, flaw.value.embargoed)
+      .then(createSuccessHandler({ title: 'Success!', body: `${type} comment saved.` }))
       .then(afterSaveSuccess)
       .catch(createCatchHandler('Error saving public comment'))
       .finally(() => isSaving.value = false);
@@ -175,7 +176,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     flawIncidentStates,
     osimLink,
     bugzillaLink,
-    addPublicComment,
+    addFlawComment,
     createFlaw,
     updateFlaw,
     afterSaveSuccess,

--- a/src/composables/useInternalComments.ts
+++ b/src/composables/useInternalComments.ts
@@ -20,6 +20,12 @@ export function useInternalComments(taskKey: string) {
     isLoadingInternalComments.value = true;
     internalComments.value = [];
 
+    if (!taskKey) {
+      available.value = false;
+      isLoadingInternalComments.value = false;
+      return;
+    }
+
     getJiraComments(taskKey)
       .then((res) => {
         if (res.response.ok) {

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -134,14 +134,16 @@ export async function postFlawCvssScores(flawId: string, cvssScoreObject: unknow
     .catch(createCatchHandler('CVSS scores Update Error'));
 }
 
-export async function postFlawPublicComment(uuid: string, comment: string, creator: string, embargoed: boolean) {
+export async function postFlawComment(
+  uuid: string, comment: string, creator: string, isPrivate: boolean, embargoed: boolean
+) {
   return osidbFetch({
     method: 'post',
     url: `/osidb/api/v1/flaws/${uuid}/comments`,
     data: {
       text: comment,
       creator: creator,
-      type: 'BUGZILLA',
+      is_private: isPrivate,
       embargoed,
     },
   }).then((response) => response.data);


### PR DESCRIPTION
# OSIDB-2912 Add ability to leave a private comment on the flaw bug

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Adds support for private comments on Bugzilla.

## Changes:

- Provides Private comment enum type
- Fix osidb comment filters
- Adapt service functions to handle private comments
- Update comment badges to include new private comment style
- Adds tooltips on comment tabs to clarify to the users each comment type scope
- Fix edge case where Jira request was being performed on flaws without task_key
- Adapt & extend comments test suite

## Considerations:

- There is a PR coming to simplify all comments stuff into a single `FlawCommentsModel`

## Demo:

https://github.com/RedHatProductSecurity/osim/assets/29104825/a152d9ec-da30-42a8-b5a7-008c15f0e69c