### PR TITLE
Reorder Flaw update saving operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,15 @@
 * Affects resolution is not updated after changing affectedness (`OSIDB-3123`)
 * Affect CVSS scores wouldn't save properly (`OSIDB-3100`)
 * Can't clear CVSS score from a flaw (`OSIDB-1843`)
+* Flaw could not be saved without affects in several situations (`OSIDB-3099`)
 
 ### Removed
 * Remove dirty flag from footer and from build validation process (`OSIDB-3068`)
+* Being unable (with one action) simultaneously update a flaw's components and affects (`OSIDB-3100`)
+
+### Changed
+* Reload trackers after filing trackers (`OSIDB-3049`)
+* Changed order of saving operations when updating a flaw (`OSIDB-3100`, `OSIDB-3099`)
 
 ## [2024.7.0]
 ### Changed

--- a/src/components/AffectsTrackers.vue
+++ b/src/components/AffectsTrackers.vue
@@ -11,7 +11,7 @@ const {
   trackerSelections,
   trackersToFile,
   fileTrackers,
-  setAll,
+  setAllTrackerSelections,
   unselectedStreams,
   selectedStreams,
   filterString,
@@ -73,7 +73,7 @@ const emit = defineEmits<{
             <button
               type="button"
               class="btn btn-white btn-outline-black btn-sm me-2"
-              @click="setAll(true)"
+              @click="setAllTrackerSelections(true)"
             >
               <i class="bi bi-check-all"></i>
               Select All
@@ -82,7 +82,7 @@ const emit = defineEmits<{
             <button
               type="button"
               class="btn btn-white btn-outline-black btn-sm me-2"
-              @click="setAll(false)"
+              @click="setAllTrackerSelections(false)"
             >
               <i class="bi bi-eraser"></i>
               Deselect All

--- a/src/composables/useFlawAffectsModel.ts
+++ b/src/composables/useFlawAffectsModel.ts
@@ -291,5 +291,6 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
     wereAffectsModified,
     affectsToDelete,
     didAffectsChange,
+    initialAffects,
   };
 }

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -105,7 +105,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
 
   async function updateFlaw() {
     const { execute } = useNetworkQueue();
-    const queue: Array<() => Promise<any>> = [];
+    const queue: (() => Promise<any>)[] = [];
 
     isSaving.value = true;
     const validatedFlaw = validate();
@@ -115,19 +115,19 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
       return;
     }
 
-    if (didAffectsChange.value) {
-      queue.push(saveAffects);
+    queue.push(putFlaw.bind(null, flaw.value.uuid, validatedFlaw.data, shouldCreateJiraTask.value));
+
+    if (wasCvssModified.value) {
+      queue.push(saveCvssScores);
     }
 
     if (affectsToDelete.value.length) {
       queue.push(removeAffects);
     }
 
-    if (wasCvssModified.value) {
-      queue.push(saveCvssScores);
+    if (didAffectsChange.value) {
+      queue.push(saveAffects);
     }
-
-    queue.push(putFlaw.bind(null, flaw.value.uuid, validatedFlaw.data, shouldCreateJiraTask.value));
 
     try {
       await execute(...queue);

--- a/src/composables/useTrackers.ts
+++ b/src/composables/useTrackers.ts
@@ -99,7 +99,9 @@ export function useTrackers(flawUuid: string, affects: ZodAffectType[]) {
     });
   });
 
-  function setAll(isSelected: boolean) {
+  loadTrackers();
+
+  function setAllTrackerSelections(isSelected: boolean) {
     for (const stream of sortedStreams.value) {
       trackerSelections.value.set(stream, isSelected);
     }
@@ -120,11 +122,11 @@ export function useTrackers(flawUuid: string, affects: ZodAffectType[]) {
       })
   );
 
-  getTrackersForFlaws({ flaw_uuids: [flawUuid] })
-    .then((response: any) => {
-      moduleComponents.value = response.modules_components;
-    })
-    .catch(console.error);
+  function loadTrackers() {
+    return getTrackersForFlaws({ flaw_uuids: [flawUuid] })
+      .then((response: any) => moduleComponents.value = response.modules_components)
+      .catch(console.error);
+  }
 
   function getUpdateStreamsFor(module: string, component: string) {
     const moduleComponent = moduleComponents.value.find(
@@ -135,7 +137,9 @@ export function useTrackers(flawUuid: string, affects: ZodAffectType[]) {
 
   function fileTrackers() {
     isFilingTrackers.value = true;
-    fileTrackingFor(trackersToFile.value).finally(() => isFilingTrackers.value = false);
+    return fileTrackingFor(trackersToFile.value)
+      .then(loadTrackers)
+      .finally(() => isFilingTrackers.value = false);
   }
 
   return {
@@ -145,7 +149,7 @@ export function useTrackers(flawUuid: string, affects: ZodAffectType[]) {
     availableUpdateStreams,
     trackerSelections,
     trackersToFile,
-    setAll,
+    setAllTrackerSelections,
     sortedStreams,
     unselectedStreams,
     selectedStreams,

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -250,15 +250,4 @@ export const ZodFlawSchema = z.object({
       ['affects', `${affect.index}`, 'ps_component'],
     );
   }
-
-  // Do we want validation for unregistered components in affected offerings?
-
-  // const unregisteredComponents = zodFlaw.components.filter(
-  //   (component) => !zodFlaw.affects.find(affect => affect.ps_component === component)
-  // );
-
-  // if (unregisteredComponents.length) {
-  //   const verb = unregisteredComponents.length === 1 ? 'is' : 'are';
-  //   raiseIssue(`${zodFlaw.components.join(', ')} ${verb} not in the Flaw's Affected Offerings`, ['components']);
-  // }
 });


### PR DESCRIPTION


# OSIDB-3099 OSIDB-3049 

## Checklist:

- [x] Linting passed
- [x] Type checks passed
- [x] Tests suite passed
- [x] Commits consolidated
- [x] Changelog updated
- [ ] Manually test on stage
- [x] Jira ticket updated

## Summary:

Reorders save operations for updating flaws, flaw & affect component validation, refreshing for trackers.

## Changes:

- Change saving order
```diff
 - Affects, Delete Affects, Flaw CVSS, Flaw
 + Flaw, Flaw CVSS, Delete Affects, Affects
```
- Added validations for presence of Flaw `components` in its affected offerings 
-  Refresh trackers after filing trackers

## Considerations:

Merge into stage for testing.

Closes OSIDB-3049.
Closes OSIDB-3099.
