### PR TITLE
Task OSIDB-3002: Disable private comment creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OSIM Changelog
 
+## [Unreleased]
+### Changed
+* Temporary disable private comments creation (`OSIDB-3002`)
+
 ## [2024.6.1]
 ### Added
 * Support private Bugzilla comments (`OSIDB-2912`)

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -109,7 +109,10 @@ onMounted(async () => {
 });
 
 async function handleCommentSave() {
-  if (selectedTab.value === CommentType.Public || selectedTab.value === CommentType.Private) {
+  if (selectedTab.value === CommentType.Public
+  // TODO: Uncomment when osidb allows private comment creation
+  // || selectedTab.value === CommentType.Private
+  ) {
     // Osidb Bugzilla comment save
     emit('comment:addFlawComment', newComment.value, userStore.userName, CommentType[selectedTab.value] === 'Private');
     isAddingNewComment.value = false;
@@ -150,8 +153,20 @@ function sanitize(text: string) {
     >
       <template #header-actions>
         <div class="tab-actions">
+          <!-- TODO: Remove when osidb allows private comment creation -->
+          <span v-if="selectedTab === CommentType.Private" title="Private comment creation is temporary disabled">
+            <button
+              type="button"
+              class="btn btn-secondary tab-btn"
+              disabled
+              @click="isAddingNewComment = true"
+            >
+              Add {{ CommentType[selectedTab] }} Comment
+            </button>
+          </span>
+          <!-- End TODO -->
           <button
-            v-if="(
+            v-else-if="(
               !isAddingNewComment
               && selectedTab !== CommentType.System)
               && (internalCommentsAvailable || selectedTab !== CommentType.Internal
@@ -179,7 +194,8 @@ function sanitize(text: string) {
           <div
             v-if="(
               isAddingNewComment
-              && selectedTab !== CommentType.System)
+              && selectedTab !== CommentType.System
+              && selectedTab !== CommentType.Private) // TODO: Remove when osidb allows private comment creation
               && (internalCommentsAvailable
                 || selectedTab !== CommentType.Internal
               )"

--- a/src/views/FlawEditView.vue
+++ b/src/views/FlawEditView.vue
@@ -41,9 +41,9 @@ function refreshFlaw() {
   <main>
     <FlawForm
       v-if="flaw"
+      :key="`${flaw.uuid}-${flaw.updated_dt}`"
       v-model:flaw="flaw"
       mode="edit"
-      :key="`${flaw.uuid}-${flaw.updated_dt}`"
       @refresh:flaw="refreshFlaw"
     />
     <div v-if="errorLoadingFlaw">


### PR DESCRIPTION
# [OSIDB-3002] [Disable private comments creation until it is supported by OSIDB]

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases not added/updated
- [x] Jira ticket updated

## Summary:

Temporary disables private comment creation until it is supported from OSIDB side.

## Changes:

- Disable comment creation button on private comments tab
- Add a tooltip to inform users that the action is temporary disabled disabled
- Hide comment creation input text area on private comments tab

## Considerations:

- Didn't add reasons on the changelog as we are providing the ticket where all the info can be found