### PR TITLE
Remove validation for dirty tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Auto commit edited references and ackowledgements when start editting a new one (`OSIDB-2905`)
 * Affects resolution is not updated after changing affectedness (`OSIDB-3123`)
 
+### Removed
+* Remove dirty flag from footer and from build validation process (`OSIDB-3068`)
+
 ## [2024.7.0]
 ### Changed
 * Make text area descriptions layout static (always visible) (`OSIDB-2005`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,10 @@ RUN yarn build
 RUN --mount=target=/mnt \
     cd /mnt \
     && git config --global --add safe.directory /mnt \
-    && printf '{"rev":"%s","tag":"%s","timestamp":"%s","dirty":%s}' >/opt/app-root/src/osim_build.json \
+    && printf '{"rev":"%s","tag":"%s","timestamp":"%s"}' >/opt/app-root/src/osim_build.json \
     "$(git rev-parse --verify HEAD)" \
     "$(git describe --always --tags --match 'v[0-9]*')" \
-    "$(date --utc --date=@"$(git show --quiet --format=%ct)" +%FT%TZ)" \
-    "$(if [ "$(git status --porcelain)" = "" ]; then echo false; else echo true; fi)"
+    "$(date --utc --date=@"$(git show --quiet --format=%ct)" +%FT%TZ)"
 
 # Nginx service stage
 FROM registry.access.redhat.com/ubi9/ubi-minimal AS nginx-base

--- a/build/entrypoint.d/20-osim-runtime-json.sh
+++ b/build/entrypoint.d/20-osim-runtime-json.sh
@@ -14,13 +14,13 @@ OSIM_BACKENDS_BUGZILLA="${OSIM_BACKENDS_BUGZILLA:-http://bugzilla-service:8001}"
 OSIM_BACKENDS_JIRA="${OSIM_BACKENDS_JIRA:-http://jira-service:8002}"
 OSIM_BACKENDS_ERRATA="${OSIM_BACKENDS_ERRATA:-http://errata-service:8003}"
 OSIM_BACKENDS_JIRA_DISPLAY="${OSIM_BACKENDS_JIRA_DISPLAY:-http://jira-service:8002}"
-OSIM_VERSION='{"rev":"dev","tag":"dev","timestamp":"1970-01-01T00:00:00Z","dirty":true}'
+OSIM_VERSION='{"rev":"dev","tag":"dev","timestamp":"1970-01-01T00:00:00Z"}'
 OSIM_READONLY_MODE=${OSIM_READONLY_MODE:-false}
 
 if [ -f "/osim_build.json" ]; then
     # Add the OSIM build info
     # File format:
-    # {"rev":"dev","tag":"dev","timestamp":0,"dirty":true}
+    # {"rev":"dev","tag":"dev","timestamp":0}
     IFS= read -r -d '' OSIM_VERSION <"/osim_build.json" || :
 fi
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -109,8 +109,7 @@ OSIM_NGINX_PROXY_CA=
       "osimVersion": {
         "rev":"dev",
         "tag":"dev",
-        "timestamp":"1970-01-01T00:00:00Z",
-        "dirty":true
+        "timestamp":"1970-01-01T00:00:00Z"
       }
     }
   ```

--- a/src/App.vue
+++ b/src/App.vue
@@ -66,7 +66,6 @@ onBeforeUnmount(() => {
         | env: {{ osimRuntime.env }}
         | <span :title="osimRuntime.osimVersion.rev">
           tag: {{ osimRuntime.osimVersion.tag }}
-          <span v-if="osimRuntime.osimVersion.dirty">(dirty)</span>
         </span>
         | ts : {{ osimRuntime.osimVersion.timestamp
           .substring(0, osimRuntime.osimVersion.timestamp.indexOf('T')) }}

--- a/src/components/__tests__/AffectExpandableForm.spec.ts
+++ b/src/components/__tests__/AffectExpandableForm.spec.ts
@@ -20,7 +20,7 @@ vi.mock('@/stores/osimRuntime', async () => {
       jiraDisplay: 'http://jira-backend',
     },
     osimVersion: {
-      rev: 'osimrev', tag: 'osimtag', timestamp: '1970-01-01T00:00:00Z', dirty: true
+      rev: 'osimrev', tag: 'osimtag', timestamp: '1970-01-01T00:00:00Z'
     },
     error: '',
   };

--- a/src/components/__tests__/App.spec.ts
+++ b/src/components/__tests__/App.spec.ts
@@ -61,7 +61,7 @@ describe('App', async () => {
           jira: 'jira-backend',
         },
         osimVersion: {
-          rev: 'osimrev', tag: 'osimtag', timestamp: '1970-01-01T00:00:00Z', dirty: true
+          rev: 'osimrev', tag: 'osimtag', timestamp: '1970-01-01T00:00:00Z'
         },
         error: '',
       };
@@ -129,7 +129,7 @@ describe('App', async () => {
     const statusBar = subject.find('.osim-status-bar');
     expect(statusBar?.exists()).toBeTruthy();
     expect(statusBar?.text().includes('env: unittest')).toBeTruthy();
-    expect(statusBar?.text().includes('tag: osimtag (dirty)')).toBeTruthy();
+    expect(statusBar?.text().includes('tag: osimtag')).toBeTruthy();
     expect(statusBar?.text().includes('ts : 1970-01-01')).toBeTruthy();
   });
 });

--- a/src/components/__tests__/FlawComments.spec.ts
+++ b/src/components/__tests__/FlawComments.spec.ts
@@ -17,7 +17,7 @@ vi.mock('@/stores/osimRuntime', async () => {
       jiraDisplay: 'http://jira-backend',
     },
     osimVersion: {
-      rev: 'osimrev', tag: 'osimtag', timestamp: '1970-01-01T00:00:00Z', dirty: true
+      rev: 'osimrev', tag: 'osimtag', timestamp: '1970-01-01T00:00:00Z'
     },
     error: '',
   };

--- a/src/stores/osimRuntime.ts
+++ b/src/stores/osimRuntime.ts
@@ -36,7 +36,6 @@ const OsimRuntime = z.object({
     rev: z.string(),
     tag: z.string(),
     timestamp: z.string(),
-    dirty: z.boolean(),
   }),
   error: z.string().default(''),
   readOnly: z.boolean().default(false),
@@ -46,7 +45,7 @@ type OsimRuntime = z.infer<typeof OsimRuntime>;
 const runtime = ref<OsimRuntime>({
   env: '',
   backends: { osidb: '', osidbAuth: '', bugzilla: '', jira: '', errata: '', jiraDisplay: '' },
-  osimVersion: { rev: '', tag: '', timestamp: '', dirty: true },
+  osimVersion: { rev: '', tag: '', timestamp: '' },
   error: '',
   readOnly: false,
 });


### PR DESCRIPTION
# OSIDB-3068 Git Repo has a dirty status

This PR removes dirty validation from build, from runtime.json, from tests and from footer in UI.

Closes OSIDB-3068.

