### PR TITLE
Allow deleting CVSS scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Auto commit edited references and ackowledgements when start editting a new one (`OSIDB-2905`)
 * Affects resolution is not updated after changing affectedness (`OSIDB-3123`)
 * Affect CVSS scores wouldn't save properly (`OSIDB-3100`)
-
+* Can't clear CVSS score from a flaw (`OSIDB-1843`)
 
 ## [2024.7.0]
 ### Changed

--- a/src/composables/useFlawCvssScores.ts
+++ b/src/composables/useFlawCvssScores.ts
@@ -1,4 +1,4 @@
-import { putFlawCvssScores, postFlawCvssScores } from '@/services/FlawService';
+import { deleteFlawCvssScores, putFlawCvssScores, postFlawCvssScores } from '@/services/FlawService';
 import { computed, ref, watch, type Ref } from 'vue';
 import type { ZodFlawType } from '@/types/zodFlaw';
 import { groupWith, equals } from 'ramda';
@@ -92,9 +92,14 @@ export function useFlawCvssScores(flaw: Ref<ZodFlawType>) {
 
   async function saveCvssScores() {
     if (flawRhCvss3.value?.created_dt) {
+      // Handle existing CVSS score
+      if (flawRhCvss3.value?.vector === null && flawRhCvss3.value?.uuid != null) {
+        return deleteFlawCvssScores(flaw.value.uuid, flawRhCvss3.value.uuid);
+      }
       return putFlawCvssScores(flaw.value.uuid, flawRhCvss3.value.uuid || '', flawRhCvss3.value as unknown);
     }
 
+    // Handle newly created CVSS score
     const requestBody = {
       // "score":  is recalculated based on the vector by OSIDB and does not need to be included
       comment: flawRhCvss3.value?.comment,

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -115,6 +115,18 @@ export async function putFlawCvssScores(
     .catch(createCatchHandler('CVSS Scores Update Error'));
 }
 
+export async function deleteFlawCvssScores(
+  flawId: string,
+  cvssScoresId: string,
+) {
+  return osidbFetch({
+    method: 'delete',
+    url: `/osidb/api/v1/flaws/${flawId}/cvss_scores/${cvssScoresId}`,
+  })
+    .then(createSuccessHandler({ title: 'Success!', body: 'CVSS score deleted.' }))
+    .catch(createCatchHandler('Error deleting CVSS score:'));
+}
+
 // {
 //   "comment": "string",
 //   "cvss_version": "string",

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -89,7 +89,7 @@ export const FlawCVSSSchema = z.object({
   cvss_version: z.string(),
   flaw: z.string().uuid(),
   issuer: z.nativeEnum(IssuerEnum),
-  score: z.number(), // $float
+  score: z.number().nullable(), // $float
   uuid: z.string().uuid().nullable(), // read-only
   vector: z.string().nullable(),
   embargoed: z.boolean().nullable(),


### PR DESCRIPTION
# OSIDB-1843 Allow deleting CVSS scores

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Right now it is not possible to delete a flaw's CVSS score through OSIM. Even though there is a button to clear the field, when trying to save the flaw it will show an error saying that this field cannot be null.

With this commit, when clearing the CVSS score field and saving the flaw, it will delete the CVSS score through OSIDB's API, using the DELETE method.

Closes OSIDB-1843.

<!--- Remember to add the `Closes OSIDB-XXX` to link the jira task or the corresponding label -->
