### PR TITLE
🐛 Fix OSIDB-3091: Internal comments creation fail on Chrome browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # [Unreleased]
 ### Fixed
 * Bugzilla tracker link overlaps with the workflow actions (`OSIDB-3089`)
+* Internal comments creation fails on chrome browser (`OSIDB-3091`)
 
 ## [2024.7.0]
 ### Changed

--- a/build/entrypoint.d/30-reverse-proxy.sh
+++ b/build/entrypoint.d/30-reverse-proxy.sh
@@ -27,5 +27,6 @@ cat <<'EOF' >>/tmp/osim-nginx-proxy.conf
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header User-Agent OSIM;
 }
 EOF

--- a/src/services/JiraService.ts
+++ b/src/services/JiraService.ts
@@ -170,7 +170,6 @@ async function osimRequestHeaders() {
     return new Headers({
       'Authorization': `Bearer ${settingsStore.settings.jiraApiKey}`,
       'Content-Type': 'application/json',
-      'User-Agent': 'OSIM',
     });
   } else {
     return new Headers({


### PR DESCRIPTION
# OSIDB-3091 Internal comments creation fail on Chrome browser

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [-] No test cases added/updated
- [x] Jira ticket updated

## Summary:

### TL;DR
Fix internal comment creation on chrome browsers by moving the User-Agent header definition (Prod only) from the `JiraService` to the nginx reverse proxy. 

### Context
User-Agent header needs to be set to a dummy value or removed for some requests to work on Jira REST API:
[REST API calls with a browser User-Agent header may fail CSRF checks](https://confluence.atlassian.com/jirakb/rest-api-calls-with-a-browser-user-agent-header-may-fail-csrf-checks-802591455.html)
[REST API request fails with XSRF check failed](https://community.developer.atlassian.com/t/rest-api-request-fails-with-xsrf-check-failed/22025)

### Issue 
We set the User-Agent header to "OSIM" in the JiraService (`osimRequestHeaders` method), as it is supposed that all headers from the original request are passed to the reverse proxy by default as per indicated on [proxy_pass_request_headers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass_request_headers).
For some reason that doesn't apply for User-Agent, and it is overridden by the browser's value, which made the post requests for the internal comments fail in production with `XSRF check failed` error when using chrome browsers.

## Changes:
- Move User-Agent header definition from `JiraService` to nginx reverse proxy configuration

## Considerations:

- Manually tested and working on Firefox and Chrome browsers for prod OSIM instances
- For future Jira API troubleshoot it's worth checking in the network requests that User-Agent header value is set to "OSIM", specially when receiving XSRF check failed response.

Closes OSIDB-3091
