### PR TITLE
Enforce jira link on pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,3 +21,5 @@
 ## Considerations:
 
 [Replace with any additional considerations, notes, or instructions for reviewers.]
+
+<!--- Remember to add the `Closes OSIDB-XXX` to link the jira task or the corresponding label -->

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -1,0 +1,34 @@
+# This workflow checks for a Jira issue link in the PR description
+# and fails the workflow if the link is missing.
+# The workflow can be ignored by adding a specific label to the PR.
+
+name: Jira Link
+
+
+env:
+  # Label to ignore the Jira link check
+  LABEL: internal 
+  # Regex to match the jira link. Only supports Extended Regular Expressions (ERE)
+  REGEX: (Closes|Fixes) +(OSIDB-[0-9]+)
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled]
+
+jobs:
+  enforce-jira-link:
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'internal') }} # Can't use env.LABEL here
+    runs-on: ubuntu-latest
+    env:
+      # Mitigate script injection
+      # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+      PULL_REQUEST: ${{ github.event.pull_request.body }}
+    steps:
+      - name: Check for Jira issue link in PR body
+        run: |
+          if [[ ! $PULL_REQUEST =~ (${{ env.REGEX }}) ]]; then
+            echo "No Jira issue link found in PR body.
+          Please include a Jira issue link in the PR body or add the '$LABEL' label.
+          Example: 'Closes OSIDB-1234'."
+            exit 1
+          fi


### PR DESCRIPTION
This PR adds a new github action that enforces the use of `Closes OSIDB-1234` or `Fixes OSIDB-1234` for linking the PR with Jira.

Added a comment to the PR template that reminds the user to add the tag as well.

In case that the PR does not have a Jira task associated, add the `internal` label to skip the check