### PR TITLE
OSIDB-3123: Invalid Affect Resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Duplicated loading spinner on flaw lists (`OSIDB-3092`)
 * Internal comments creation fails on chrome browser (`OSIDB-3091`)
 * Auto commit edited references and ackowledgements when start editting a new one (`OSIDB-2905`)
+* Affects resolution is not updated after changing affectedness (`OSIDB-3123`)
 
 ## [2024.7.0]
 ### Changed

--- a/src/components/AffectedOfferingForm.vue
+++ b/src/components/AffectedOfferingForm.vue
@@ -6,21 +6,17 @@ import LabelSelect from '@/components/widgets/LabelSelect.vue';
 import { osimRuntime } from '@/stores/osimRuntime';
 import { trackerUrl } from '@/services/TrackerService';
 import {
+  AffectednessResolutionPairs,
   affectAffectedness,
   affectImpacts,
-  affectResolutions,
   type ZodAffectType,
 } from '@/types/zodAffect';
 import { formatDate, getRhCvss3 } from '@/utils/helpers';
 
 const { width: screenWidth } = useWindowSize();
-const resolutionOptions = computed(() => {
-  return {
-    AFFECTED: affectResolutions,
-    NEW: [''],
-    NOTAFFECTED: [''],
-  }[modelValue.value?.affectedness as string] || [''];
-});
+const resolutionOptions = computed(() =>
+  (modelValue.value?.affectedness && AffectednessResolutionPairs[modelValue.value?.affectedness]) || []
+);
 type NotUndefined<T> = Exclude<T, undefined>;
 
 defineProps<{
@@ -54,6 +50,11 @@ watch(() => rhCvss3.value?.vector, () => {
   }
 });
 
+watch(() => modelValue.value?.affectedness, () => {
+  if (modelValue.value) {
+    modelValue.value.resolution = '';
+  }
+});
 
 const hasTrackers = computed(() =>
   modelValue.value?.trackers
@@ -61,10 +62,6 @@ const hasTrackers = computed(() =>
   && modelValue.value?.trackers.every(({ ps_update_stream }) => ps_update_stream)
 );
 
-const hiddenResolutionOptions = computed(() => {
-  const availableOptions = ['', 'DELEGATED', 'WONTFIX', 'OOSS'];
-  return affectResolutions.filter(option => !availableOptions.includes(option));
-});
 </script>
 
 <template>
@@ -93,7 +90,6 @@ const hiddenResolutionOptions = computed(() => {
         :error="error?.resolution"
         label="Resolution"
         :options="resolutionOptions"
-        :optionsHidden="hiddenResolutionOptions"
       />
       <LabelSelect
         v-model="modelValue.impact"

--- a/src/components/__tests__/AffectExpandableForm.spec.ts
+++ b/src/components/__tests__/AffectExpandableForm.spec.ts
@@ -1,12 +1,12 @@
-import { mount } from '@vue/test-utils';
+import { type VueWrapper, mount } from '@vue/test-utils';
 import { describe, it, expect } from 'vitest';
 
 import AffectExpandableForm from '@/components/AffectExpandableForm.vue';
 import AffectedOfferingForm from '@/components/AffectedOfferingForm.vue';
 import LabelSelect from '@/components/widgets/LabelSelect.vue';
 import {
-  affectResolutions,
   affectAffectedness,
+  AffectednessResolutionPairs,
 } from '@/types/zodAffect';
 
 vi.mock('@/stores/osimRuntime', async () => {
@@ -152,9 +152,7 @@ describe('AffectExpandableForm', () => {
     expect(affectednessOptions).toStrictEqual(affectAffectedness);
     await affectednessSelectEl.find('select').setValue('AFFECTED');
     const resolutionOptions = resolutionSelectEL.props('options');
-    expect(resolutionOptions).toStrictEqual(affectResolutions);
-    const resolutoinHiddenOptions = resolutionSelectEL.findAll('option[hidden]');
-    expect(resolutoinHiddenOptions.length).toBe(3);
+    expect(resolutionOptions).toStrictEqual(AffectednessResolutionPairs['AFFECTED']);
   });
 
   it('should render trackers with errata link', async () => {

--- a/src/components/widgets/LabelSelect.vue
+++ b/src/components/widgets/LabelSelect.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
+import { isStringArray } from '@/utils/guards';
+
 defineEmits<{
   'update:modelValue': [value: string | undefined],
 }>();
 withDefaults(
   defineProps<{
     modelValue: string | null;
-    options: string[];
+    options: string[] | Record<string, string>;
     optionsHidden?: string[] | null;
     label: string;
     error: string | null;
@@ -38,15 +40,28 @@ withDefaults(
             $emit('update:modelValue', (($event as InputEvent).target as HTMLInputElement).value)
           "
         >
-          <option
-            v-for="option in options"
-            :key="option"
-            :value="option"
-            :selected="option === modelValue"
-            :hidden="optionsHidden?.includes(option)"
-          >
-            {{ option }}
-          </option>
+          <template v-if="isStringArray(options)">
+            <option
+              v-for="option in options"
+              :key="option"
+              :value="option"
+              :selected="option === modelValue"
+              :hidden="optionsHidden?.includes(option)"
+            >
+              {{ option }}
+            </option>
+          </template>
+          <template v-else>
+            <option
+              v-for="(value, key) in options"
+              :key="key"
+              :value="value"
+              :selected="value === modelValue"
+              :hidden="optionsHidden?.includes(value)"
+            >
+              {{ key }}
+            </option>
+          </template>
         </select>
         <div
           v-if="error"

--- a/src/utils/guards.ts
+++ b/src/utils/guards.ts
@@ -1,0 +1,6 @@
+export function isStringArray(value: unknown): value is string[] {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.every((item) => typeof item === 'string');
+}


### PR DESCRIPTION
# OSIDB-3123: Invalid Affect Resolution

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

When the `affectedness` was changed, the `resolution` kept the previous value, only the available options where updated but not the affect model.

## Changes:

* Reset the `resolution` value when the `affectedness` is changed
* Simplify the logic by using the available `affectedness` and `resolution` enums
* Changed the empty value (`''`) to an `Empty` string so it's easier to differentiate empty vs undefined
* Added a validation to the `resolution` based on the possibles values. See https://github.com/RedHatProductSecurity/osidb/blob/master/osidb/constants.py#L61-L76
## Considerations:

Closes OSIDB-3123

https://github.com/RedHatProductSecurity/osim/assets/4268580/c483d8ee-b05b-4c5f-a714-6616bf6d057e

