### PR TITLE
Fix/osidb 3042 cvss affect updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Formatting for Tracker table timestamps (`OSIDB-2983`)
 * Inconsistent focusing on calculator fields (`OSIDB-2511`)
 * Some affects' trackers were not showing (`OSIDB-3065`, `OSIDB-3074`)
+* Affect CVSS scores could not be edited (`OSIDB-3042`)
 
 ### Removed
 * Removed Cvss Score field (`OSIDB-2511`)

--- a/src/components/AffectedOfferings.vue
+++ b/src/components/AffectedOfferings.vue
@@ -158,7 +158,7 @@ defineExpose({ togglePsModuleExpansion, togglePsComponentExpansion, isExpanded }
       </button>
     </div>
 
-    <div v-for="(moduleName) in affectedModules" :key="moduleName">
+    <div v-for="(moduleName, index) in affectedModules" :key="`ps_module-${index}`">
       <LabelCollapsible
         :isExpanded="expandedModules[moduleName] ?? false"
         class="mb-3"
@@ -192,7 +192,7 @@ defineExpose({ togglePsModuleExpansion, togglePsComponentExpansion, isExpanded }
         </template>
         <div
           v-for="(affect, index) in affectsWithModuleName(moduleName)"
-          :key="`moduleName-${affect.ps_component}-${index}`"
+          :key="affect.uuid || `new-affect-${index}`"
           class="osim-affected-offering"
         >
           <AffectExpandableForm

--- a/src/components/AffectedOfferings.vue
+++ b/src/components/AffectedOfferings.vue
@@ -158,7 +158,7 @@ defineExpose({ togglePsModuleExpansion, togglePsComponentExpansion, isExpanded }
       </button>
     </div>
 
-    <div v-for="(moduleName, index) in affectedModules" :key="`ps_module-${index}`">
+    <div v-for="(moduleName, moduleIndex) in affectedModules" :key="`ps_module-${moduleIndex}`">
       <LabelCollapsible
         :isExpanded="expandedModules[moduleName] ?? false"
         class="mb-3"

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -99,3 +99,13 @@ export function formatDate(date: Date | string, includeTime: boolean): string {
   const jsDate = new Date(date); // Handles strings in ISO/component format, and Date object
   return DateTime.fromJSDate(jsDate, { zone: 'utc' }).toFormat(format);
 }
+
+export function getSpecficCvssScore(scores: any[], issuer: string, version: string) {
+  return scores.find(
+    (score) => score.issuer === issuer && score.cvss_version === version
+  );
+}
+
+export function getRhCvss3 (scores: any[]) {
+  return getSpecficCvssScore(scores, 'RH', 'V3');
+}


### PR DESCRIPTION
# OSIDB-3042 Fix Affect CVSS score editing

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [ ] Test cases added/updated
- [x] Jira ticket updated

## Summary:

- Fixes tabbing in affect fields
- Fixes Affect CVSS score saving

## Changes:

For tabbing behavior, a dynamic, input-bound value was being used as key, which caused a reordering of the Vue component. 

For fixing the affect saving, the model was not being correctly interacted with by the update and input logic on the Affected Offering form.

## Considerations:

Closes OSIDB-3042