### PR TITLE
OSIDB-2948: Update FlawEditView.vue with key binding for flaw updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 * Support private Bugzilla comments (`OSIDB-2912`)
 * Refresh flaw after cvss scores on create (`OSIDB-2981`)
+* Flaw form not beign responsive after save (`OSIDB-2948`)
 
 ## [2024.6.0]
 ### Added

--- a/src/views/FlawEditView.vue
+++ b/src/views/FlawEditView.vue
@@ -43,6 +43,7 @@ function refreshFlaw() {
       v-if="flaw"
       v-model:flaw="flaw"
       mode="edit"
+      :key="`${flaw.uuid}-${flaw.updated_dt}`"
       @refresh:flaw="refreshFlaw"
     />
     <div v-if="errorLoadingFlaw">


### PR DESCRIPTION
# [OSIDB-2948]: Update FlawEditView.vue with key binding for flaw updates

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [ ] Test cases added/updated
- [x] Jira ticket updated

## Summary:

`key` property is needed for vue to detect reactive changes and update components properly, without it, only active references are updated.

Inside `useFlawAffectsModel` we are looping over the flaw affects and adding a `watch` to detect changes
https://github.com/RedHatProductSecurity/osim/blob/8a9a0dc28145cc6142647b4a600061b4730371ce/src/composables/useFlawAffectsModel.ts#L151

After the flaw is updated, the event `refreshFlaw` is emitted, this fetches the latest flaw version from OSIDB and updates the `flaw.value` reference. https://github.com/RedHatProductSecurity/osim/blob/8a9a0dc28145cc6142647b4a600061b4730371ce/src/views/FlawEditView.vue#L21-L25

Because the loop in `useFlawAffectsModel` is not inside a `watch` that detects changes to the flaw `reference` its only called once, and after the flaw is updated, the original `flaw.value.affects` is disposed, meaning that the `trackAffectChanges` function is not run on changes any more.

Having this `key` prop makes the form re-render when the flaw changes, updating every `ref` and `compute` variable, reducing the possible cases of reactivity missmatch