### PR TITLE
OSIDB-2916: Add Contributors field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 * Create Jira task on demand for legacy flaws (`OSIDB-2883`)
+* Jira contributors field is now displayed on the Flaw form (`OSIDB-2916`)
 
 ### Changed
 * Temporary disable private comments creation (`OSIDB-3002`)

--- a/src/components/FlawContributors.vue
+++ b/src/components/FlawContributors.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { onBeforeMount, ref } from 'vue';
+import { isDefined, watchDebounced } from '@vueuse/core';
+import sanitize from 'sanitize-html';
+import LabelDiv from './widgets/LabelDiv.vue';
+import useJiraContributors from '@/composables/useJiraContributors';
+import type { ZodJiraUserPickerType } from '@/types/zodJira';
+import { createCatchHandler } from '@/composables/service-helpers';
+
+const props = defineProps<{
+  taskKey: string,
+}>();
+
+const inputRef = ref<HTMLInputElement | null>(null);
+const query = ref<string>();
+const results = ref<ZodJiraUserPickerType[]>([]);
+
+const {
+  contributors,
+  isLoadingContributors,
+  searchContributors,
+  loadJiraContributors,
+  saveContributors,
+} = useJiraContributors(props.taskKey);
+
+onBeforeMount(loadJiraContributors);
+
+watchDebounced(query, async () => {
+  if (!isDefined(query)) {
+    return;
+  }
+  const users = await searchContributors(query.value);
+  results.value = users ?? [];
+}, { debounce: 500 });
+
+
+const onFocus = () => {
+  inputRef.value?.focus();
+};
+
+const onBlur = (event: FocusEvent) => {
+  if (
+    event.relatedTarget !== event.currentTarget
+    && !(event.currentTarget as Node)?.contains(event.relatedTarget as Node)
+  ) {
+    inputRef.value?.blur();
+    results.value = [];
+    query.value = '';
+    saveContributors().catch(createCatchHandler('Failed to save contributors', false));
+  }
+};
+
+const add = (contributor: ZodJiraUserPickerType) => {
+  contributors.value.push(contributor);
+  query.value = '';
+  results.value = [];
+};
+
+const remove = (index: number) => {
+  contributors.value.splice(index, 1);
+};
+
+</script>
+
+<template>
+  <LabelDiv
+    label="Contributors"
+    tabindex="99"
+    @click.prevent="onFocus"
+    @blur.capture="onBlur"
+  >
+    <div class="dropdown form-control">
+      <ul class="ps-0 mb-0 list-unstyled">
+        <li v-for="(contributor, index) in contributors" :key="contributor.name" class="badge text-bg-secondary">
+          {{ contributor.displayName }}
+          <i
+            class="bi bi-x-square ms-1"
+            @keydown.enter.prevent="remove(index)"
+            @keydown.space.prevent="remove(index)"
+            @click.prevent="remove(index)"
+          >
+            <span class="visually-hidden">Remove</span>
+          </i>
+        </li>
+        <li v-osim-loading.grow="isLoadingContributors">
+          <input
+            ref="inputRef"
+            v-model="query"
+            type="text"
+            class="osim-contributor-input"
+            @submit.prevent
+            @keydown.enter.prevent
+          >
+        </li>
+      </ul>
+
+      <div v-if="results.length > 0" class="menu">
+        <div
+          v-for="contributor in results"
+          :key="contributor.name"
+          class="item"
+          @click="add(contributor)"
+        >
+          <span v-html="sanitize(contributor.html)" />
+        </div>
+      </div>
+    </div>
+  </LabelDiv>
+</template>
+
+<style scoped lang="scss">
+.dropdown {
+  position: relative;
+
+  :deep(.spinner-grow) {
+    float: right;
+    position: relative;
+    top: 5px;
+    color: #dee2e6;
+  }
+
+  ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    z-index: 1000;
+    display: block;
+    color: #212529;
+    background-color: #fff;
+    border: 1px solid rgb(0 0 0 / 15%);
+    border-radius: 0.25rem;
+    max-height: 400px;
+    overflow-y: auto;
+
+    .item {
+      display: block;
+      width: 100%;
+      padding: 0.25rem 1.5rem;
+      clear: both;
+      white-space: nowrap;
+      cursor: pointer;
+      font-size: .85rem;
+
+      &:hover {
+        background-color: #dee2e6;
+      }
+    }
+  }
+}
+
+.osim-contributor-input {
+  display: inline-block;
+  border: none;
+  outline: none;
+  box-shadow: none;
+}
+</style>

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -26,6 +26,7 @@ import { type ZodFlawType, descriptionRequiredStates } from '@/types/zodFlaw';
 import { type ZodTrackerType, type ZodAffectCVSSType } from '@/types/zodAffect';
 import { useDraftFlawStore } from '@/stores/DraftFlawStore';
 import CvssExlplainForm from './CvssExlplainForm.vue';
