### PR TITLE
🐛 Fix: Regression UI bug on textarea descriptions layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OSIM Changelog
 
+## [Unreleased]
+### Fixed
+* Fix comment#0 and description fields layout (`OSIDB-3174`)
+
 ## [2024.7.1]
 ### Added
 * Apply modified style to references and ackowledgements cards when they differ to the saved value (`OSIDB-2905`)

--- a/src/components/widgets/LabelTextarea.vue
+++ b/src/components/widgets/LabelTextarea.vue
@@ -69,13 +69,17 @@ defineOptions({
   </label>
 </template>
 
-<style scoped>
+<style scoped lang="scss">
 .osim-input {
   display: block;
 
   .throbber {
     position: absolute;
     left: 1rem;
+  }
+
+  textarea {
+    position: relative;
   }
 }
 </style>

--- a/src/components/widgets/LabelTextarea.vue
+++ b/src/components/widgets/LabelTextarea.vue
@@ -40,7 +40,7 @@ defineOptions({
 </script>
 
 <template>
-  <label class="osim-input mb-2 ps-3">
+  <label class="osim-input mb-2 ps-3" :class="$attrs.class">
     <div class="row">
       <slot name="label">
         <span class="form-label col-3 position-relative">


### PR DESCRIPTION
# OSIDB-3174: Style for Comment#0 reverted back to previous version

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Fix regression issue on text-area description fields and the focus highlight - label overlap

## Changes:

- Fix inheritable classes on text-area widget
- Fix text-area focus highlight label overlap

Closes OSIDB-3174