### PR TITLE
OSIDB-2946: Unmodified affects are updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Support private Bugzilla comments (`OSIDB-2912`)
 * Refresh flaw after cvss scores on create (`OSIDB-2981`)
 * Flaw form not beign responsive after save (`OSIDB-2948`)
+* Don't update unmodified affects (`OSIDB-2946`)
 
 ## [2024.6.0]
 ### Added

--- a/src/components/AffectedOfferingForm.vue
+++ b/src/components/AffectedOfferingForm.vue
@@ -10,7 +10,6 @@ import {
   affectImpacts,
   affectResolutions,
   type ZodAffectType,
-  type ZodAffectCVSSType,
 } from '@/types/zodAffect';
 
 const { width: screenWidth } = useWindowSize();
@@ -24,29 +23,6 @@ defineProps<{
 const isScreenSortaSmall = computed(() => screenWidth.value < 950);
 
 const modelValue = defineModel<ZodAffectType>();
-
-
-function getCvssData(issuer: string, version: string) {
-  return modelValue.value?.cvss_scores.find(
-    (assessment) => assessment.issuer === issuer && assessment.cvss_version === version
-  );
-}
-
-if (!getCvssData('RH', 'V3')) {
-  modelValue.value?.cvss_scores?.push(
-    {
-      vector: null,
-      uuid: null,
-      issuer: 'RH',
-      cvss_version: 'V3',
-      comment: 'hardcoded comment', // TODO: remove this line when the comment field is added to the UI
-      created_dt: null,
-      score: null,
-      embargoed: modelValue.value.embargoed,
-      alerts: [],
-    } as ZodAffectCVSSType
-  );
-}
 
 const affectCvss3Vector = computed(
   () => modelValue.value?.cvss_scores.find(({ issuer, cvss_version }) => issuer === 'RH' && cvss_version === 'V3')


### PR DESCRIPTION
# OSIDB-2946: Unmodified affects are updated

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [ ] Test cases added/updated
- [x] Jira ticket updated

## Summary:

We were adding this default value to any affect that didn't have a `cvss_score`, triggering the `trackAffectChanges` hook and updating all the affects when saving the flaw. I've done some testing and removing it doesn't seems to break anything but I may be missing something, already discussed with @superbuggy 