### PR TITLE
Fix OSIDB-2905: Edited references not commited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # OSIM Changelog
 
 ## [Unreleased]
+### Added
+* Apply modified style to references and ackowledgements cards when they differ to the saved value (`OSIDB-2905`)
+
 ### Fixed
 * Missing references and/or acknowledgements after multiple creation (`OSIDB-3066`)
 * Form is not disabled during multiple references and/or acknowledgements creation (`OSIDB-3066`)
+* Auto commit edited references and ackowledgements when start editting a new one (`OSIDB-2905`)
 
 ## [2024.6.2]
 ### Added

--- a/src/components/widgets/EditableList.vue
+++ b/src/components/widgets/EditableList.vue
@@ -93,11 +93,10 @@ defineExpose({ isExpanded });
         v-for="(item, itemIndex) in items"
         :id="item.uuid"
         :key="itemIndex"
-        class="card p-3 pb-1 mb-3 rounded-3 osim-editable-list-card"
+        class="card p-3 pb-1 mb-3 rounded-3 osim-editable-list-card bg-light-light-gray"
         :class="{
-          'bg-light-light-orange': modifiedItemIndexes.includes(itemIndex),
-          'bg-light-light-gray': !modifiedItemIndexes.includes(itemIndex),
           'bg-light-green': !item.uuid,
+          'bg-light-yellow': modifiedItem(itemIndex),
         }"
       >
         <div>


### PR DESCRIPTION
# OSIDB-2905: Changing edited references are not saved

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [-] No test cases added/updated
- [x] Jira ticket updated

## Summary:

- Fix for the issue of not auto committing attributions being edited when changing to edit a new one.
Also applying minor enhancements for modified items logic, and styling.

Closes OSIDB-2905

## Changes:

- Adds a watcher to `EditableList` that auto-commits the changes if switching edit mode between items.
- Changes logic to consider a item has been modified when it differs with the saved values (previously compared with `priorValues`)
- Adjust items card styling

## Considerations:

- `priorValues` are still needed for revert changes on `cancel` actions

## Demo:
### Before:

https://github.com/RedHatProductSecurity/osim/assets/29104825/a8119a2a-814c-45a3-8696-363edc84057e

### After:

https://github.com/RedHatProductSecurity/osim/assets/29104825/64a4b09d-5851-4a19-a3a7-02e810c9c133

Closes OSIDB-2905
