### PR TITLE
OSIDB-2883: Enable jira task creation on legacy flaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # OSIM Changelog
 
 ## [Unreleased]
+### Added
+* Create Jira task on demand for legacy flaws (`OSIDB-2883`)
+
 ### Changed
 * Temporary disable private comments creation (`OSIDB-3002`)
 * Enable private comments creation again (`OSIDB-3012`)

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -55,6 +55,8 @@ const {
   rhCvss3String,
   highlightedNvdCvss3String,
   shouldDisplayEmailNistForm,
+  shouldCreateJiraTask,
+  toggleShouldCreateJiraTask,
   addBlankReference,
   addBlankAcknowledgment,
   addBlankAffect,
@@ -116,6 +118,7 @@ const showMitigation = ref(flaw.value.mitigation && flaw.value.mitigation.trim()
 const onReset = () => {
   // is deepCopyFromRaw needed?
   flaw.value = deepCopyFromRaw(initialFlaw);
+  shouldCreateJiraTask.value = false;
 };
 
 const onUnembargoed = (isEmbargoed: boolean) => {
@@ -354,7 +357,9 @@ const createdDate = computed(() => {
               v-if="mode === 'edit'"
               :classification="flaw.classification"
               :flawId="flaw.uuid"
+              :shouldCreateJiraTask
               @refresh:flaw="emit('refresh:flaw')"
+              @create:jiraTask="toggleShouldCreateJiraTask()"
             />
             <LabelSelect
               v-model="flaw.major_incident_state"

--- a/src/components/IssueFieldState.vue
+++ b/src/components/IssueFieldState.vue
@@ -21,9 +21,10 @@ type WorkflowPhases = (typeof workflowStates)[keyof typeof workflowStates];
 
 const DONE_STATE = workflowStates.Done as string;
 const REJECTED_STATE = workflowStates.Rejected as string;
+const EMPTY_STATE = workflowStates.Empty as string;
 
 const shouldShowWorkflowButtons = computed(
-  () => ![DONE_STATE, REJECTED_STATE].includes(props.classification.state),
+  () => ![DONE_STATE, REJECTED_STATE,EMPTY_STATE].includes(props.classification.state),
 );
 
 function openModal() {
@@ -108,6 +109,10 @@ function nextPhase(workflowState: WorkflowPhases) {
 
   .osim-workflow-state-display {
     margin-bottom: 0 !important;
+  }
+
+  span.form-control {
+    min-height: 38px;
   }
 }
 </style>

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -25,6 +25,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
   const isSaving = ref(false);
   const { addToast } = useToastStore();
   const flaw = ref<ZodFlawType>(forFlaw);
+  const shouldCreateJiraTask = ref(false);
   const cvssScoresModel = useFlawCvssScores(flaw);
   const flawAffectsModel = useFlawAffectsModel(flaw);
   const flawAttributionsModel = useFlawAttributionsModel(flaw, isSaving, afterSaveSuccess);
@@ -126,7 +127,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
       queue.push(saveCvssScores);
     }
 
-    queue.push(putFlaw.bind(null, flaw.value.uuid, validatedFlaw.data));
+    queue.push(putFlaw.bind(null, flaw.value.uuid, validatedFlaw.data, shouldCreateJiraTask.value));
 
     try {
       await execute(...queue);
@@ -156,6 +157,10 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
 
   const errors = computed(() => flawErrors(flaw.value));
 
+  const toggleShouldCreateJiraTask = () => {
+    shouldCreateJiraTask.value = !shouldCreateJiraTask.value;
+  };
+
   return {
     flaw,
     isSaving,
@@ -167,6 +172,8 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     flawIncidentStates,
     osimLink,
     bugzillaLink,
+    shouldCreateJiraTask,
+    toggleShouldCreateJiraTask,
     addFlawComment,
     createFlaw,
     updateFlaw,

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -73,11 +73,14 @@ export async function getUpdatedDt(url: string): Promise<string> {
   }).then((response) => response.data.updated_dt);
 }
 
-export async function putFlaw(uuid: string, flawObject: ZodFlawType) {
+export async function putFlaw(uuid: string, flawObject: ZodFlawType, createJiraTask = false) {
   return osidbFetch({
     method: 'put',
     url: `/osidb/api/v1/flaws/${uuid}`,
     data: flawObject,
+    params: {
+      ...(createJiraTask && { create_jira_task: true }),
+    },
   }, { beforeFetch })
     .then((response) => response.data)
     .then(createSuccessHandler({ title: 'Success!', body: 'Flaw saved' }))

--- a/src/services/OsidbAuthService.ts
+++ b/src/services/OsidbAuthService.ts
@@ -24,7 +24,7 @@ export type OsidbPutPostFetchOptions = {
   url: string;
   method: 'POST' | 'PUT' | 'post' | 'put';
   data?: Record<string, any>;
-  params?: never;
+  params?: Record<string, any>;
 };
 
 export type OsidbDeleteFetchOptions = {


### PR DESCRIPTION
# OSIDB-2883: Enable jira task creation on legacy flaw

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [ ] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Adds a button to create and associate a jira task to a flaw that does not have one

## Changes:

* Handle the new  `EMPTY` state when a Flaw does not have a Jira task associated
* Hide workflow buttons on `EMPTY` state
* Add a new `Create Jira Task` button.

---
OSIDB Added a boolean query param `create_jira_task` to the update flaw endpoint that forces the creation in https://github.com/RedHatProductSecurity/osidb/pull/603


https://github.com/RedHatProductSecurity/osim/assets/4268580/15b2ca5e-0b21-41cf-a6c2-2a10f331aa58


