### PR TITLE
OSIDB-2981: Refresh flaw after CVSS scores on create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2024.6.1]
 ### Added
 * Support private Bugzilla comments (`OSIDB-2912`)
+* Refresh flaw after cvss scores on create (`OSIDB-2981`)
 
 ## [2024.6.0]
 ### Added

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -65,13 +65,10 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
       Object.entries(validatedFlaw.data).filter(([, value]) => value !== '')
     );
     try {
+      // TODO: Refactor promise chain
       await postFlaw(flawForPost)
         .then(createSuccessHandler({ title: 'Success!', body: 'Flaw created' }))
         .then(async (response: any) => {
-          router.push({
-            name: 'flaw-details',
-            params: { id: response?.cve_id || response?.uuid },
-          });
           flaw.value.uuid = response.uuid;
           saveDraftFlaw(flaw.value);
           if (flaw.value.acknowledgments.length > 0) {
@@ -80,14 +77,19 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
           if (flaw.value.references.length > 0) {
             await flawAttributionsModel.saveReferences(flaw.value.references);
           }
+          return response;
         })
-        .catch(createCatchHandler('Error creating Flaw'));
+        .catch(createCatchHandler('Error creating Flaw'))
+        .finally(async () => {
+          if (flaw.value.uuid) {
+            if (wasCvssModified.value) {
+              await saveCvssScores()
+                .catch(createCatchHandler('Error saving CVSS scores after creating Flaw'));
+            }
 
-      // Catch above will throw another error if the flaw is not created
-      if (wasCvssModified.value) {
-        await saveCvssScores()
-          .catch(createCatchHandler('Error saving CVSS scores after creating Flaw'));
-      }
+            router.push({ name: 'flaw-details', params: { id: flaw.value.uuid } });
+          }
+        });
     } catch (error) {
       console.error('Error when saving flaw:', error);
     } finally {


### PR DESCRIPTION
# OSIDB-2981: Refresh flaw after CVSS scores on create

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [ ] Test cases added/updated
- [x] Jira ticket updated

## Summary:

When we create a Flaw, we navigate to the _edit view_ before saving the `cvss_score`, the _edit view_ fetches the flaw from osidb and if the request to save the `cvss_score` is not finished, it arrives with the `cvss_scores` empty, having to reload the page to be able to see it.

## Changes:

Reorganized the async steps after flaw creation to navigate only after all the requests are made.

If the flaw fails to be created, the navigation is aborted, but if the flaw creation succeeds the navigation is performed even if any of the extra requests fails, like it did before
