### PR TITLE
✨ Show untrackable affects in Trackers Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,22 @@
 # OSIM Changelog
 
 ## [Unreleased]
+
 ### Fixed
 * Fix comment#0 and description fields layout (`OSIDB-3174`)
 
-## [2024.7.1]
 ### Added
+* Indicate when trackers are unexpectedly not available (`OSIDB-3158`)
+
+## [2024.7.1]
+
+### Added
+* Indicate when trackers are unexpectedly not available (`OSIDB-3158`)
 * Apply modified style to references and ackowledgements cards when they differ to the saved value (`OSIDB-2905`)
 * Sort affects by product family, alphabetically (`OSIDB-2533`)
 * Suggestions for Flaw Owner field (`OSIDB-3004`)
 * Suggestions for Jira mentions in internal comments (`OSIDB-3005`)
 * Support for non empty CVE Description on advanced search (`OSIDB-3138`)
-* Indicate when trackers are unexpectedly not available (`OSIDB-3158`)
 
 ### Fixed
 * Bugzilla tracker link overlaps with the workflow actions (`OSIDB-3089`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Suggestions for Flaw Owner field (`OSIDB-3004`)
 * Suggestions for Jira mentions in internal comments (`OSIDB-3005`)
 * Support for non empty CVE Description on advanced search (`OSIDB-3138`)
+* Indicate when trackers are unexpectedly not available (`OSIDB-3158`)
 
 ### Fixed
 * Bugzilla tracker link overlaps with the workflow actions (`OSIDB-3089`)

--- a/src/components/AffectsTrackers.vue
+++ b/src/components/AffectsTrackers.vue
@@ -65,14 +65,14 @@ function handleFileTrackers() {
           {{ `${tracker.ps_update_stream} (${tracker.ps_component})` }}
         </label>
       </div>
-      <div v-if="untrackableAffects.length > 0" class="row">
-        <div class="ms-2 col-6 alert alert-danger">
+      <div v-if="untrackableAffects.length > 0">
+        <div class="ms-3 alert alert-danger w-50">
           <h5>Untrackable Affects</h5>
           <p>
             These affects do not have available trackers. This may indicate an issue with product defintions.
             Please contact the OSIDB/OSIM team for assistance.
           </p>
-          <div class="osim-trackers-list">
+          <div class="osim-tracker-list">
             <span v-for="affect in untrackableAffects" :key="`${affect.ps_module}-${affect.ps_component}`">
               <span class="ps-1 text-danger">
                 <i class="bi bi-exclamation-triangle"></i>
@@ -80,8 +80,6 @@ function handleFileTrackers() {
               </span>
             </span>
           </div>
-        </div>
-        <div class="col-6">
         </div>
       </div>
       <h5>
@@ -198,17 +196,14 @@ function handleFileTrackers() {
 
 .osim-tracker-list {
   display: flex;
-  flex-flow: column wrap;
+  flex-flow: column;
+  max-height: 30vh;
+  overflow-y: auto;
+  background-color: #fff;
 }
 
 .osim-trackers-filing {
   overflow: hidden;
-
-  .col-6:has(.osim-tracker-list) {
-    max-height: 30vh;
-    overflow-y: auto;
-    background-color: #fff;
-  }
 }
 
 .osim-affect-trackers-container {

--- a/src/components/AffectsTrackers.vue
+++ b/src/components/AffectsTrackers.vue
@@ -20,6 +20,7 @@ const {
   filterString,
   alreadyFiledTrackers,
   isFilingTrackers,
+  untrackableAffects,
 } = useTrackers(props.flawId, theAffects);
 
 const emit = defineEmits<{
@@ -49,7 +50,7 @@ function handleFileTrackers() {
     </h4>
 
     <div class="osim-trackers-filing mb-2">
-      <div v-if="alreadyFiledTrackers.length" class="osim-tracker-selections mb-2">
+      <div v-if="alreadyFiledTrackers.length" class="osim-tracker-list mb-2">
         <h5>Filed</h5>
         <label
           v-for="(tracker, index) in alreadyFiledTrackers"
@@ -63,6 +64,25 @@ function handleFileTrackers() {
           />
           {{ `${tracker.ps_update_stream} (${tracker.ps_component})` }}
         </label>
+      </div>
+      <div v-if="untrackableAffects.length > 0" class="row">
+        <div class="ms-2 col-6 alert alert-danger">
+          <h5>Untrackable Affects</h5>
+          <p>
+            These affects do not have available trackers. This may indicate an issue with product defintions.
+            Please contact the OSIDB/OSIM team for assistance.
+          </p>
+          <div class="osim-trackers-list">
+            <span v-for="affect in untrackableAffects" :key="`${affect.ps_module}-${affect.ps_component}`">
+              <span class="ps-1 text-danger">
+                <i class="bi bi-exclamation-triangle"></i>
+                {{ affect.ps_module }}/{{ affect.ps_component }}
+              </span>
+            </span>
+          </div>
+        </div>
+        <div class="col-6">
+        </div>
       </div>
       <h5>
         Unfiled
@@ -115,7 +135,7 @@ function handleFileTrackers() {
         </div>
         <div class="row">
           <div class="col-6 pt-1">
-            <div class="osim-tracker-selections mb-2">
+            <div class="osim-tracker-list mb-2">
               <label
                 v-for="(tracker, index) in unselectedStreams"
                 :key="`${tracker.ps_update_stream}:${tracker.ps_component}:${index}`"
@@ -141,7 +161,7 @@ function handleFileTrackers() {
           </div>
 
           <div class="col-6 pt-1">
-            <div class="osim-tracker-selections mb-2">
+            <div class="osim-tracker-list mb-2">
               <label
                 v-for="(tracker, index) in selectedStreams"
                 :key="`${tracker.ps_update_stream}:${tracker.ps_component}:${index}`"
@@ -176,7 +196,7 @@ function handleFileTrackers() {
 <style lang="scss" scoped>
 @import '@/scss/bootstrap-overrides';
 
-.osim-tracker-selections {
+.osim-tracker-list {
   display: flex;
   flex-flow: column wrap;
 }
@@ -184,7 +204,7 @@ function handleFileTrackers() {
 .osim-trackers-filing {
   overflow: hidden;
 
-  .col-6:has(.osim-tracker-selections) {
+  .col-6:has(.osim-tracker-list) {
     max-height: 30vh;
     overflow-y: auto;
     background-color: #fff;

--- a/src/components/__tests__/AffectsTrackers.spec.ts
+++ b/src/components/__tests__/AffectsTrackers.spec.ts
@@ -1,27 +1,60 @@
 import { mount } from '@vue/test-utils';
-import AffectsTrackers from '@/components/AffectedOfferings.vue';
+import AffectsTrackers from '@/components/AffectsTrackers.vue';
 import { mockAffect } from './test-suite-helpers';
+import { LoadingAnimationDirective } from '@/directives/LoadingAnimationDirective.js';
 
-describe('Trackers for Affects Component', () => {
-  it('renders the component', () => {
-    const $AffectedOfferings = mount(AffectsTrackers, {
-      global: {
-        stubs: {
-        },
+vi.mock('@/composables/useTrackers', () => ({
+  useTrackers: () => ({
+    alreadyFiledTrackers: [],
+    untrackableAffects: [
+      mockAffect({ ps_module: 'Module 1', ps_component: 'Component 1' }),
+    ],
+    trackersToFile: [],
+    getUpdateStreamsFor: vi.fn(() => []),
+  }),
+}));
+
+describe('Trackers Manager', () => {
+  const defaultMountOptions = {
+    global: {
+      stubs: {
       },
-      props: {
-        theAffects: [
-          mockAffect({ ps_module: 'Module 1', ps_component: 'Component 1' }),
-          mockAffect({ ps_module: 'Module 1', ps_component: 'Component 2' }),
-          mockAffect({ ps_module: 'Module 2', ps_component: 'Component 1' }),
-        ],
-        affectsToDelete: [],
-        // error: [mockError(), mockError(), mockError()],
-        error: null,
-      },
+    },
+    directives: {
+      'osim-loading': LoadingAnimationDirective,
+    },
+    props: {
+      theAffects: [
+        mockAffect({ ps_module: 'Module 1', ps_component: 'Component 1' }),
+        mockAffect({ ps_module: 'Module 1', ps_component: 'Component 2' }),
+        mockAffect({ ps_module: 'Module 2', ps_component: 'Component 1' }),
+      ],
+      affectsToDelete: [],
+      error: null,
+      flawId: '[[TEST]] flaw-id',
+    }
+  };
+
+  describe('Baseline functionality', () => {
+    it('renders the component', () => {
+      const wrapper = mount(AffectsTrackers, defaultMountOptions);
+      expect(wrapper.exists()).toBeTruthy();
+    });
+  });
+
+
+  describe('Trackers listing', () => {
+    it('shows an alert when tracker(s) are unavailable', () => {
+      const wrapper = mount(AffectsTrackers, defaultMountOptions);
+      const warning = wrapper.find('.alert-danger');
+      expect(warning.exists()).toBeTruthy();
     });
 
-    expect($AffectedOfferings.exists()).toBeTruthy();
-
+    it('shows which trackers are not available', () => {
+      const wrapper = mount(AffectsTrackers, defaultMountOptions);
+      const warning = wrapper.find('.alert-danger');
+      expect(warning.html().includes('Module 1/Component 1')).toBeTruthy();
+    });
   });
+
 });

--- a/src/composables/useTrackers.ts
+++ b/src/composables/useTrackers.ts
@@ -1,9 +1,10 @@
 import { computed, ref, watch, type Ref } from 'vue';
 
 import { getTrackersForFlaws, type TrackersPost, fileTrackingFor } from '@/services/TrackerService';
-import type { ZodAffectType } from '@/types/zodAffect';
+import type { ZodAffectType, ZodTrackerType } from '@/types/zodAffect';
 
 export type UpdateStream = ModuleComponentProductStream & UpdateStreamMeta;
+type ZodTrackerTypeWithAffect = ZodTrackerType & ZodAffectType;
 
 type ModuleComponent = {
   ps_module: string;
@@ -22,7 +23,7 @@ type ModuleComponentProductStream = {
 };
 
 type UpdateStreamMeta = {
-  affectUuid?: string;
+  affectUuid?: string | null;
   ps_component?: string;
   ps_module?: string;
 };
@@ -52,15 +53,15 @@ export function useTrackers(flawUuid: string, affects: Ref<ZodAffectType[]>) {
     })
   );
 
-  const availableUpdateStreams = computed((): UpdateStream[] => moduleComponents.value.flatMap((moduleComponent: any) =>
-    moduleComponent.streams.map((stream: Record<string, any>) => ({
+  const availableUpdateStreams = computed((): UpdateStream[] => moduleComponents.value.flatMap((moduleComponent) =>
+    moduleComponent.streams.map((stream: UpdateStream) => ({
       ...stream,
       ps_component: moduleComponent.ps_component,
       ps_module: moduleComponent.ps_module,
       affectUuid: moduleComponent.affect.uuid
     }))
-  ).filter((stream: any) => !alreadyFiledTrackers.value.find(
-    (tracker: any) => tracker.ps_update_stream === stream.ps_update_stream
+  ).filter((stream: UpdateStream) => !alreadyFiledTrackers.value.find(
+    (tracker: ZodTrackerTypeWithAffect) => tracker.ps_update_stream === stream.ps_update_stream
       && tracker.ps_component === stream.ps_component
   )));
 
@@ -139,7 +140,7 @@ export function useTrackers(flawUuid: string, affects: Ref<ZodAffectType[]>) {
 
   function getUpdateStreamsFor(module: string, component: string) {
     const moduleComponent = moduleComponents.value.find(
-      ({ ps_module, ps_component }: any) => ps_module === module && ps_component === component
+      ({ ps_module, ps_component }: ModuleComponent) => ps_module === module && ps_component === component
     );
     return moduleComponent ? moduleComponent.streams : [];
   }

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -23,6 +23,7 @@ export async function fileTrackingFor(trackerData: TrackersPost[] | TrackersPost
   if (!Array.isArray(trackerData) || trackerData.length === 1) {
     const tracker = !Array.isArray(trackerData) ? trackerData : trackerData[0];
     return postTracker(tracker)
+      .then(createSuccessHandler({ title: 'Success!', body: 'Tracker filed.', css: 'success' }))
       .catch(createCatchHandler(`Failed to create tracker for ${tracker.ps_update_stream}`));
   }
 
@@ -51,7 +52,11 @@ export async function fileTrackingFor(trackerData: TrackersPost[] | TrackersPost
     createCatchHandler(`${errors.length} trackers failed to file`)(errors);
     return Promise.reject({ errors, successes });
   } else {
-    createSuccessHandler({ title: 'Success!', body: `${trackerData.length} trackers filed.` })({ data: null });
+    createSuccessHandler({
+      title: 'Success!',
+      body: `${trackerData.length} trackers filed.`,
+      css: 'success',
+    })({ data: null });
     return Promise.resolve({ successes });
   }
 }


### PR DESCRIPTION
# OSIDB-3158 Indicate when affects are untrackable
# OSIDB-3144 Show success on single tracker filing

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Shows a warning when untracked affects do not have any available trackers.

## Changes:

Compares a list of untracked affects with a list of available trackers. If any untracked affects do not have an available tracker, a warning is shown with the untrackable affect,

## Considerations:
![image](https://github.com/user-attachments/assets/0db05a66-e426-418b-9150-d54c6263b56f)

[Replace with any additional considerations, notes, or instructions for reviewers.]

Closes OSIDB-3144. Closes OSIDB-3158.
