### PR TITLE
✨ Provide fallback values for unparsed errors

### DIFF
--- a/src/services/__tests__/osidb-errors-helpers.spec.ts
+++ b/src/services/__tests__/osidb-errors-helpers.spec.ts
@@ -70,6 +70,20 @@ describe('OSIDB Error helpers', () => {
     expect(getDisplayedOsidbError(error)).toBe('Likely error between OSIDB and database:\nSome error on line 1');
   });
 
+  it('should return default error when HTML does not match', () => {
+    const error = {
+      response: {
+        headers: {
+          'content-type': 'text/html',
+        },
+        data: '<h1>Server Error (500)</h1><p></p>',
+      }
+    };
+
+    expect(getDisplayedOsidbError(error))
+      .toBe('Likely error between OSIDB and database:\nPlease contact OSIM/OSIDB team');
+  });
+
   describe('parseOsidbErrors', () => {
     it('should return a string with each error message separated by a pair of newlines', () => {
       const errors = [

--- a/src/services/osidb-errors-helpers.ts
+++ b/src/services/osidb-errors-helpers.ts
@@ -34,17 +34,17 @@ export function parseOsidbErrors(errors: any[]) {
 }
 
 
-function parseOsidbHtmlError(error: any){
+function parseOsidbHtmlError(error: any) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(
     error.response.data, error.response.headers['content-type']
   );
   const exception_value = doc.querySelector('.exception_value'); // May depend on OSIDB being in debug mode?
 
-  const text = (exception_value as HTMLElement)?.innerText
+  const text = ((exception_value as HTMLElement)?.innerText
     ?? (exception_value as HTMLElement)?.textContent
-    ?? (exception_value as HTMLElement)?.innerHTML
-    ?? 'No error message found in HTML response from OSIDB. Check developer tools for more info.';
+    ?? (exception_value as HTMLElement)?.innerHTML)
+    || 'Please contact OSIM/OSIDB team';
 
   return 'Likely error between OSIDB and database:\n' + text;
 }

--- a/src/services/osidb-errors-helpers.ts
+++ b/src/services/osidb-errors-helpers.ts
@@ -41,7 +41,10 @@ function parseOsidbHtmlError(error: any){
   );
   const exception_value = doc.querySelector('.exception_value'); // May depend on OSIDB being in debug mode?
 
-  const text = (exception_value as HTMLElement)?.innerText;
+  const text = (exception_value as HTMLElement)?.innerText
+    ?? (exception_value as HTMLElement)?.textContent
+    ?? (exception_value as HTMLElement)?.innerHTML
+    ?? 'No error message found in HTML response from OSIDB. Check developer tools for more info.';
 
   return 'Likely error between OSIDB and database:\n' + text;
 }


### PR DESCRIPTION
# OSIDB-3080 Capture errors on prod when not in DEBUG mode

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

When the DEBUG mode is disabled (like in production) Django returns a generic `Server error` HTML body that didn't match our parser and a `undefined` was shown instead. Added a generic default message for that case.

For now this message is enough, in a future release we could add a `Contact` page to OSIM with links to email/slack channels for help and point to that page in the error message

## Considerations:

Closes OSIDB-3080
