### PR TITLE
Feature OSIDB-3138: Search non empty CVE description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Sort affects by product family, alphabetically (`OSIDB-2533`)
 * Suggestions for Flaw Owner field (`OSIDB-3004`)
 * Suggestions for Jira mentions in internal comments (`OSIDB-3005`)
+* Support for non empty CVE Description on advanced search (`OSIDB-3138`)
 
 ### Fixed
 * Bugzilla tracker link overlaps with the workflow actions (`OSIDB-3089`)

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -17,6 +17,8 @@ const emit = defineEmits(['filter:save']);
 
 const isNonEmptyDescriptionSelected = ref(false);
 
+const descriptionParamValue = computed(() => facets.value.find(facet => facet.field === 'cve_description')?.value);
+
 watch(isNonEmptyDescriptionSelected, () => {
   const facet = facets.value.find(facet => facet.field === 'cve_description');
   if (isNonEmptyDescriptionSelected.value) {
@@ -25,8 +27,17 @@ watch(isNonEmptyDescriptionSelected, () => {
     } else {
       facet.value = 'nonempty';
     }
-  } else if (facet) {
+  } else if (facet && descriptionParamValue.value === 'nonempty') {
     facet.value = '';
+  }
+});
+
+watch(descriptionParamValue, (value) => {
+  if (value !== 'nonempty' && isNonEmptyDescriptionSelected.value) {
+    isNonEmptyDescriptionSelected.value = false;
+  }
+  if (value === 'nonempty' && !isNonEmptyDescriptionSelected.value) {
+    isNonEmptyDescriptionSelected.value = true;
   }
 });
 

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { flawImpacts, flawSources, flawIncidentStates } from '@/types/zodFlaw';
-import { useRoute } from 'vue-router';
+import LabelCheckbox from '@/components/widgets/LabelCheckbox.vue';
 import { flawFields } from '@/constants/flawFields';
 import { useSearchParams } from '@/composables/useSearchParams';
 import { descriptionRequiredStates } from '@/types/zodFlaw';
@@ -16,6 +16,21 @@ const props = defineProps<{
 const route = useRoute();
 
 const emit = defineEmits(['filter:save']);
+
+const isNonEmptyDescriptionSelected = ref(false);
+
+watch(isNonEmptyDescriptionSelected, () => {
+  const facet = facets.value.find(facet => facet.field === 'cve_description');
+  if (isNonEmptyDescriptionSelected.value) {
+    if (!facet) {
+      facets.value.push({ field: 'cve_description', value: 'nonempty' });
+    } else {
+      facet.value = 'nonempty';
+    }
+  } else if (facet) {
+    facet.value = '';
+  }
+});
 
 const nameForOption = (fieldName: string) => {
   const mappings: Record<string, string> = {
@@ -123,6 +138,11 @@ const shouldShowAdvanced = ref(route.query.mode === 'advanced');
       >
         Save as Default
       </button>
+      <LabelCheckbox
+        v-model="isNonEmptyDescriptionSelected"
+        label="Non Empty CVE Description"
+        class="d-inline-block"
+      />
     </form>
   </details>
 </template>

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -13,8 +13,6 @@ const props = defineProps<{
   isLoading: boolean;
 }>();
 
-const route = useRoute();
-
 const emit = defineEmits(['filter:save']);
 
 const isNonEmptyDescriptionSelected = ref(false);
@@ -86,7 +84,7 @@ const optionsFor = (field: string) =>
     major_incident_state: flawIncidentStates,
     affects__affectedness: affectAffectedness,
   })[field] || null;
-const shouldShowAdvanced = ref(route.query.mode === 'advanced');
+const shouldShowAdvanced = ref(true);
 </script>
 
 <template>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -138,7 +138,7 @@ const usernameDisplay = computed(() => {
               <li>
                 <RouterLink
                   class="dropdown-item"
-                  :to="{ name: 'search', query: { 'mode': 'advanced' } }"
+                  :to="{ name: 'search' }"
                 >
                   Advanced Search
                 </RouterLink>

--- a/src/components/__tests__/FlawSearchView.spec.ts
+++ b/src/components/__tests__/FlawSearchView.spec.ts
@@ -55,7 +55,7 @@ vi.mock('vue-router', async () => {
 
   return {
     ...actual,
-    useRoute: vi.fn(() => ({ query: { mode: 'advanced', query: 'search' } })),
+    useRoute: vi.fn(() => ({ query: { query: 'search' } })),
     useRouter: vi.fn(() => ({
       replace: replaceMock
     }))
@@ -140,7 +140,6 @@ describe('FlawSearchView', () => {
   it('should call saveFilter on save filter button click', async () => {
     (useRoute as Mock).mockReturnValue({
       'query': {
-        mode: 'advanced',
         query: 'search',
         'affects__ps_component': 'test'
       },
@@ -171,7 +170,6 @@ describe('FlawSearchView', () => {
   it('should call with correct filters from route on mounted', async () => {
     (useRoute as Mock).mockReturnValue({
       'query': {
-        mode: 'advanced',
         query: 'search',
         'affects__ps_component': 'test'
       },

--- a/src/components/__tests__/IssueSearchAdvanced.spec.ts
+++ b/src/components/__tests__/IssueSearchAdvanced.spec.ts
@@ -10,7 +10,7 @@ vi.mock('vue-router', async () => {
 
   return {
     ...actual,
-    useRoute: vi.fn(() => ({ query: { mode: 'advanced', query: 'search' } })),
+    useRoute: vi.fn(() => ({ query: { query: 'search' } })),
     useRouter: vi.fn(() => ({
       replace: replaceMock
     }))

--- a/src/components/widgets/LabelCheckbox.vue
+++ b/src/components/widgets/LabelCheckbox.vue
@@ -26,5 +26,6 @@ const modelValue = defineModel<boolean | undefined>();
 <style scoped>
 .osim-input {
   display: block;
+  user-select: none;
 }
 </style>

--- a/src/composables/__tests__/useSearchParams.spec.ts
+++ b/src/composables/__tests__/useSearchParams.spec.ts
@@ -8,7 +8,7 @@ vi.mock('vue-router', async () => {
 
   return {
     ...actual,
-    useRoute: vi.fn(() => ({ query: { mode: 'advanced', query: 'search' } })),
+    useRoute: vi.fn(() => ({ query: { query: 'search' } })),
     useRouter: vi.fn(() => ({
       replace: replaceMock,
       push: pushMock
@@ -19,7 +19,7 @@ vi.mock('vue-router', async () => {
 describe('useSearchParams', () => {
   beforeEach(() => {
     (useRoute as Mock).mockReturnValue({
-      'query': { mode: 'advanced', query: 'search' },
+      'query': { query: 'search' },
     });
   });
 
@@ -69,7 +69,6 @@ describe('useSearchParams', () => {
   it('getSearchParams', () => {
     (useRoute as Mock).mockReturnValue({
       'query': {
-        mode: 'advanced',
         query: 'search',
         'affects__ps_component': 'test'
       },
@@ -85,7 +84,6 @@ describe('useSearchParams', () => {
   it('populatedFacets from route', () => {
     (useRoute as Mock).mockReturnValue({
       'query': {
-        mode: 'advanced',
         query: 'search',
         'affects__ps_component': 'test',
         'acknowledgments__name': 'test'

--- a/src/composables/useFlawsFetching.ts
+++ b/src/composables/useFlawsFetching.ts
@@ -13,8 +13,8 @@ export function useFlawsFetching() {
   function finializeRequestParams(params: any = {}){
     const requestParams: Record<string, any> = {};
     for (const key in params) {
-      if (params[key] === '' && allowedEmptyFieldMapping[key]) {
-        requestParams[allowedEmptyFieldMapping[key]] = 1;
+      if (['', 'nonempty'].includes(params[key]) && allowedEmptyFieldMapping[key]) {
+        requestParams[allowedEmptyFieldMapping[key]] = params[key] === '' ? 1 : 0;
       } else {
         requestParams[key] = params[key];
       }


### PR DESCRIPTION
# OSIDB-3138: Search non empty CVE description

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] No test cases added/updated
- [x] Jira ticket updated

## Context:

Due to a bug there are lot of flaws with empty CVE Description on Requested status, which difficult the work of users as it is generally expected to receive flaws with non empty description when looking for status Requested.

## Summary:

Adds support for searching flaws with non empty CVE description on `AdvancedSearch` view as a workaround for users search queries. It is provided a checkbox on Advanced search which modifies the CVE Description Field setting the value to `nonempty` which triggers the param for the OSIDB request.

## Changes:

- Adds a checkbox `Non empty CVE description` on advanced
- Supports `nonempty` value for CVE Descriptions params

## Demo

![image](https://github.com/user-attachments/assets/5e5b11e0-f406-4f5f-8a32-29c5b89e205b)

https://github.com/user-attachments/assets/60a0e04c-fc48-4d3b-a109-7ab1a592213e

## Considerations:

- There probably are cleaner ways to do this (both for code and UI), but as it is a temporary workaround my aim was to cover the need in the simplest and quickest way.
- I had to put the `shouldShowAdvanced` ref initialized to `true` cause the advanced search was always loaded in hidden state.

Closes OSIDB-3138
