### PR TITLE
🐛 OSIDB-3092: Remove duplicated loading spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # [Unreleased]
 ### Fixed
 * Bugzilla tracker link overlaps with the workflow actions (`OSIDB-3089`)
+* Duplicated loading spinner on flaw lists (`OSIDB-3092`)
 
 ## [2024.7.0]
 ### Changed

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -182,14 +182,6 @@ const nameForOption = (fieldName: string) => {
         <span> Loading Flaws&hellip; </span>
       </div>
       <span
-        v-if="isLoading"
-        class="spinner-border spinner-border-sm d-inline-block ms-3"
-        role="status"
-      >
-        <span class="visually-hidden">Loading...</span>
-      </span>
-      <span v-if="isLoading"> Loading Flaws&hellip; </span>
-      <span
         v-if="issues.length"
         class="float-end"
         :class="{'text-secondary': isLoading}"


### PR DESCRIPTION
# OSIDB-3092 Remove duplicated loading spinner

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [-] No test cases added/updated
- [x] Jira ticket updated

## Summary:

Removes duplicated spinner indicator on flaw queues when loading flaws

## Changes:

- Removes duplicated code

## Considerations:

Closes OSIDB-3092

## Demo
Before:
![image](https://github.com/RedHatProductSecurity/osim/assets/29104825/122bcef9-1eba-4fe6-8e41-f31083d58642)

After:
![image](https://github.com/RedHatProductSecurity/osim/assets/29104825/5a04c054-5cb9-4d14-bcba-94ae121e6e48)
