### PR TITLE
OSIDB-3154: Affects with changes were not updated

### DIFF
--- a/src/composables/useFlawAffectsModel.ts
+++ b/src/composables/useFlawAffectsModel.ts
@@ -223,7 +223,7 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
 
     if (wereAffectsModified.value) {
       try {
-        const response: any = await putAffects(affectsToCreate.value.map(requestBodyFromAffect));
+        const response: any = await putAffects(affectsToUpdate.value.map(requestBodyFromAffect));
         savedAffects.push(...response.data.results);
         resetModifiedAffects();
       } catch (error) {


### PR DESCRIPTION
Variable `affectsToUpdate` was never used

Closes OSIDB-3154