### PR TITLE
Fix OSIDB-2827: Flaw list text overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 * Flaws without a Jira task cannot be updated (`OSIDB-2960`)
 * Remove Trackers section on Flaw Edit (`OSIDB-2954`)
+* Owner - Status text overlap on flaw list (`OSIDB-2827`)
 
 ## [2024.6.1]
 ### Added

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -178,7 +178,15 @@ const nameForOption = (fieldName: string) => {
         <span> Loading Flaws&hellip; </span>
       </div>
       <span
-        v-else-if="issues.length"
+        v-if="isLoading"
+        class="spinner-border spinner-border-sm d-inline-block ms-3"
+        role="status"
+      >
+        <span class="visually-hidden">Loading...</span>
+      </span>
+      <span v-if="isLoading"> Loading Flaws&hellip; </span>
+      <span
+        v-if="issues.length"
         class="float-end"
         :class="{'text-secondary': isLoading}"
       > Loaded {{ issues.length }} of {{ total }}</span>
@@ -301,30 +309,26 @@ const nameForOption = (fieldName: string) => {
       padding: 1ch;
 
       &:nth-of-type(1) {
-        width: 2.5%;
+        width: 20%;
       }
 
       &:nth-of-type(2) {
-        width: 17.5%;
-      }
-
-      &:nth-of-type(3) {
         width: 8%;
       }
 
-      &:nth-of-type(4) {
+      &:nth-of-type(3) {
         width: 9.5%;
       }
 
-      &:nth-of-type(5) {
+      &:nth-of-type(4) {
         width: 27.5%;
       }
 
-      &:nth-of-type(6) {
+      &:nth-of-type(5) {
         width: 17.5%;
       }
 
-      &:nth-of-type(7) {
+      &:nth-of-type(6) {
         width: 17.5%;
       }
     }

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -178,15 +178,7 @@ const nameForOption = (fieldName: string) => {
         <span> Loading Flaws&hellip; </span>
       </div>
       <span
-        v-if="isLoading"
-        class="spinner-border spinner-border-sm d-inline-block ms-3"
-        role="status"
-      >
-        <span class="visually-hidden">Loading...</span>
-      </span>
-      <span v-if="isLoading"> Loading Flaws&hellip; </span>
-      <span
-        v-if="issues.length"
+        v-else-if="issues.length"
         class="float-end"
         :class="{'text-secondary': isLoading}"
       > Loaded {{ issues.length }} of {{ total }}</span>

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -158,7 +158,7 @@ const nameForOption = (fieldName: string) => {
 </script>
 
 <template>
-  <div class="osim-content container osim-issue-queue">
+  <div class="osim-content container-fluid osim-issue-queue">
     <div class="osim-incident-filter">
       <LabelCheckbox v-model="isMyIssuesSelected" label="My Issues" class="d-inline-block" />
       <LabelCheckbox v-model="isOpenIssuesSelected" label="Open Issues" class="d-inline-block" />
@@ -168,7 +168,15 @@ const nameForOption = (fieldName: string) => {
         label="Default Filter"
         class="d-inline-block"
       />
-
+      <div v-if="isLoading" class="d-inline-block float-end">
+        <span
+          class="spinner-border spinner-border-sm"
+          role="status"
+        >
+          <span class="visually-hidden">Loading...</span>
+        </span>
+        <span> Loading Flaws&hellip; </span>
+      </div>
       <span
         v-if="isLoading"
         class="spinner-border spinner-border-sm d-inline-block ms-3"
@@ -257,9 +265,10 @@ const nameForOption = (fieldName: string) => {
 
 .osim-issue-queue {
   font-family: 'Red Hat Mono', monospace;
+  width: 97.5%;
+  margin-top: 0.75rem;
 
   // tbody
-
   div.osim-incident-list {
     display: block;
     max-height: calc(100vh - 164px);
@@ -300,51 +309,31 @@ const nameForOption = (fieldName: string) => {
       padding: 1ch;
 
       &:nth-of-type(1) {
-        // min-width: 15ch;
-        // max-width: 15ch;
-        // min-width: 12.5%;
-        // max-width: 12.5%;
-        width: 12.5%;
+        width: 2.5%;
       }
 
       &:nth-of-type(2) {
-        // min-width: 11ch;
-        // max-width: 11ch;
-        // min-width: 8.5%;
-        // max-width: 8.5%;
-        width: 8.5%;
+        width: 17.5%;
       }
 
       &:nth-of-type(3) {
-        // min-width: 12ch;
-        // max-width: 12ch;
-        // min-width: 9.5%;
-        // max-width: 9.5%;
-        width: 9.5%;
+        width: 8%;
       }
 
       &:nth-of-type(4) {
-        // min-width: 12ch;
-        // max-width: 12ch;
-        // min-width: 32%;
-        // max-width: 32%;
-        width: 42.5%;
+        width: 9.5%;
       }
 
       &:nth-of-type(5) {
-        // min-width: 10ch;
-        // max-width: 10ch;
-        // min-width: 8.5%;
-        // max-width: 8.5%;
-        width: 8.5%;
+        width: 27.5%;
       }
 
       &:nth-of-type(6) {
-        // min-width: 20ch;
-        // max-width: 20ch;
-        // min-width: 17%;
-        // max-width: 17%;
-        width: 20%;
+        width: 17.5%;
+      }
+
+      &:nth-of-type(7) {
+        width: 17.5%;
       }
     }
 

--- a/src/components/IssueQueueItem.vue
+++ b/src/components/IssueQueueItem.vue
@@ -42,7 +42,7 @@ const hasBadges = computed(() => isEmbargoed.value);
   </tr>
   <tr v-if="hasBadges" class="osim-badge-lane" :class="$attrs.class">
     <td colspan="100%" class="pt-0">
-      <div class="ps-4 ms-1">
+      <div class="ps-4 ms-4">
         <span v-if="isEmbargoed">
           <span class="badge rounded-pill text-bg-danger">Embargoed</span>
         </span>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -56,7 +56,7 @@ function onSearch(query: string) {
 
 <template>
   <nav ref="elHeader" class="osim-navbar navbar navbar-expand navbar-dark">
-    <div class="container">
+    <div class="container-fluid">
       <RouterLink to="/" class="osim-home-link">
         <!--<RedHatLogo class="osim-logo"/>-->
         <img :src="RedHatIconSvg" alt="Red Hat Logo" class="osim-logo" />

--- a/src/components/__tests__/IssueQueue.spec.ts
+++ b/src/components/__tests__/IssueQueue.spec.ts
@@ -236,7 +236,7 @@ describe('IssueQueue', () => {
     expect(countEL.text()).toBe('Loaded 50 of 100');
   });
 
-  it('should render total count when loading', async () => {
+  it('should render loader when loading flaws', async () => {
     const pinia = createTestingPinia({
       createSpy: vitest.fn,
       stubActions: false,
@@ -254,9 +254,8 @@ describe('IssueQueue', () => {
     });
     const filterEl = wrapper.find('div.osim-incident-filter');
     expect(filterEl.exists()).toBeTruthy();
-    const countEL = filterEl.find('span.float-end.text-secondary');
-    expect(countEL.exists()).toBeTruthy();
-    expect(countEL.text()).toBe('Loaded 25 of 100');
+    const spinner = filterEl.find('div.float-end span.spinner-border');
+    expect(spinner.exists()).toBeTruthy();
   });
 
   it('shouldn\'t render useDefault filter button', async () => {


### PR DESCRIPTION
# OSIDB-2827 Flaw list text overlap

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Fixes text overlaps on flaw queue when status value is `PRE_SECONDARY_ASSESSMENT` by making the table larger in width.
Additionally adds a couple of minor UI/UX enhancements that were considered after this change.

## Changes:

- Increases flaw queue table's width
- Adjust spacing on navbar to for aesthetics
- Make loading/loaded flaws indicator act like a single element
- Removes unused code

## Demo:
### Width adjustments:
- Before:
![OSIM-FlawQueue-Before](https://github.com/RedHatProductSecurity/osim/assets/29104825/9aad5c5f-d776-438c-a91e-2c0e5e4542e9)

- After:
![OSIM-FlawQueue-After](https://github.com/RedHatProductSecurity/osim/assets/29104825/d11a424f-a6db-4997-958f-45d268864cd4)

### Loading/Loaded:
- Before:
[OSIM-LoadingIndicator-Before.webm](https://github.com/RedHatProductSecurity/osim/assets/29104825/bff773cf-8e64-4893-accb-59089775a235)

- After:
[OSIM-LoadingIndicator-After.webm](https://github.com/RedHatProductSecurity/osim/assets/29104825/3ffc88fb-81b8-40aa-9203-0ff421b5e626)

## Considerations:

- Loading/loaded flaws indicator is covered if there are some alerts, may be we may consider relocating
- There is a to-do task to remove whitespaces on the application (OSIDB-2005) the idea is to adjust the width of other views (like flaw form or advanced seatch) on that task so all the UI has a consistent layout within different views
- I think it would be nice to have embargoed badge on an individual table column, for better visibility and equal height of all rows. Also probably applying a truncate on long titles.