### PR TITLE
Task OSIDB-3012: Enable private comments creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Changed
 * Temporary disable private comments creation (`OSIDB-3002`)
+* Enable private comments creation again (`OSIDB-3012`)
 
 ### Fixed
 * Flaws without a Jira task cannot be updated (`OSIDB-2960`)

--- a/src/components/FlawComments.vue
+++ b/src/components/FlawComments.vue
@@ -109,10 +109,7 @@ onMounted(async () => {
 });
 
 async function handleCommentSave() {
-  if (selectedTab.value === CommentType.Public
-  // TODO: Uncomment when osidb allows private comment creation
-  // || selectedTab.value === CommentType.Private
-  ) {
+  if (selectedTab.value === CommentType.Public || selectedTab.value === CommentType.Private) {
     // Osidb Bugzilla comment save
     emit('comment:addFlawComment', newComment.value, userStore.userName, CommentType[selectedTab.value] === 'Private');
     isAddingNewComment.value = false;
@@ -153,20 +150,8 @@ function sanitize(text: string) {
     >
       <template #header-actions>
         <div class="tab-actions">
-          <!-- TODO: Remove when osidb allows private comment creation -->
-          <span v-if="selectedTab === CommentType.Private" title="Private comment creation is temporary disabled">
-            <button
-              type="button"
-              class="btn btn-secondary tab-btn"
-              disabled
-              @click="isAddingNewComment = true"
-            >
-              Add {{ CommentType[selectedTab] }} Comment
-            </button>
-          </span>
-          <!-- End TODO -->
           <button
-            v-else-if="(
+            v-if="(
               !isAddingNewComment
               && selectedTab !== CommentType.System)
               && (internalCommentsAvailable || selectedTab !== CommentType.Internal
@@ -194,8 +179,7 @@ function sanitize(text: string) {
           <div
             v-if="(
               isAddingNewComment
-              && selectedTab !== CommentType.System
-              && selectedTab !== CommentType.Private) // TODO: Remove when osidb allows private comment creation
+              && selectedTab !== CommentType.System)
               && (internalCommentsAvailable
                 || selectedTab !== CommentType.Internal
               )"


### PR DESCRIPTION
# OSIDB-3012 Enable private comments creation

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [-] No test cases added/updated
- [x] Jira ticket updated

## Summary:

Re-enables private comment creation on edit flaw form as OSIDB part to handle the `is_private` parameter has been already completed and deployed.

## Changes:

- Enable comment creation button on private comments tab
- Removes tooltip to inform users that the action is temporary disabled disabled
- Shows comment creation input text area on private comments tab

## Considerations:

- Relates to: [OSIDB-3002: Disable private comment creation](https://github.com/RedHatProductSecurity/osim/pull/307)