### PR TITLE
🐛 Ensure Expand All button shows on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Remove Trackers section on Flaw Edit (`OSIDB-2954`)
 * Owner - Status text overlap on flaw list (`OSIDB-2827`)
 * Fix Error for Duplicated Affects (`OSIDB-2894`)
+* Missing Expand All button on initial Flaw load (`OSIDB-3024`)
 
 ## [2024.6.1]
 ### Added

--- a/src/components/AffectedOfferings.vue
+++ b/src/components/AffectedOfferings.vue
@@ -49,7 +49,7 @@ watch(theAffects, (nextValue) => {
     return modules;
   }, {});
   updateAffectsExpandedState(nextValue);
-}, { deep: true });
+}, { deep: true, immediate: true });
 
 const areAnyComponentsExpanded = computed(
   () => affectedModules.value.some((moduleName) => affectsWithModuleName(moduleName).some(isExpanded))

--- a/src/components/__tests__/AffectedOfferings.spec.ts
+++ b/src/components/__tests__/AffectedOfferings.spec.ts
@@ -33,6 +33,50 @@ describe('AffectedOfferings', () => {
     expect(subject.findAll('.osim-affected-offering')).toHaveLength(3);
   });
 
+  it('renders the Expand All button only when some affects are collapsed', async () => {
+    const subject = mount(AffectedOfferings, {
+      props: {
+        theAffects: [
+          mockAffect({ ps_module: 'Module 1', ps_component: 'Component 1' }),
+          mockAffect({ ps_module: 'Module 1', ps_component: 'Component 2' }),
+          mockAffect({ ps_module: 'Module 2', ps_component: 'Component 1' }),
+        ],
+        affectsToDelete: [],
+        error: [],
+      },
+    });
+
+    let expandButton = subject.findAll('button').find((button) => button.text().includes('Expand All'));
+    expect(expandButton?.exists()).toBe(true);
+
+    await expandButton?.trigger('click');
+
+    expandButton = subject.findAll('button').find((button) => button.text().includes('Expand All'));
+    expect(expandButton).toBe(undefined);
+  });
+
+  it('renders the Collapse All button only when some affects are expanded', async () => {
+    const subject = mount(AffectedOfferings, {
+      props: {
+        theAffects: [
+          mockAffect({ ps_module: 'Module 1', ps_component: 'Component 1' }),
+          mockAffect({ ps_module: 'Module 1', ps_component: 'Component 2' }),
+          mockAffect({ ps_module: 'Module 2', ps_component: 'Component 1' }),
+        ],
+        affectsToDelete: [],
+        error: [],
+      },
+    });
+
+    let collapseButton = subject.findAll('button').find((button) => button.text().includes('Collapse All'));
+    expect(collapseButton).toBe(undefined);
+
+    const expandButton = subject.findAll('button').find((button) => button.text().includes('Expand All'));
+    await expandButton?.trigger('click');
+    collapseButton = subject.findAll('button').find((button) => button.text().includes('Collapse All'));
+    expect(collapseButton?.exists()).toBe(true);
+  });
+
   it('expands and collapses modules', async () => {
     const subject = mount(AffectedOfferings, {
       props: {


### PR DESCRIPTION
# OSIDB-3024 Show Expand All Button on load

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

A ref mirroring the prop containing the list of affects is watched in order to update the list of expanded modules. This watcher did not fire when the component initially receives this data, and the list of expanded affects did not update

## Changes:

- Fire the watcher function on load.
- Add test coverage for Expand/Collapse All buttons

## Considerations:

[Replace with any additional considerations, notes, or instructions for reviewers.]