### PR TITLE
Fix OSIDB-3066: Refresh multiple created attributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OSIM Changelog
 
+## [Unreleased]
+### Fixed
+* Missing references and/or acknowledgements after multiple creation (`OSIDB-3066`)
+* Form is not disabled during multiple references and/or acknowledgements creation (`OSIDB-3066`)
+
 ## [2024.6.2]
 ### Added
 * Create Jira task on demand for legacy flaws (`OSIDB-2883`)

--- a/src/composables/useFlawAttributionsModel.ts
+++ b/src/composables/useFlawAttributionsModel.ts
@@ -30,14 +30,12 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<b
     isSaving.value = true;
     await putFlawReference(flaw.value.uuid, reference.uuid, reference as any)
       .finally(() => isSaving.value = false);
-    afterSaveSuccess();
   }
 
   async function createReference(reference: ZodFlawReferenceType) {
     isSaving.value = true;
     await postFlawReference(flaw.value.uuid, reference)
       .finally(() => isSaving.value = false);
-    afterSaveSuccess();
   }
 
   async function deleteReference(referenceId: string) {
@@ -60,6 +58,7 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<b
         await createReference(reference);
       }
     }
+    afterSaveSuccess();
   }
 
   function addBlankReference(isEmbargoed: boolean) {
@@ -78,7 +77,6 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<b
     isSaving.value = true;
     await postFlawAcknowledgment(flaw.value.uuid, acknowlegdment)
       .finally(() => isSaving.value = false);
-    afterSaveSuccess();
   }
 
   async function deleteAcknowledgment(acknowledgmentId: string) {
@@ -92,7 +90,6 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<b
     isSaving.value = true;
     await putFlawAcknowledgment(flaw.value.uuid, acknowlegdment.uuid, acknowlegdment as any)
       .finally(() => isSaving.value = false);
-    afterSaveSuccess();
   }
 
   async function saveAcknowledgments(acknowledgments: ZodFlawAcknowledgmentType[]) {
@@ -103,6 +100,7 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<b
         await createAcknowledgment(acknowledgment);
       }
     }
+    afterSaveSuccess();
   }
 
   function addBlankAcknowledgment(isEmbargoed: boolean) {


### PR DESCRIPTION
# OSIDB-3066: Flaw refreshed before expected when creating multiple Refs/Acks

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [-] No test cases added/updated
- [x] Jira ticket updated

## Summary:

Fix for the `afterSaveSuccess` callback when the first attribution was created on multiple creation, refreshing the flaw and making the form enabled again when attributions were still on creation process.

## Changes:

- Handle `afterSuccess` on `useFlawAttributionModel` after all specific attribution operations are completed (e.g. creating multiple references)

## Considerations:

- Multiple delete operation on attributions is not supported
- For future improvement, would be nice to keep collapsibles state after refresh

## Demo:
### Before

https://github.com/RedHatProductSecurity/osim/assets/29104825/8fc2c7f5-d31a-4a9a-b567-f62eac9aee50

### After

https://github.com/RedHatProductSecurity/osim/assets/29104825/bcc835dd-a629-4657-ad61-eade376c5aa2