+import FlawContributors from '@/components/FlawContributors.vue';
 
 const props = defineProps<{
   flaw: any;
@@ -400,6 +401,7 @@ const createdDate = computed(() => {
               label="Created Date"
               type="text"
             />
+            <FlawContributors v-if="flaw.task_key" :taskKey="flaw.task_key" />
           </div>
         </div>
       </div>

--- a/src/components/__tests__/FlawContributors.spec.ts
+++ b/src/components/__tests__/FlawContributors.spec.ts
@@ -1,0 +1,109 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import FlawContributors from '../FlawContributors.vue';
+import { LoadingAnimationDirective } from '@/directives/LoadingAnimationDirective';
+import { ref, type ExtractPublicPropTypes } from 'vue';
+import type { ZodJiraContributorType } from '@/types/zodJira';
+
+const useJiraContributors = {
+  contributors: ref<Partial<ZodJiraContributorType>[]>([]),
+  isLoadingContributors: false,
+  loadJiraContributors: vi.fn(),
+  searchContributors: vi.fn(),
+  saveContributors: vi.fn()
+
+};
+
+vi.mock('@/composables/useJiraContributors', () => ({
+  default: () => useJiraContributors
+}));
+
+describe('FlawContributors', () => {
+  const contributor = { name: 'test', html: '<b>test</b> user', displayName: 'test user' };
+  const mountComponent = (props?: ExtractPublicPropTypes<typeof FlawContributors>) =>
+    mount(FlawContributors, {
+      props: {
+        task_key: 'TASK-123',
+        ...props
+      },
+      global: {
+        directives: {
+          'osim-loading': LoadingAnimationDirective
+        }
+      }
+    });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the component', () => {
+    const wrapper = mountComponent();
+    expect(wrapper.text()).toContain('Contributors');
+  });
+
+  it('should call loadJiraContributors on mount', () => {
+    mountComponent();
+    expect(useJiraContributors.loadJiraContributors).toHaveBeenCalled();
+  });
+
+  it('should show loading animation when loading contributors', async () => {
+    useJiraContributors.isLoadingContributors = true;
+    const wrapper = mountComponent();
+    expect(wrapper.find('.spinner-grow').exists()).toBe(true);
+  });
+
+  it('should call searchContributors when input changes', async () => {
+    const wrapper = mountComponent();
+    const input = wrapper.find('input');
+    await input.setValue('test');
+
+    vi.runAllTimers();
+
+    expect(useJiraContributors.searchContributors).toHaveBeenCalled();
+  });
+
+  it('should show search results when search is done', async () => {
+    useJiraContributors.searchContributors.mockResolvedValue([{ name: 'test', html: 'test user' }]);
+    const wrapper = mountComponent();
+    const input = wrapper.find('input');
+    await input.setValue('test');
+
+    vi.runAllTimers();
+    await flushPromises();
+
+    expect(wrapper.find('.menu').exists()).toBe(true);
+    expect(wrapper.find('.menu').text()).toContain('test user');
+  });
+
+  it('should add contributor when clicked', async () => {
+    useJiraContributors.searchContributors.mockResolvedValue([contributor]);
+    const wrapper = mountComponent();
+    const input = wrapper.find('input');
+    await input.setValue('test');
+
+    vi.runAllTimers();
+    await flushPromises();
+
+    const user = wrapper.find('.item');
+    await user.trigger('click');
+
+    expect(useJiraContributors.contributors.value).toEqual([contributor]);
+    expect(wrapper.find('.badge').exists()).toBe(true);
+    expect(wrapper.find('.badge').text()).toContain('test user');
+  });
+
+  it('should remove contributor when clicked', async () => {
+    const contributor = { name: 'test', html: '<b>test</b> user', displayName: 'test user' };
+    useJiraContributors.contributors.value = [contributor];
+    const wrapper = mountComponent();
+    const badge = wrapper.find('.badge i');
+    await badge.trigger('click');
+
+    expect(useJiraContributors.contributors.value).toEqual([]);
+    expect(wrapper.find('.badge').exists()).toBe(false);
+  });
+});

--- a/src/composables/__tests__/useJiraContributors.spec.ts
+++ b/src/composables/__tests__/useJiraContributors.spec.ts
@@ -1,0 +1,104 @@
+import { getJiraIssue, searchJiraUsers } from '@/services/JiraService';
+import useJiraContributors from '../useJiraContributors';
+import type { ZodJiraContributorType, ZodJiraUserPickerType } from '@/types/zodJira';
+
+vi.mock('@/services/JiraService', () => ({
+  getJiraIssue: vi.fn().mockResolvedValue({}),
+  searchJiraUsers: vi.fn().mockResolvedValue({})
+}));
+
+describe('useJiraContributors', () => {
+  const mockUsers: ZodJiraUserPickerType[] = [
+    {
+      displayName: 'Alvaro Tinoco',
+      name: 'atinoco',
+      html: 'Alvaro <b>Tinoco</b>',
+    },
+    {
+      displayName: 'John Doe',
+      name: 'jdoe',
+      html: 'John <b>Doe</b>',
+    },
+  ];
+
+  const mockContributors: ZodJiraContributorType[] = [
+    {
+      displayName: 'Alvaro Tinoco',
+      name: 'atinoco',
+      emailAddress: 'email@test.com',
+      self: 'https://jira.com',
+    },
+    {
+      displayName: 'John Doe',
+      name: 'jdoe',
+      emailAddress: 'email@test.com',
+      self: 'https://jira.com',
+    },
+  ];
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should initiate with empty contributors', () => {
+    const { contributors } = useJiraContributors('task_key');
+    expect(contributors.value).toEqual([]);
+  });
+
+  it('should load contributors', async () => {
+    vi.mocked(getJiraIssue, { partial: true }).mockResolvedValue({
+      data: {
+        id: '123',
+        self: 'https://jira.com',
+        key: 'key',
+        fields: {
+          customfield_12315950: mockContributors,
+        }
+      }
+    });
+    const { contributors, loadJiraContributors } = useJiraContributors('task_key');
+
+    await loadJiraContributors();
+
+    expect(getJiraIssue).toHaveBeenCalledWith('task_key');
+    expect(contributors.value).toEqual(mockContributors);
+  });
+
+  describe('searchContributors', () => {
+    beforeEach(() => {
+      vi.mocked(searchJiraUsers, { partial: true }).mockResolvedValue({
+        data: {
+          users: mockUsers,
+        }
+      });
+    });
+
+    it('should search contributors', async () => {
+      const { searchContributors } = useJiraContributors('task_key');
+
+      const result = await searchContributors('Alvaro');
+
+      expect(searchJiraUsers).toHaveBeenCalledWith('Alvaro');
+      expect(result).toEqual(mockUsers);
+    });
+
+    it('should not search if query is empty', async () => {
+      const { searchContributors } = useJiraContributors('task_key');
+
+      const result = await searchContributors('');
+
+      expect(searchJiraUsers).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('should memoize search', async () => {
+      const { searchContributors } = useJiraContributors('task_key');
+
+      await searchContributors('Alvaro');
+      await searchContributors('Alvaro');
+
+      expect(searchJiraUsers).toHaveBeenCalledTimes(1);
+    });
+  });
+
+});

--- a/src/composables/useJiraContributors.ts
+++ b/src/composables/useJiraContributors.ts
@@ -1,0 +1,63 @@
+import { ref } from 'vue';
+import type { ZodJiraContributorType } from '@/types/zodJira';
+import { getJiraIssue, putJiraIssue, searchJiraUsers } from '@/services/JiraService';
+import { createCatchHandler } from './service-helpers';
+import { useMemoize, watchIgnorable } from '@vueuse/core';
+
+export default function useJiraContributors(task_key: string) {
+  const contributors = ref<Partial<ZodJiraContributorType>[]>([]);
+  const hasNewContributors = ref(false);
+  const isLoadingContributors = ref(false);
+
+  const { ignoreUpdates } = watchIgnorable(contributors, () => {
+    console.log('Contributors updated');
+    hasNewContributors.value = true;
+  }, { deep: true });
+
+  const loadJiraContributors = async () => {
+    isLoadingContributors.value = true;
+
+    const data = await getJiraIssue(task_key)
+      .catch(createCatchHandler('Failed to load contributors', false));
+
+    ignoreUpdates(() => {
+      contributors.value = data?.data?.fields.customfield_12315950 ?? [];
+    });
+    isLoadingContributors.value = false;
+  };
+
+  const searchContributors = useMemoize(async (query: string) => {
+    if (!query) {
+      return [];
+    }
+    isLoadingContributors.value = true;
+    const users = await searchJiraUsers(query)
+      .catch(createCatchHandler('Failed to search contributors', false));
+    isLoadingContributors.value = false;
+    return users?.data?.users ?? [];
+  });
+
+  const saveContributors = async () => {
+    if (!hasNewContributors.value) {
+      return;
+    }
+
+    return await putJiraIssue(task_key, {
+      data: {
+        fields: {
+          customfield_12315950: contributors.value,
+        }
+      },
+    });
+  };
+
+  return {
+    contributors,
+    hasNewContributors,
+    isLoadingContributors,
+    loadJiraContributors,
+    searchContributors,
+    saveContributors,
+
+  };
+}

--- a/src/types/zodJira.ts
+++ b/src/types/zodJira.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export type ZodJiraUserPickerType = z.infer<typeof JiraUserPickerSchema>;
+export const JiraUserPickerSchema = z.object({
+  displayName: z.string(),
+  html: z.string(),
+  name: z.string(),
+});
+
+
+export type ZodJiraContributorType = z.infer<typeof JiraContributorSchema>;
+export const JiraContributorSchema = z.object({
+  self: z.string().url(),
+  name: z.string(),
+  key: z.string().optional(),
+  displayName: z.string(),
+  emailAddress: z.string().email(),
+});
+
+export type ZodJiraIssueType = z.infer<typeof JiraIssueSchema>;
+export const JiraIssueSchema = z.object({
+  id: z.string(),
+  self: z.string().url(),
+  key: z.string(),
+  fields:z.object({
+    customfield_12315950: z.array(JiraContributorSchema),
+  }).passthrough()
+});


### PR DESCRIPTION
# OSIDB-2916: Add Contributors field

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Added the `Contributors` field from Jira to OSIM

![image](https://github.com/RedHatProductSecurity/osim/assets/4268580/99e69fef-a7bb-4bf2-8735-7e3e6e106d26)
> Censored for privacy reasons. There's an uncensored video attached to the jira ticket

## Changes:

~While working on this task I got the `[object Object]` error and added the missing `return` that fixes the issue when osidb returns html (i.e stack trace of error).~ Fixed in https://github.com/RedHatProductSecurity/osim/pull/308

Created new `FlawContributors` component, is similar to the `TagsInput` widget, decided not to reuse the component because the auto-suggestions behavior is hard to implement in a reusable way. All the logic is inside the `useJiraContributors` composable.

I've added a generic type parameter to the `jiraFetch` function in `JiraService` so we can type the response easily, as well as some basic zod schemas and types for the response of the 2 new methods I added

## Considerations

https://github.com/RedHatProductSecurity/osidb/pull/598 **needs** to be merged/deployed first for editing the jira task to work