### PR TITLE
Style OSIDB-2005: UI Space optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 * Added timezone to Public Date field (UTC) (`OSIDB-2790`)
 * Don't collapse affected modules automatically after deleting a component (only occurred when no other components were expanded) (`OSIDB-2757`)
 * Add emptiness for CVSSv3, CWE ID, Owner, Description, Statement, Mitigation on Advanced Search (`OSIDB-2816`)
+* Make text area descriptions layout static (always visible) (`OSIDB-2005`)
 
 ### Fixed
 * The session is now shared across tabs
@@ -108,6 +109,8 @@
 * Removed Flaw.meta usage (`OSIDB-2801`)
 * Removed cvss2 and cvss3 fields from Flaw and Affects (`OSIDB-2779`)
 * Removed validation on empty references description (`OSIDB-2846`)
+* Remove extra whitespace and optimize UI spacing (`OSIDB-2005`)
+* Remove buttons to show/hide text area descriptions (they are always visible now) (`OSIDB-2005`)
 
 ## [Unreleased] (TODO update for 2024.1.1 and 2024.2.0 releases)
 

--- a/src/components/AffectExpandableForm.vue
+++ b/src/components/AffectExpandableForm.vue
@@ -53,7 +53,7 @@ const resolutionLabel = computed(() => {
 </script>
 
 <template>
-  <LabelCollapsible :isExpanded="isExpanded" class="mt-2" :class="{'alert alert-warning': isAffectNew}">
+  <LabelCollapsible :isExpanded="isExpanded" class="mt-2 mb-0" :class="{'alert alert-warning': isAffectNew}">
     <template #label>
       <label class="mx-2 form-label">
         {{ `${affect.ps_component}` }}

--- a/src/components/AffectedOfferings.vue
+++ b/src/components/AffectedOfferings.vue
@@ -121,7 +121,7 @@ defineExpose({ togglePsModuleExpansion, togglePsComponentExpansion, isExpanded }
 </script>
 
 <template>
-  <div v-if="theAffects" class="osim-affects">
+  <div v-if="theAffects" class="osim-affects my-2">
     <h4>Affected Offerings</h4>
     <AffectsTrackers
       v-show="shouldShowTrackers"
@@ -129,7 +129,7 @@ defineExpose({ togglePsModuleExpansion, togglePsComponentExpansion, isExpanded }
       :theAffects="affectsNotBeingDeleted"
       @affects-trackers:hide="shouldShowTrackers = false"
     />
-    <div class="mb-4">
+    <div class="my-2 py-2">
       <button
         v-if="isAnythingCollapsed"
         type="button"
@@ -149,7 +149,7 @@ defineExpose({ togglePsModuleExpansion, togglePsComponentExpansion, isExpanded }
       <button
         v-show="!shouldShowTrackers"
         type="button"
-        class="button ms-3 btn btn-sm btn-black text-white"
+        class="button btn btn-sm btn-black text-white"
         @click="shouldShowTrackers = !shouldShowTrackers"
       >
         <!-- <i class="bi bi-journal-plus"></i> -->
@@ -161,7 +161,7 @@ defineExpose({ togglePsModuleExpansion, togglePsComponentExpansion, isExpanded }
     <div v-for="(moduleName) in affectedModules" :key="moduleName">
       <LabelCollapsible
         :isExpanded="expandedModules[moduleName] ?? false"
-        class="mb-3"
+        class="mb-1"
         @setExpanded="togglePsModuleExpansion(moduleName)"
       >
         <template #label>
@@ -209,7 +209,7 @@ defineExpose({ togglePsModuleExpansion, togglePsComponentExpansion, isExpanded }
         </div>
       </LabelCollapsible>
     </div>
-    <button type="button" class="btn btn-secondary mt-3" @click.prevent="emit('add-blank-affect')">
+    <button type="button" class="btn btn-secondary mt-2" @click.prevent="emit('add-blank-affect')">
       Add New Affect
     </button>
     <div v-if="affectsToDelete.length" class="mt-3 row">

--- a/src/components/AffectsTrackers.vue
+++ b/src/components/AffectsTrackers.vue
@@ -25,7 +25,7 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div class="mt-3 mb-5 osim-affect-trackers-container py-1 px-3">
+  <div class="mt-3 mb-2 osim-affect-trackers-container py-1 px-3">
     <h4 class="mb-2">
       Manage Trackers
       <button

--- a/src/components/CvssCalculator.vue
+++ b/src/components/CvssCalculator.vue
@@ -114,7 +114,7 @@ function handlePaste(e: ClipboardEvent) {
   >
     <div class="osim-input vector-row">
       <label class="label-group row">
-        <span class="form-label col-2">
+        <span class="form-label col-3">
           CVSSv3
         </span>
         <div class="input-wrapper col">
@@ -180,7 +180,7 @@ function handlePaste(e: ClipboardEvent) {
         class="osim-input"
         mx-0nd="$attrs"
       >
-        <div class="px-3 py-2">
+        <div class="ps-4 mx-auto">
           <div
             v-for="(row, rowIndex) in calculatorButtons.rows"
             :key="rowIndex"
@@ -241,7 +241,6 @@ function handlePaste(e: ClipboardEvent) {
 .osim-input {
   display: inline-flex;
   width: 100%;
-  margin-bottom: 15px;
 
   .label-group {
     width: 100%;
@@ -250,6 +249,10 @@ function handlePaste(e: ClipboardEvent) {
     margin-inline: 0;
     padding-left: 0.25rem;
     height: 100%;
+
+    .form-label {
+      min-width: 14.375rem;
+    }
 
     .input-wrapper {
       z-index: 1;
@@ -264,7 +267,7 @@ function handlePaste(e: ClipboardEvent) {
     .vector-input {
       height: 100%;
       border-radius: 0;
-      padding-left: 30px;
+      padding-left: 0.75rem;
     }
 
     .vector-input.alert {

--- a/src/components/CvssCalculator.vue
+++ b/src/components/CvssCalculator.vue
@@ -112,7 +112,7 @@ function handlePaste(e: ClipboardEvent) {
     @focus="onInputFocus"
     @paste="handlePaste"
   >
-    <div class="osim-input vector-row">
+    <div class="osim-input vector-row mb-2">
       <label class="label-group row">
         <span class="form-label col-3">
           CVSSv3

--- a/src/components/CvssExplainForm.vue
+++ b/src/components/CvssExplainForm.vue
@@ -14,12 +14,12 @@ const rhCvss = computed(() => modelValue.value?.cvss_scores
   <LabelCollapsible
     v-if="rhCvss > -1"
     label="Explain non-obvious CVSSv3 score metrics"
-    class="mb-3 cvss-score-mismatch"
+    class="ms-2 cvss-score-mismatch"
   >
     <textarea
       v-model="modelValue.cvss_scores[rhCvss].comment"
-      rows="5"
-      class="form-control col-9 d-inline-block"
+      rows="3"
+      class="form-control col-9 d-inline-block mb-3"
       placeholder="CVSS Score Explanation"
     />
   </LabelCollapsible>

--- a/src/components/CvssNISTForm.vue
+++ b/src/components/CvssNISTForm.vue
@@ -55,8 +55,8 @@ function openMailto() {
 </script>
 
 <template>
-  <div class="osim-cve-nist-button">
-    <button type="button" class="btn btn-secondary" @click="openModal">
+  <div class="osim-cve-nist-form">
+    <button type="button" class="osim-cve-email btn btn-secondary" @click="openModal">
       Email NIST
     </button>
 
@@ -101,7 +101,13 @@ function openMailto() {
 </template>
 
 <style scoped>
-.osim-cve-nist-button :deep(.modal-dialog) {
+.osim-cve-nist-form :deep(.modal-dialog) {
   max-width: 80ch;
 }
+
+.osim-cve-email {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
 </style>

--- a/src/components/FlawAlert.vue
+++ b/src/components/FlawAlert.vue
@@ -35,7 +35,7 @@ function scrollToComponent(parent_uuid: string) {
 <template>
   <div
     v-if="alert"
-    class="alert my-1"
+    class="alert my-1 p-2"
     :class="{'alert-warning': isWarning, 'alert-danger': isError}"
     role="alert"
   >
@@ -46,20 +46,16 @@ function scrollToComponent(parent_uuid: string) {
           {{ alert?.alert_type.charAt(0) + alert?.alert_type.slice(1).toLowerCase() + " " + alert?.name }}
         </span>
       </template>
-      <div class="my-2 ms-1 pt-1 px-2 container text-left">
-        <div class="row">
-          <strong>Description</strong>
+      <div class="ms-1 py-2 container text-left">
+        <div class="osim-flaw-alert-info">
+          <strong>Description:</strong>
+          <span>{{ ` ${alert.description}` }}</span>
         </div>
-        <div class="row mx-auto mt-1">
-          {{ alert.description }}
+        <div class="osim-flaw-alert-info">
+          <strong>How To Resolve:</strong>
+          <span>{{ alert?.resolution_steps || " No resolution steps are defined." }}</span>
         </div>
-        <div class="row mt-3">
-          <strong>How To Resolve</strong>
-        </div>
-        <div class="row mx-auto mt-1">
-          {{ alert?.resolution_steps || "No resolution steps are defined." }}
-        </div>
-        <div class="row mt-3">
+        <div class="row mt-2">
           <div class="col">
             <button
               type="button"
@@ -75,3 +71,11 @@ function scrollToComponent(parent_uuid: string) {
     </LabelCollapsible>
   </div>
 </template>
+
+<style scoped lang="scss">
+.osim-flaw-alert-info {
+  strong, span {
+    font-size: 14px;
+  }
+}
+</style>

--- a/src/components/FlawAlert.vue
+++ b/src/components/FlawAlert.vue
@@ -46,7 +46,7 @@ function scrollToComponent(parent_uuid: string) {
           {{ alert?.alert_type.charAt(0) + alert?.alert_type.slice(1).toLowerCase() + " " + alert?.name }}
         </span>
       </template>
-      <div class="my-2 pt-1 px-2 container text-left">
+      <div class="my-2 ms-1 pt-1 px-2 container text-left">
         <div class="row">
           <strong>Description</strong>
         </div>

--- a/src/components/FlawAlertsList.vue
+++ b/src/components/FlawAlertsList.vue
@@ -41,7 +41,7 @@ const alertsExpanded = ref(false);
     @setExpanded="alertsExpanded = !alertsExpanded"
   >
     <template #label>
-      <label class="mx-2 form-label">
+      <label class="mx-2 mb-0 form-label">
         Alerts:
       </label>
       <span v-if="!alertsExpanded">

--- a/src/components/FlawAlertsSection.vue
+++ b/src/components/FlawAlertsSection.vue
@@ -30,7 +30,7 @@ const emitExpandFocusedComponent = (parent_uuid: string) => {
   >
     <template #label>
       <span>
-        <label class="mx-2 mb-2">
+        <label class="mx-2">
           {{ props.sectionName + ":" }}
         </label>
         <span v-if="!isExpanded">

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -140,7 +140,7 @@ function sanitize(text: string) {
 </script>
 
 <template>
-  <section class="osim-comments">
+  <section class="osim-comments my-2">
     <h4 class="mb-4">Comments</h4>
     <Tabs
       :labels="commentLabels"

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -246,8 +246,8 @@ const createdDate = computed(() => {
 
 <template>
   <form class="osim-flaw-form" :class="{'osim-disabled': isSaving || formDisabled}" @submit.prevent="onSubmit">
-    <div class="osim-content container-lg">
-      <div class="osim-flaw-form-section">
+    <div class="osim-content container-fluid">
+      <div class="row osim-flaw-form-section" :class="{ 'pt-5': mode === 'create'}">
         <div v-if="flaw.meta_attr?.bz_id" class="col-12 mb-2 text-end">
           <a
             :href="bugzillaLink"
@@ -567,7 +567,9 @@ form.osim-flaw-form :deep(*) {
   }
 }
 
-
+div.osim-content {
+  width: 97.5%;
+}
 
 :deep(.osim-input) {
   .row {

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -511,17 +511,19 @@ const createdDate = computed(() => {
           />
         </div>
       </div>
-      <AffectedOfferings
-        v-if="mode === 'edit'"
-        ref="affectedOfferingsComp"
-        :theAffects="flaw.affects"
-        :affectsToDelete="affectsToDelete"
-        :error="errors.affects"
-        :flawId="flaw.uuid"
-        @affect:recover="(affect) => recoverAffect(flaw.affects.indexOf(affect))"
-        @affect:remove="(affect) => removeAffect(flaw.affects.indexOf(affect))"
-        @add-blank-affect="addBlankAffect"
-      />
+      <div class="osim-flaw-form-section">
+        <AffectedOfferings
+          v-if="mode === 'edit'"
+          ref="affectedOfferingsComp"
+          :theAffects="flaw.affects"
+          :affectsToDelete="affectsToDelete"
+          :error="errors.affects"
+          :flawId="flaw.uuid"
+          @affect:recover="(affect) => recoverAffect(flaw.affects.indexOf(affect))"
+          @affect:remove="(affect) => removeAffect(flaw.affects.indexOf(affect))"
+          @add-blank-affect="addBlankAffect"
+        />
+      </div>
       <div v-if="mode === 'edit'" class="border-top osim-flaw-form-section">
         <FlawComments
           :comments="flaw.comments"

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -411,6 +411,7 @@ const createdDate = computed(() => {
               type="text"
             />
             <FlawContributors v-if="flaw.task_key" :taskKey="flaw.task_key" />
+            <CvssExlplainForm v-if="shouldDisplayEmailNistForm" v-model="flaw" />
           </div>
         </div>
       </div>

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -374,7 +374,7 @@ const createdDate = computed(() => {
               type="text"
             />
             <FlawContributors v-if="flaw.task_key" :taskKey="flaw.task_key" />
-            <CvssExlplainForm v-if="shouldDisplayEmailNistForm" v-model="flaw" />
+            <CvssExplainForm v-if="shouldDisplayEmailNistForm" v-model="flaw" />
           </div>
         </div>
         <div class="osim-flaw-form-section border-top row mx-0">

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -490,7 +490,7 @@ const createdDate = computed(() => {
           <IssueFieldReferences
             ref="referencesComp"
             v-model="flawReferences"
-            class="w-100 my-3"
+            class="w-100 my-2"
             :mode="mode"
             :error="errors.references"
             @reference:update="saveReferences"
@@ -501,7 +501,7 @@ const createdDate = computed(() => {
           <IssueFieldAcknowledgments
             ref="acknowledgmentsComp"
             v-model="flawAcknowledgments"
-            class="w-100 my-3"
+            class="w-100 my-2"
             :mode="mode"
             :error="errors.acknowledgments"
             @acknowledgment:update="saveAcknowledgments"

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -261,9 +261,9 @@ const createdDate = computed(() => {
                   :error="errors.cve_id"
                 />
               </div>
-              <div
+                <div
                 v-if="!(flaw.cve_id || '').includes('CVE') && mode === 'edit'"
-                class="col-auto align-self-end mb-3"
+                class="col-auto align-self-end mb-2"
               >
                 <CveRequestForm
                   :embargoed="flaw.embargoed"
@@ -275,29 +275,29 @@ const createdDate = computed(() => {
               </div>
             </div>
             <LabelSelect
-              v-model="flaw.impact"
-              label="Impact"
-              :options="flawImpacts"
-              :error="errors.impact"
-            />
+            v-model="flaw.impact"
+            label="Impact"
+            :options="flawImpacts"
+            :error="errors.impact"
+          />
             <CvssCalculator
               :id="flawRhCvss3.uuid"
               v-model:cvss-vector="flawRhCvss3.vector"
               v-model:cvss-score="flawRhCvss3.score"
             />
-            <div class="row">
+            <div>
               <div class="col">
                 <LabelDiv label="NVD CVSSv3">
-                  <div class="d-flex flex-row">
-                    <div class="form-control text-break h-auto rounded-0">
-                      <template v-for="(chars, index) in highlightedNvdCvss3String" :key="index">
-                        <span v-if="chars[0].isHighlighted" class="text-primary">
-                          {{ chars.map(c => c.char).join('') }}
-                        </span>
-                        <template v-else>{{ chars.map(c => c.char).join('') }}</template>
-                      </template>
-                    </div>
-                    <div v-if="shouldDisplayEmailNistForm" class="col-auto align-self-center">
+                <div class="d-flex flex-row">
+                  <div class="form-control text-break h-auto rounded-0">
+                    <template v-for="(chars, index) in highlightedNvdCvss3String" :key="index">
+                      <span v-if="chars[0].isHighlighted" class="text-primary">
+                        {{ chars.map(c => c.char).join('') }}
+                      </span>
+                      <template v-else>{{ chars.map(c => c.char).join('') }}</template>
+                    </template>
+                  </div>
+                  <div v-if="shouldDisplayEmailNistForm" class="col-auto align-self-center">
                       <CvssNISTForm
                         :cveid="flaw.cve_id"
                         :summary="flaw.comment_zero"
@@ -309,18 +309,6 @@ const createdDate = computed(() => {
                   </div>
                 </LabelDiv>
               </div>
-              <template v-if="shouldDisplayEmailNistForm">
-                <div class="col-auto align-self-center mb-3">
-                  <CvssNISTForm
-                    :cveid="flaw.cve_id"
-                    :summary="flaw.comment_zero"
-                    :bugzilla="bugzillaLink"
-                    :cvss="rhCvss3String"
-                    :nistcvss="nvdCvss3String"
-                  />
-                </div>
-                <CvssExplainForm v-model="flaw" />
-              </template>
             </div>
             <LabelEditable
               v-model="flaw.cwe_id"

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -261,7 +261,7 @@ const createdDate = computed(() => {
                   :error="errors.cve_id"
                 />
               </div>
-                <div
+              <div
                 v-if="!(flaw.cve_id || '').includes('CVE') && mode === 'edit'"
                 class="col-auto align-self-end mb-2"
               >
@@ -275,11 +275,11 @@ const createdDate = computed(() => {
               </div>
             </div>
             <LabelSelect
-            v-model="flaw.impact"
-            label="Impact"
-            :options="flawImpacts"
-            :error="errors.impact"
-          />
+              v-model="flaw.impact"
+              label="Impact"
+              :options="flawImpacts"
+              :error="errors.impact"
+            />
             <CvssCalculator
               :id="flawRhCvss3.uuid"
               v-model:cvss-vector="flawRhCvss3.vector"
@@ -288,16 +288,16 @@ const createdDate = computed(() => {
             <div>
               <div class="col">
                 <LabelDiv label="NVD CVSSv3">
-                <div class="d-flex flex-row">
-                  <div class="form-control text-break h-auto rounded-0">
-                    <template v-for="(chars, index) in highlightedNvdCvss3String" :key="index">
-                      <span v-if="chars[0].isHighlighted" class="text-primary">
-                        {{ chars.map(c => c.char).join('') }}
-                      </span>
-                      <template v-else>{{ chars.map(c => c.char).join('') }}</template>
-                    </template>
-                  </div>
-                  <div v-if="shouldDisplayEmailNistForm" class="col-auto align-self-center">
+                  <div class="d-flex flex-row">
+                    <div class="form-control text-break h-auto rounded-0">
+                      <template v-for="(chars, index) in highlightedNvdCvss3String" :key="index">
+                        <span v-if="chars[0].isHighlighted" class="text-primary">
+                          {{ chars.map(c => c.char).join('') }}
+                        </span>
+                        <template v-else>{{ chars.map(c => c.char).join('') }}</template>
+                      </template>
+                    </div>
+                    <div v-if="shouldDisplayEmailNistForm" class="col-auto align-self-center">
                       <CvssNISTForm
                         :cveid="flaw.cve_id"
                         :summary="flaw.comment_zero"
@@ -632,7 +632,7 @@ div.osim-content {
 
 .osim-flaw-header-link {
   position: absolute;
-  right: 0rem;
+  right: 0;
   top: 2rem;
   width: auto;
 }

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -248,7 +248,7 @@ const createdDate = computed(() => {
   <form class="osim-flaw-form" :class="{'osim-disabled': isSaving || formDisabled}" @submit.prevent="onSubmit">
     <div class="osim-content container-fluid">
       <div class="row osim-flaw-form-section" :class="{ 'pt-5': mode === 'create'}">
-        <div v-if="flaw.meta_attr?.bz_id" class="col-12 mb-2 text-end">
+        <div v-if="flaw.meta_attr?.bz_id" class="osim-flaw-header-link">
           <a
             :href="bugzillaLink"
             class="osim-bugzilla-link"
@@ -571,8 +571,9 @@ form.osim-flaw-form :deep(*) {
   line-height: 1.5;
   font-family: 'Red Hat Mono', monospace;
 
-  .osim-flaw-form-section{
-    padding-block: 3rem;
+  .osim-flaw-form-section {
+    position: relative;
+    padding-block: 2rem;
   }
 }
 
@@ -686,4 +687,10 @@ div.osim-content {
   margin-top: -15px;
 }
 
+.osim-flaw-header-link {
+  position: absolute;
+  right: 0rem;
+  top: 2rem;
+  width: auto;
+}
 </style>

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -579,7 +579,7 @@ form.osim-flaw-form :deep(*) {
 
   .osim-flaw-form-section {
     position: relative;
-    padding-block: 2rem;
+    padding-block: 1.5rem;
   }
 }
 

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -112,10 +112,6 @@ const onSubmit = async () => {
   }
 };
 
-const showDescription = ref(flaw.value.cve_description && flaw.value.cve_description.trim() !== '');
-const showStatement = ref(flaw.value.statement && flaw.value.statement.trim() !== '');
-const showMitigation = ref(flaw.value.mitigation && flaw.value.mitigation.trim() !== '');
-
 const onReset = () => {
   // is deepCopyFromRaw needed?
   flaw.value = deepCopyFromRaw(initialFlaw);
@@ -164,27 +160,6 @@ const allowedSources = [
 const hiddenSources = computed(() => {
   return flawSources.filter(source => !allowedSources.includes(source));
 });
-
-const toggleDescription = () => {
-  showDescription.value = !showDescription.value;
-  if (!showDescription.value) {
-    flaw.value.cve_description = '';
-  }
-};
-
-const toggleStatement = () => {
-  showStatement.value = !showStatement.value;
-  if (!showStatement.value) {
-    flaw.value.statement = '';
-  }
-};
-
-const toggleMitigation = () => {
-  showMitigation.value = !showMitigation.value;
-  if (!showMitigation.value) {
-    flaw.value.mitigation = '';
-  }
-};
 
 const affectedOfferingsComp = ref<InstanceType<typeof AffectedOfferings> | null>(null);
 const referencesComp = ref<InstanceType<typeof IssueFieldReferences> | null>(null);
@@ -425,7 +400,6 @@ const createdDate = computed(() => {
           class="col-6 px-4 py-2"
         />
         <LabelTextarea
-          v-if="showDescription"
           v-model="flaw.cve_description"
           label="Description"
           placeholder="Description Text ..."
@@ -446,7 +420,6 @@ const createdDate = computed(() => {
           </template>
         </LabelTextarea>
         <LabelTextarea
-          v-if="showStatement"
           v-model="flaw.statement"
           label="Statement"
           placeholder="Statement Text ..."
@@ -454,36 +427,12 @@ const createdDate = computed(() => {
           class="col-6 px-4 py-2"
         />
         <LabelTextarea
-          v-if="showMitigation"
           v-model="flaw.mitigation"
           label="Mitigation"
           placeholder="Mitigation Text ..."
           :error="errors.mitigation"
           class="col-6 px-4 py-2"
         />
-        <div class="d-flex gap-3 m-1 mb-3">
-          <button
-            type="button"
-            class="btn btn-secondary osim-show-description"
-            @click="toggleDescription"
-          >
-            {{ showDescription ? 'Remove Description' : 'Add Description' }}
-          </button>
-          <button
-            type="button"
-            class="btn btn-secondary"
-            @click="toggleStatement"
-          >
-            {{ showStatement ? 'Remove Statement' : 'Add Statement' }}
-          </button>
-          <button
-            type="button"
-            class="btn btn-secondary"
-            @click="toggleMitigation"
-          >
-            {{ showMitigation ? 'Remove Mitigation' : 'Add Mitigation' }}
-          </button>
-        </div>
       </div>
       <div class="osim-flaw-form-section border-top border-bottom">
         <div class="d-flex gap-3">

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -222,24 +222,24 @@ const createdDate = computed(() => {
 <template>
   <form class="osim-flaw-form" :class="{'osim-disabled': isSaving || formDisabled}" @submit.prevent="onSubmit">
     <div class="osim-content container-fluid">
-      <div class="row osim-flaw-form-section" :class="{ 'pt-5': mode === 'create'}">
-        <div v-if="flaw.meta_attr?.bz_id" class="osim-flaw-header-link">
-          <a
-            :href="bugzillaLink"
-            class="osim-bugzilla-link"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Open in Bugzilla <i class="bi-box-arrow-up-right ms-2" />
-          </a>
-        </div>
-        <div class="col-12 osim-alerts-banner">
-          <FlawAlertsList :flaw="flaw" @expandFocusedComponent="expandFocusedComponent" />
-        </div>
-        <div
-          class="row pt-3"
-          :class="{'osim-flaw-form-embargoed border border-2 border-primary': flaw.embargoed}"
-        >
+      <div
+        class="row px-4 my-3"
+        :class="{'osim-flaw-form-embargoed border border-2 border-primary': flaw.embargoed}"
+      >
+        <div class="row osim-flaw-form-section" :class="{ 'pt-5': mode === 'create'}">
+          <div v-if="flaw.meta_attr?.bz_id" class="osim-flaw-header-link">
+            <a
+              :href="bugzillaLink"
+              class="osim-bugzilla-link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Open in Bugzilla <i class="bi-box-arrow-up-right ms-2" />
+            </a>
+          </div>
+          <div class="col-12 osim-alerts-banner">
+            <FlawAlertsList :flaw="flaw" @expandFocusedComponent="expandFocusedComponent" />
+          </div>
           <div :id="flaw.uuid" class="col-6">
             <LabelEditable
               v-model="flaw.title"
@@ -377,133 +377,133 @@ const createdDate = computed(() => {
             <CvssExlplainForm v-if="shouldDisplayEmailNistForm" v-model="flaw" />
           </div>
         </div>
-      </div>
-      <div class="osim-flaw-form-section border-top row mx-0">
-        <LabelTextarea
-          v-model="flaw.comment_zero"
-          label="Comment#0"
-          placeholder="Comment#0 ..."
-          :error="errors.comment_zero"
-          :disabled="mode === 'edit'"
-          class="col-6 px-4 py-2"
-        />
-        <LabelTextarea
-          v-model="flaw.cve_description"
-          label="Description"
-          placeholder="Description Text ..."
-          :error="errors.cve_description"
-          class="col-6 px-4 py-2"
-        >
-          <template #label>
-            <span class="form-label col-3 osim-folder-tab-label">
-              Description
-            </span>
-            <span class="col-3 ps-2">
-              <select v-model="flaw.requires_cve_description" class="form-select col-3 osim-description-required">
-                <option disabled :selected="!flaw.requires_cve_description" value="">Review Status</option>
-                <option v-for="state in descriptionRequiredStates" :key="state" :value="state">{{ state }}</option>
-              </select>
-            </span>
-
-          </template>
-        </LabelTextarea>
-        <LabelTextarea
-          v-model="flaw.statement"
-          label="Statement"
-          placeholder="Statement Text ..."
-          :error="errors.statement"
-          class="col-6 px-4 py-2"
-        />
-        <LabelTextarea
-          v-model="flaw.mitigation"
-          label="Mitigation"
-          placeholder="Mitigation Text ..."
-          :error="errors.mitigation"
-          class="col-6 px-4 py-2"
-        />
-      </div>
-      <div class="osim-flaw-form-section border-top border-bottom">
-        <div class="d-flex gap-3">
-          <IssueFieldReferences
-            ref="referencesComp"
-            v-model="flawReferences"
-            class="w-100 my-2"
-            :mode="mode"
-            :error="errors.references"
-            @reference:update="saveReferences"
-            @reference:new="addBlankReference(flaw.embargoed)"
-            @reference:cancel-new="cancelAddReference"
-            @reference:delete="deleteReference"
+        <div class="osim-flaw-form-section border-top row mx-0">
+          <LabelTextarea
+            v-model="flaw.comment_zero"
+            label="Comment#0"
+            placeholder="Comment#0 ..."
+            :error="errors.comment_zero"
+            :disabled="mode === 'edit'"
+            class="col-6 px-4 py-2"
           />
-          <IssueFieldAcknowledgments
-            ref="acknowledgmentsComp"
-            v-model="flawAcknowledgments"
-            class="w-100 my-2"
-            :mode="mode"
-            :error="errors.acknowledgments"
-            @acknowledgment:update="saveAcknowledgments"
-            @acknowledgment:new="addBlankAcknowledgment(flaw.embargoed)"
-            @acknowledgment:cancel-new="cancelAddAcknowledgment"
-            @acknowledgment:delete="deleteAcknowledgment"
+          <LabelTextarea
+            v-model="flaw.cve_description"
+            label="Description"
+            placeholder="Description Text ..."
+            :error="errors.cve_description"
+            class="col-6 px-4 py-2"
+          >
+            <template #label>
+              <span class="form-label col-3 osim-folder-tab-label">
+                Description
+              </span>
+              <span class="col-3 ps-2">
+                <select v-model="flaw.requires_cve_description" class="form-select col-3 osim-description-required">
+                  <option disabled :selected="!flaw.requires_cve_description" value="">Review Status</option>
+                  <option v-for="state in descriptionRequiredStates" :key="state" :value="state">{{ state }}</option>
+                </select>
+              </span>
+
+            </template>
+          </LabelTextarea>
+          <LabelTextarea
+            v-model="flaw.statement"
+            label="Statement"
+            placeholder="Statement Text ..."
+            :error="errors.statement"
+            class="col-6 px-4 py-2"
+          />
+          <LabelTextarea
+            v-model="flaw.mitigation"
+            label="Mitigation"
+            placeholder="Mitigation Text ..."
+            :error="errors.mitigation"
+            class="col-6 px-4 py-2"
+          />
+        </div>
+        <div class="osim-flaw-form-section border-top border-bottom">
+          <div class="d-flex gap-3">
+            <IssueFieldReferences
+              ref="referencesComp"
+              v-model="flawReferences"
+              class="w-100 my-2"
+              :mode="mode"
+              :error="errors.references"
+              @reference:update="saveReferences"
+              @reference:new="addBlankReference(flaw.embargoed)"
+              @reference:cancel-new="cancelAddReference"
+              @reference:delete="deleteReference"
+            />
+            <IssueFieldAcknowledgments
+              ref="acknowledgmentsComp"
+              v-model="flawAcknowledgments"
+              class="w-100 my-2"
+              :mode="mode"
+              :error="errors.acknowledgments"
+              @acknowledgment:update="saveAcknowledgments"
+              @acknowledgment:new="addBlankAcknowledgment(flaw.embargoed)"
+              @acknowledgment:cancel-new="cancelAddAcknowledgment"
+              @acknowledgment:delete="deleteAcknowledgment"
+            />
+          </div>
+        </div>
+        <div class="osim-flaw-form-section">
+          <AffectedOfferings
+            v-if="mode === 'edit'"
+            ref="affectedOfferingsComp"
+            :theAffects="flaw.affects"
+            :affectsToDelete="affectsToDelete"
+            :error="errors.affects"
+            :flawId="flaw.uuid"
+            @affect:recover="(affect) => recoverAffect(flaw.affects.indexOf(affect))"
+            @affect:remove="(affect) => removeAffect(flaw.affects.indexOf(affect))"
+            @add-blank-affect="addBlankAffect"
+          />
+        </div>
+        <div v-if="mode === 'edit'" class="border-top osim-flaw-form-section">
+          <FlawComments
+            :comments="flaw.comments"
+            :taskKey="flaw.task_key"
+            :error="errors.comments"
+            :isSaving="isSaving"
+            @comment:addFlawComment="addFlawComment"
+            @disableForm="(value) => formDisabled = value"
           />
         </div>
       </div>
-      <div class="osim-flaw-form-section">
-        <AffectedOfferings
-          v-if="mode === 'edit'"
-          ref="affectedOfferingsComp"
-          :theAffects="flaw.affects"
-          :affectsToDelete="affectsToDelete"
-          :error="errors.affects"
-          :flawId="flaw.uuid"
-          @affect:recover="(affect) => recoverAffect(flaw.affects.indexOf(affect))"
-          @affect:remove="(affect) => removeAffect(flaw.affects.indexOf(affect))"
-          @add-blank-affect="addBlankAffect"
-        />
-      </div>
-      <div v-if="mode === 'edit'" class="border-top osim-flaw-form-section">
-        <FlawComments
-          :comments="flaw.comments"
-          :taskKey="flaw.task_key"
-          :error="errors.comments"
-          :isSaving="isSaving"
-          @comment:addFlawComment="addFlawComment"
-          @disableForm="(value) => formDisabled = value"
-        />
-      </div>
-    </div>
-    <div class="osim-action-buttons sticky-bottom d-grid gap-2 d-flex justify-content-end">
-      <!-- <button type="button" class="btn btn-primary col">Customer Pending</button>-->
-      <!-- <button type="button" class="btn btn-primary col">
+      <div class="osim-action-buttons sticky-bottom d-grid gap-2 d-flex justify-content-end">
+        <!-- <button type="button" class="btn btn-primary col">Customer Pending</button>-->
+        <!-- <button type="button" class="btn btn-primary col">
         Close this issue without actions
       </button>-->
-      <!-- <button type="button" class="btn btn-primary col">
+        <!-- <button type="button" class="btn btn-primary col">
         Move this issue to another source queue
       </button>-->
-      <!-- <button type="button" class="btn btn-primary col">Create a flaw</button>-->
-      <!-- <button type="button" class="btn btn-primary col">
+        <!-- <button type="button" class="btn btn-primary col">Create a flaw</button>-->
+        <!-- <button type="button" class="btn btn-primary col">
         Create hardening bug/weakness
       </button>-->
-      <div v-if="mode === 'edit'">
-        <button type="button" class="btn btn-secondary" @click="onReset">Reset Changes</button>
-        <button
-          v-osim-loading.grow="isSaving"
-          type="submit"
-          class="btn btn-primary ms-3"
-          :disabled="isSaving"
-        >
-          Save Changes
-        </button>
-      </div>
-      <div v-if="mode === 'create'">
-        <button
-          v-osim-loading.grow="isSaving"
-          type="submit"
-          class="btn btn-primary ms-3"
-          :disabled="isSaving"
-        >
-          Create New Flaw
-        </button>
+        <div v-if="mode === 'edit'">
+          <button type="button" class="btn btn-secondary" @click="onReset">Reset Changes</button>
+          <button
+            v-osim-loading.grow="isSaving"
+            type="submit"
+            class="btn btn-primary ms-3"
+            :disabled="isSaving"
+          >
+            Save Changes
+          </button>
+        </div>
+        <div v-if="mode === 'create'">
+          <button
+            v-osim-loading.grow="isSaving"
+            type="submit"
+            class="btn btn-primary ms-3"
+            :disabled="isSaving"
+          >
+            Create New Flaw
+          </button>
+        </div>
       </div>
     </div>
   </form>

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -415,13 +415,14 @@ const createdDate = computed(() => {
           </div>
         </div>
       </div>
-      <div class="osim-flaw-form-section border-top">
+      <div class="osim-flaw-form-section border-top row mx-0">
         <LabelTextarea
           v-model="flaw.comment_zero"
           label="Comment#0"
           placeholder="Comment#0 ..."
           :error="errors.comment_zero"
           :disabled="mode === 'edit'"
+          class="col-6 px-4 py-2"
         />
         <LabelTextarea
           v-if="showDescription"
@@ -429,7 +430,7 @@ const createdDate = computed(() => {
           label="Description"
           placeholder="Description Text ..."
           :error="errors.cve_description"
-          class="osim-flaw-description-component"
+          class="col-6 px-4 py-2"
         >
           <template #label>
             <span class="form-label col-3 osim-folder-tab-label">
@@ -450,6 +451,7 @@ const createdDate = computed(() => {
           label="Statement"
           placeholder="Statement Text ..."
           :error="errors.statement"
+          class="col-6 px-4 py-2"
         />
         <LabelTextarea
           v-if="showMitigation"
@@ -457,8 +459,9 @@ const createdDate = computed(() => {
           label="Mitigation"
           placeholder="Mitigation Text ..."
           :error="errors.mitigation"
+          class="col-6 px-4 py-2"
         />
-        <div class="d-flex gap-3 mb-3">
+        <div class="d-flex gap-3 m-1 mb-3">
           <button
             type="button"
             class="btn btn-secondary osim-show-description"

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -313,14 +313,23 @@ const createdDate = computed(() => {
             <div class="row">
               <div class="col">
                 <LabelDiv label="NVD CVSSv3">
-                  <div class="form-control text-break h-100">
-                    <div class="p-0 h-100">
+                  <div class="d-flex flex-row">
+                    <div class="form-control text-break h-auto rounded-0">
                       <template v-for="(chars, index) in highlightedNvdCvss3String" :key="index">
                         <span v-if="chars[0].isHighlighted" class="text-primary">
                           {{ chars.map(c => c.char).join('') }}
                         </span>
                         <template v-else>{{ chars.map(c => c.char).join('') }}</template>
                       </template>
+                    </div>
+                    <div v-if="shouldDisplayEmailNistForm" class="col-auto align-self-center">
+                      <CvssNISTForm
+                        :cveid="flaw.cve_id"
+                        :summary="flaw.comment_zero"
+                        :bugzilla="bugzillaLink"
+                        :cvss="rhCvss3String"
+                        :nistcvss="nvdCvss3String"
+                      />
                     </div>
                   </div>
                 </LabelDiv>

--- a/src/components/FlawFormOwner.vue
+++ b/src/components/FlawFormOwner.vue
@@ -31,7 +31,7 @@ const isLoading = ref(false);
 </script>
 
 <template>
-  <label class="ps-3 mb-3 input-group osim-input">
+  <label class="ps-3 mb-2 input-group osim-input">
     <div class="row">
       <span class="form-label col-3 pe-3 ">
         Owner

--- a/src/components/IssueFieldReferences.vue
+++ b/src/components/IssueFieldReferences.vue
@@ -98,7 +98,7 @@ defineExpose({ editableListComp });
 
       <template #create-form="{ items, itemIndex }">
         <div class="form-group">
-          <div class="p-3 pt-4">
+          <div class="ms-3 me-4">
             <button
               type="button"
               class="btn osim-cancel-new-reference"
@@ -112,7 +112,7 @@ defineExpose({ editableListComp });
               label="Description"
               :error="error?.[itemIndex].description"
             />
-            <select v-model="items[itemIndex].type" class="form-select mb-3 osim-reference-types">
+            <select v-model="items[itemIndex].type" class="form-select mb-2 osim-reference-types">
               <option value="" disabled selected>Select a reference type</option>
               <option
                 v-for="referenceType in allowedReferenceTypes"

--- a/src/components/IssueFieldState.vue
+++ b/src/components/IssueFieldState.vue
@@ -63,7 +63,37 @@ function nextPhase(workflowState: WorkflowPhases) {
 <template>
   <div class="osim-workflow-state-container mb-3">
     <LabelDiv label="State" type="text" class="osim-workflow-state-display">
-      <span class="form-control">{{ classification.state || 'Legacy Flaw without Jira task' }}</span>
+      <div class="d-flex">
+        <span class="form-control rounded-0">{{ classification.state || 'Legacy Flaw without Jira task' }}</span>
+        <div class="col-auto">
+          <div v-if="shouldShowWorkflowButtons" class="osim-workflow-state-buttons">
+            <button type="button" class="btn btn-secondary rounded-0" @click="openModal">
+              Reject
+            </button>
+            <button
+              type="button"
+              class="btn btn-warning osim-last-field-button"
+              :title="`Promote to ${nextPhase(classification.state as WorkflowPhases)}`"
+              @click="onPromote(flawId)"
+            >
+              Promote to {{ nextPhase(classification.state as WorkflowPhases) }}
+            </button>
+          </div>
+          <div v-else-if="shouldShowCreateJiraTaskButton" class="osim-workflow-state-buttons">
+            <button
+              type="button"
+              class="btn btn-warning osim-last-field-button"
+              title="Creates Jira task when flaw is saved"
+              @click="toggleCreateJiraTask"
+            >
+              <i
+                :class="{ 'bi-square': !shouldCreateJiraTask, 'bi-check-square': shouldCreateJiraTask }"
+              />
+              Create Jira task
+            </button>
+          </div>
+        </div>
+      </div>
       <Modal :show="shouldShowRejectionModal" @close="closeModal">
         <template #title> Reject Flaw </template>
         <template #body>
@@ -80,39 +110,14 @@ function nextPhase(workflowState: WorkflowPhases) {
         </template>
       </Modal>
     </LabelDiv>
-    <div class="row">
-      <div class="col-lg-9 col-md-11 offset-lg-3 offset-md-1">
-        <div v-if="shouldShowWorkflowButtons" class="osim-workflow-state-buttons mb-3">
-          <button type="button" class="btn btn-warning ms-2 osim-workflow-button" @click="openModal">
-            Reject
-          </button>
-          <button
-            type="button"
-            class="btn btn-warning ms-2 osim-promote-button osim-workflow-button"
-            :title="`Promote to ${nextPhase(classification.state as WorkflowPhases)}`"
-            @click="onPromote(flawId)"
-          >
-            Promote to {{ nextPhase(classification.state as WorkflowPhases) }}
-          </button>
-        </div>
-        <div v-if="shouldShowCreateJiraTaskButton" class="osim-workflow-state-buttons mb-3">
-          <button type="button" class="btn btn-warning ms-2 osim-workflow-button" @click="toggleCreateJiraTask">
-            <i
-              :class="{ 'bi-square': !shouldCreateJiraTask, 'bi-check-square': shouldCreateJiraTask }"
-            />
-            Create Jira task
-          </button>
-        </div>
-      </div>
-    </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
 .osim-workflow-state-container {
-  button.osim-workflow-button {
+  .osim-last-field-button {
     border-top-left-radius: 0;
-    border-top-right-radius: 0;
+    border-bottom-left-radius: 0;
   }
 
   label.osim-modal-label {
@@ -121,10 +126,6 @@ function nextPhase(workflowState: WorkflowPhases) {
 
   .osim-workflow-state-display {
     margin-bottom: 0 !important;
-  }
-
-  span.form-control {
-    min-height: 2.375px;
   }
 }
 </style>

--- a/src/components/IssueFieldState.vue
+++ b/src/components/IssueFieldState.vue
@@ -61,7 +61,7 @@ function nextPhase(workflowState: WorkflowPhases) {
 </script>
 
 <template>
-  <div class="osim-workflow-state-container mb-3">
+  <div class="osim-workflow-state-container mb-2">
     <LabelDiv label="State" type="text" class="osim-workflow-state-display">
       <div class="d-flex">
         <span class="form-control rounded-0">{{ classification.state || 'Legacy Flaw without Jira task' }}</span>

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -523,27 +523,6 @@ describe('FlawForm', () => {
     expect(flaw.unembargo_dt).not.toBe(null);
   });
 
-  it('show set description, statement, mitigation values correctly after clicking remove buttons', async () => {
-    const flaw = sampleFlaw();
-    flaw.cve_description = 'description';
-    flaw.statement = 'statement';
-    flaw.mitigation = 'mitigation';
-    mountWithProps({ flaw, mode: 'edit' });
-    const buttonGroups = subject.find('div.d-flex.gap-3.mb-3').findAll('button.btn.btn-secondary');
-    const removeDescriptionButton = buttonGroups[0];
-    expect(removeDescriptionButton.element?.textContent).toBe('Remove Description');
-    const removeStatementButton = buttonGroups[1];
-    expect(removeStatementButton.element?.textContent).toBe('Remove Statement');
-    const removeMitigationButton = buttonGroups[2];
-    expect(removeMitigationButton.element?.textContent).toBe('Remove Mitigation');
-    await removeDescriptionButton.trigger('click');
-    await removeStatementButton.trigger('click');
-    await removeMitigationButton.trigger('click');
-    expect((subject.vm as any).flaw.cve_description).toBe('');
-    expect((subject.vm as any).flaw.statement).toBe('');
-    expect((subject.vm as any).flaw.mitigation).toBe('');
-  });
-
   it('should show only allowed sources in edit mode', async () => {
     const flaw = sampleFlaw();
     mountWithProps({ flaw, mode: 'edit' });

--- a/src/components/widgets/EditableList.vue
+++ b/src/components/widgets/EditableList.vue
@@ -81,7 +81,7 @@ defineExpose({ isExpanded });
         v-for="(item, itemIndex) in items"
         :id="item.uuid"
         :key="itemIndex"
-        class="card p-3 pb-1 mb-3 rounded-3 osim-editable-list-card"
+        class="card p-3 pb-1 mb-2 rounded-3 osim-editable-list-card"
         :class="{
           'bg-light-light-orange': modifiedItemIndexes.includes(itemIndex),
           'bg-light-light-gray': !modifiedItemIndexes.includes(itemIndex),

--- a/src/components/widgets/LabelDiv.vue
+++ b/src/components/widgets/LabelDiv.vue
@@ -7,7 +7,7 @@ defineProps<{
 </script>
 
 <template>
-  <div class="osim-input mb-3 ps-3" v-bind="$attrs">
+  <div class="osim-input mb-2 ps-3" v-bind="$attrs">
     <div class="row">
       <span class="form-label col-3">
         {{ label }}

--- a/src/components/widgets/LabelEditable.vue
+++ b/src/components/widgets/LabelEditable.vue
@@ -16,7 +16,7 @@ const modelValue = defineModel<string | undefined | null | number | Date>();
 </script>
 
 <template>
-  <label class="osim-input ps-3 mb-3 input-group">
+  <label class="osim-input ps-3 mb-2 input-group">
     <div class="row">
       <span class="form-label col-3">
         <slot name="label">

--- a/src/components/widgets/LabelInput.vue
+++ b/src/components/widgets/LabelInput.vue
@@ -44,7 +44,7 @@ const type = computed<string>(() => props.type ?? 'text');
 </script>
 
 <template>
-  <label class="osim-input mb-3 ps-3">
+  <label class="osim-input mb-2 ps-3">
     <div class="row">
       <span class="form-label col-3 gx-2">
         {{ label }}

--- a/src/components/widgets/LabelSelect.vue
+++ b/src/components/widgets/LabelSelect.vue
@@ -18,7 +18,7 @@ withDefaults(
 </script>
 
 <template>
-  <label class="osim-input mb-3 ps-3">
+  <label class="osim-input mb-2 ps-3">
     <div class="row">
       <span v-if="label" class="form-label col-3">
         {{ label }}

--- a/src/components/widgets/LabelStatic.vue
+++ b/src/components/widgets/LabelStatic.vue
@@ -14,7 +14,7 @@ const emptyModel = computed(() => {
 </script>
 
 <template>
-  <div class="osim-static-label osim-input mb-3 ps-3">
+  <div class="osim-static-label osim-input mb-2 ps-3">
     <div v-if="hasTopLabelStyle" class="osim-static-label-top-style">
       <span class="top-label">
         {{ label }}

--- a/src/components/widgets/LabelTagsInput.vue
+++ b/src/components/widgets/LabelTagsInput.vue
@@ -14,7 +14,7 @@ const modelValue = defineModel<string[]>({ required: true });
 </script>
 
 <template>
-  <label class="osim-input ps-3 mb-3 input-group">
+  <label class="osim-input ps-3 mb-2 input-group">
     <div class="row">
       <span class="form-label col-3">
         <slot name="label">

--- a/src/components/widgets/LabelTextarea.vue
+++ b/src/components/widgets/LabelTextarea.vue
@@ -31,7 +31,7 @@ const elTextArea = ref();
 </script>
 
 <template>
-  <label class="osim-input mb-3 ps-3">
+  <label class="osim-input mb-2 ps-3">
     <div class="row">
       <slot name="label">
         <span class="form-label col-3">

--- a/src/components/widgets/TagsInput.vue
+++ b/src/components/widgets/TagsInput.vue
@@ -146,10 +146,12 @@ function edit(index: number, event: Event) {
 
 .osim-pill-list-item {
   font-size: .85rem;
+  padding-block: 0.1rem;
 }
 
 .osim-pill-list-input {
   display: inline-block;
+  height: 1.5rem;
   border: none;
   outline: none;
   box-shadow: none;

--- a/src/components/widgets/TagsInput.vue
+++ b/src/components/widgets/TagsInput.vue
@@ -85,6 +85,7 @@ function edit(index: number, event: Event) {
         :data-index="index"
       >
         <span
+          style="cursor: text"
           @click="makeEditable"
           @keydown.enter.prevent="edit(index, $event)"
           @keydown.escape.prevent="edit(index, $event)"
@@ -94,6 +95,7 @@ function edit(index: number, event: Event) {
         </span>
         <i
           class="bi bi-x-square ms-1"
+          style="cursor: pointer"
           tabindex="0"
           @keydown.enter.prevent="remove(index)"
           @keydown.space.prevent="remove(index)"


### PR DESCRIPTION
# OSIDB-2005 Remove extra whitespace

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits (not yet) consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Remove whitespace on OSIM's UI make a better use of the space available in every view aiming for a compact style.

## Changes:

- Make flaw form larger width
- Adjust form elements for a compact inline style
- Optimize space on text area fields section (descriptions)
- Make text area fields always visible (and remove buttons)
- Sightly adjust spacing on flaw attributions
- Minor UI corrections for affects sections
- Minor spacing adjustment between affect items
- Sightly adjust spacing on comments section

## Considerations:

- Depends on [OSIM-288](https://github.com/RedHatProductSecurity/osim/pull/288)
- Also asked for feedback on the demo to users
- I considered toggling text area descriptions is not required anymore as with new layout the space is already compact
- Considered to make the embargoed highlighted border cover all the sections. Reason is users may want to have feedback that they are on a embargoed flaw in different sections (e.g. adding comments)

## Demo:

![image](https://github.com/RedHatProductSecurity/osim/assets/29104825/fdf7d425-75c3-47aa-a982-1d6a4739540c)

![image](https://github.com/RedHatProductSecurity/osim/assets/29104825/6f4aaaa1-ceb8-4847-b82f-b9e7fbd667f7)

Video (some things might be outdated)

https://github.com/RedHatProductSecurity/osim/assets/29104825/b94d0a1a-2988-4c51-91dc-d03175a51843
