### PR TITLE
Fix absolute positioning of bugzilla link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OSIM Changelog
 
+# [Unreleased]
+### Fixed
+* Bugzilla tracker link overlaps with the workflow actions (`OSIDB-3089`)
+
 ## [2024.7.0]
 ### Changed
 * Make text area descriptions layout static (always visible) (`OSIDB-2005`)

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -226,7 +226,7 @@ const createdDate = computed(() => {
         class="row px-4 my-3"
         :class="{'osim-flaw-form-embargoed border border-2 border-primary': flaw.embargoed}"
       >
-        <div class="row osim-flaw-form-section" :class="{ 'pt-5': mode === 'create'}">
+        <div class="row osim-flaw-form-section">
           <div v-if="flaw.meta_attr?.bz_id" class="osim-flaw-header-link">
             <a
               :href="bugzillaLink"
@@ -517,6 +517,10 @@ form.osim-flaw-form :deep(*) {
   .osim-flaw-form-section {
     position: relative;
     padding-block: 1.5rem;
+  }
+
+  .osim-alerts-banner {
+    min-height: 3rem;
   }
 }
 


### PR DESCRIPTION
# OSIDB-3089 Open in Bugzilla link blocks workflow actions

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [ ] Test cases added/updated
- [x] Jira ticket updated

## Summary:

When a Flaw does not have alerts, the `Open in bugzilla` link overlaps with the workflow actions because of the absolute positioning

## Changes:

### Before
![image](https://github.com/RedHatProductSecurity/osim/assets/4268580/fe02f54d-2442-4dfc-9b52-b8c4e7eaa288)
![image](https://github.com/RedHatProductSecurity/osim/assets/4268580/213d849a-a34b-4941-b1e7-ec4f50863da4)

### After
![image](https://github.com/RedHatProductSecurity/osim/assets/4268580/8a9cb95c-dd9f-46f7-89ff-9004f3ca3604)
![image](https://github.com/RedHatProductSecurity/osim/assets/4268580/62f95ac3-b046-4b31-a3cf-87864cce7149)

## Considerations:

Closes OSIDB-3089
