### PR TITLE
🐛 Fix affect refreshing

### DIFF
--- a/src/components/AffectedOfferings.vue
+++ b/src/components/AffectedOfferings.vue
@@ -21,6 +21,7 @@ const emit = defineEmits<{
   'file-tracker': [value: object];
   'affect:remove': [value: ZodAffectType];
   'affect:recover': [value: ZodAffectType];
+  'affects:refresh': [];
   'add-blank-affect': [];
 }>();
 
@@ -127,6 +128,7 @@ defineExpose({ togglePsModuleExpansion, togglePsComponentExpansion, isExpanded }
       v-show="shouldShowTrackers"
       :flawId="flawId"
       :theAffects="affectsNotBeingDeleted"
+      @affects-trackers:refresh="emit('affects:refresh')"
       @affects-trackers:hide="shouldShowTrackers = false"
     />
     <div class="my-2 py-2">

--- a/src/components/AffectsTrackers.vue
+++ b/src/components/AffectsTrackers.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { type ZodAffectType } from '@/types/zodAffect';
 import { useTrackers } from '@/composables/useTrackers';
+import { toRef } from 'vue';
 
 const props = defineProps<{
   flawId: string;
   theAffects: ZodAffectType[];
 }>();
+
+const theAffects = toRef(props, 'theAffects');
 
 const {
   trackerSelections,
@@ -17,11 +20,18 @@ const {
   filterString,
   alreadyFiledTrackers,
   isFilingTrackers,
-} = useTrackers(props.flawId, props.theAffects);
+} = useTrackers(props.flawId, theAffects);
 
 const emit = defineEmits<{
   'affects-trackers:hide': [];
+  'affects-trackers:refresh': [];
 }>();
+
+function handleFileTrackers() {
+  fileTrackers().then(() => {
+    emit('affects-trackers:refresh');
+  });
+}
 </script>
 
 <template>
@@ -152,7 +162,7 @@ const emit = defineEmits<{
           type="button"
           class="btn btn-sm btn-black text-white osim-file-trackers mt-3"
           :disabled="!trackersToFile.length || isFilingTrackers"
-          @click="fileTrackers"
+          @click="handleFileTrackers"
         >
           <i v-if="!isFilingTrackers" class="bi bi-archive"></i>
           File Selected Trackers

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -76,6 +76,7 @@ const {
   isSaving,
   isValid,
   errors,
+  refreshAffects,
 } = useFlawModel(props.flaw, onSaveSuccess);
 
 
@@ -476,6 +477,7 @@ const theAffects = computed(() => {
             :flawId="flaw.uuid"
             @affect:recover="(affect) => recoverAffect(flaw.affects.indexOf(affect))"
             @affect:remove="(affect) => removeAffect(flaw.affects.indexOf(affect))"
+            @affects:refresh="refreshAffects"
             @add-blank-affect="addBlankAffect"
           />
         </div>

--- a/src/composables/useFlawAffectsModel.ts
+++ b/src/composables/useFlawAffectsModel.ts
@@ -6,7 +6,7 @@ import {
   putAffectCvssScore,
   postAffectCvssScore,
 } from '@/services/AffectService';
-// import { getDisplayedOsidbError } from '@/services/OsidbAuthService';
+import { getFlaw } from '@/services/FlawService';
 import { useToastStore } from '@/stores/ToastStore';
 import type { ZodFlawType } from '@/types/zodFlaw';
 import type { ZodAffectType, ZodAffectCVSSType } from '@/types/zodAffect';
@@ -20,6 +20,13 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
   const affectIdsForPutRequest = ref<string[]>([]);
   const affectsToDelete = ref<ZodAffectType[]>([]);
   const initialAffects = deepCopyFromRaw(flaw.value.affects);
+
+  function refreshAffects() {
+    return getFlaw(flaw.value.uuid).then((response) => {
+      console.log('refreshing affects');
+      flaw.value.affects = response.affects;
+    });
+  }
 
   function isCvssNew(cvssScore: ZodAffectCVSSType) {
     if (
@@ -292,5 +299,6 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
     affectsToDelete,
     didAffectsChange,
     initialAffects,
+    refreshAffects,
   };
 }

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -36,6 +36,7 @@ export function useFlawModel(forFlaw: ZodFlawType = blankFlaw(), onSaveSuccess: 
     removeAffects,
     affectsToDelete,
     initialAffects,
+    refreshAffects,
   } = flawAffectsModel;
 
   const router = useRouter();

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -27,10 +27,12 @@ export async function fileTrackingFor(trackerData: TrackersPost[] | TrackersPost
   }
 
   const errors = [];
+  const successes = [];
 
   for (const tracker of trackerData) {
     try {
-      await postTracker(tracker, trackerData.at(-1) === tracker);
+      const response = await postTracker(tracker, trackerData.at(-1) === tracker);
+      successes.push(response);
     } catch (error: any) {
       if (error?.response?.data !== null && typeof error?.response?.data === 'object') {
         error.response.data.stream = tracker.ps_update_stream;
@@ -47,8 +49,10 @@ export async function fileTrackingFor(trackerData: TrackersPost[] | TrackersPost
 
   if (errors.length) {
     createCatchHandler(`${errors.length} trackers failed to file`)(errors);
+    return Promise.reject({ errors, successes });
   } else {
     createSuccessHandler({ title: 'Success!', body: `${trackerData.length} trackers filed.` })({ data: null });
+    return Promise.resolve({ successes });
   }
 }
 


### PR DESCRIPTION
# [OSIDB-ID] [Title]

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [x] Jira ticket updated

## Summary:

After filing trackers, the UI will now refresh trackers:
https://github.com/user-attachments/assets/ca00d80e-ac73-4d81-9c8f-dfe7b09a115e


## Changes:

- Added mechanism and event chain for refreshing affects.


## Considerations:

Re-fetching and refreshing affects is necessary to see what trackers have been filed on an affect, so this additional functionality was needed.

Closes OSIDB-3049.