### PR TITLE
OSIDB-3154: Use a shallow watch

### DIFF
--- a/src/composables/useFlawAffectsModel.ts
+++ b/src/composables/useFlawAffectsModel.ts
@@ -190,7 +190,7 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
   watch(flaw.value.affects, (affects) => {
     watchers.forEach((unwatch: () => void) => unwatch());
     watchers = affects.map((affect) => watch(affect, trackAffectChange, { deep: true }));
-  }, { immediate: true });
+  }, { immediate: true, deep: false });
 
   async function removeAffects() {
     await deleteAffects(affectsToDelete.value.map(({ uuid }) => uuid as string).filter(Boolean));


### PR DESCRIPTION
# OSIDB-3154: Use a shallow watch

## Checklist:

- [x] Commits consolidated
- [ ] Changelog updated
- [ ] Test cases added/updated
- [x] Jira ticket updated

## Summary:

From the [Vue documentation](https://vuejs.org/guide/essentials/watchers#deep-watchers): 
>When you call watch() directly on a reactive object, it will implicitly **create a deep watcher**

Because the top level watch was a `deep` watch, each time the affects were modified, it will trigger and run the `unwatch` stopping the `trackAffectChange` from being run, so the variable `didAffectsChange` was never updated.

Link to a playground to reproduce the error: https://play.vuejs.org/#eNqFU02PmzAQ/SsjXwJaRDZtTymJul3l0B7aqu0tzsGFIfHG2AibJBLiv3ewQxZpV7s3Zua9x5sPd+yhrtNTi2zJMps3snZg0bX1mmtZ1aZx0EGDZQJn4fID9FA2poIZMWZc50ZbB6USZ1gNqKjjGkCUJebOLmHbgSyWsIB+l3Ddx1yPFNeI/PjgcY8HofdI/CjwYlitwesMUKMwVWZ/raWyIJF+0FHogiW0xN3uuPZRNJhJT0K1mF59JKOyfV16Vkpy5NkzUgcoTQNR8NkGVTDl+LM4CMBYijyFLN36Tom/EVSZNnRlp3VrD1EghmrychYJjbxArJdUahH6OI4/U9fP6VIoSyhZVVhI4fAG5DqbhyXS+ihwWNWKABQBZIfFuuvCtvo+m1Po0/9a54yGL7mS+XHFmZ/g2Iv3G9b4YfgBW9N1gDOwyOaB+L7I9n5Hi7u7m5DvJ+xsPrHJEuYszb6U+/TJGk1n6efNWW6qWipsftZO0m44W46b4EwoZc7ffW6YBB1byNPI8+Mr+Sd7GXKc/WrQYnNCzm41J5o9ulDe/PmBF/q+FStTtIrQbxR/I11WO3gMsK+tLsj2BOfdfvOPS+r9X7u5ONR2bGow6k/K4zmjl/b4RuvPdj+mn66n2LP+P7ODSwQ=

## Considerations

Because this fixes a bug introduced in #340 which is not yet released, I think it does not make sense to update the changelog

Closes OSIDB-3154
