### PR TITLE
OSIDB-3189: Filter jira users by task key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Added
 * Indicate when trackers are unexpectedly not available (`OSIDB-3158`)
 
+### Changed
+* Jira suggestions are now filtered by the current project (`OSIDB-3189`)
+
 ## [2024.7.1]
 
 ### Added

--- a/src/components/FlawContributors.vue
+++ b/src/components/FlawContributors.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { onBeforeMount, ref } from 'vue';
 import { isDefined, watchDebounced } from '@vueuse/core';
-import sanitize from 'sanitize-html';
 import LabelDiv from './widgets/LabelDiv.vue';
 import DropDown from './widgets/DropDown.vue';
+import JiraUser from './widgets/JiraUser.vue';
 import useJiraContributors from '@/composables/useJiraContributors';
-import type { ZodJiraUserPickerType } from '@/types/zodJira';
+import type { ZodJiraUserAssignableType } from '@/types/zodJira';
 import { createCatchHandler } from '@/composables/service-helpers';
 
 const props = defineProps<{
@@ -14,7 +14,7 @@ const props = defineProps<{
 
 const inputRef = ref<HTMLInputElement | null>(null);
 const query = ref<string>();
-const results = ref<ZodJiraUserPickerType[]>([]);
+const results = ref<ZodJiraUserAssignableType[]>([]);
 
 const {
   contributors,
@@ -51,7 +51,7 @@ const onBlur = (event: FocusEvent) => {
   }
 };
 
-const add = (contributor: ZodJiraUserPickerType) => {
+const add = (contributor: ZodJiraUserAssignableType) => {
   contributors.value.push(contributor);
   query.value = '';
   results.value = [];
@@ -101,8 +101,7 @@ const remove = (index: number) => {
           :key="contributor.name"
           @click="add(contributor)"
         >
-          <!--eslint-disable-next-line vue/no-v-html -->
-          <span v-html="sanitize(contributor.html)" />
+          <JiraUser v-bind="contributor" :query />
         </div>
       </DropDown>
     </div>

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -386,7 +386,7 @@ const theAffects = computed(() => {
               @updateFlaw="updateFlaw"
               @update:model-value="onUnembargoed"
             />
-            <FlawFormOwner v-model="flaw.owner" />
+            <FlawFormOwner v-model="flaw.owner" :task_key="flaw.task_key" />
             <LabelStatic
               v-if="mode === 'edit'"
               :modelValue="createdDate"

--- a/src/components/__tests__/FlawComments.spec.ts
+++ b/src/components/__tests__/FlawComments.spec.ts
@@ -224,7 +224,7 @@ describe('FlawComments', () => {
   it('Should call `searchJiraUsers` on internal comments', async () => {
     vi.mocked(searchJiraUsers, { partial: true }).mockResolvedValueOnce({
       data: {
-        users: [{ name: 'test', displayName: 'Test User', html: 'Test User' }]
+        users: [{ name: 'test', displayName: 'Test User', avatarUrl: '' }]
       }
     });
 
@@ -239,6 +239,6 @@ describe('FlawComments', () => {
     vi.runAllTimers();
     await flushPromises();
 
-    expect(searchJiraUsers).toHaveBeenCalledWith('user');
+    expect(searchJiraUsers).toHaveBeenCalledWith('user', 'sampleKey');
   });
 });

--- a/src/components/__tests__/FlawContributors.spec.ts
+++ b/src/components/__tests__/FlawContributors.spec.ts
@@ -67,7 +67,7 @@ describe('FlawContributors', () => {
   });
 
   it('should show search results when search is done', async () => {
-    useJiraContributors.searchContributors.mockResolvedValue([{ name: 'test', html: 'test user' }]);
+    useJiraContributors.searchContributors.mockResolvedValue([{ name: 'test', displayName: 'test user' }]);
     const wrapper = mountComponent();
     const input = wrapper.find('input');
     await input.setValue('test');

--- a/src/components/__tests__/FlawFormOwner.spec.ts
+++ b/src/components/__tests__/FlawFormOwner.spec.ts
@@ -60,6 +60,9 @@ describe('Owner field', () => {
       global: {
         plugins: [pinia],
       },
+      props:{
+        taskKey: 'OSIM-1234'
+      }
     });
   });
 
@@ -91,7 +94,7 @@ describe('Owner field', () => {
     vi.mocked(searchJiraUsers, { partial: true }).mockResolvedValueOnce({
       data: {
         users:
-          [{ name: 'test', displayName: 'Test User', html: 'Test User' }]
+          [{ name: 'test', displayName: 'Test User', avatarUrl: '' }]
       }
     });
     const input = subject.find('input');

--- a/src/components/widgets/JiraUser.vue
+++ b/src/components/widgets/JiraUser.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { computed, toValue } from 'vue';
+
+const props = defineProps<{
+  displayName: string;
+  emailAddress?: string;
+  name?: string;
+  query?: string;
+}>();
+
+const formatedUser = computed(() => {
+  let output = props.displayName;
+  if (props.emailAddress) {
+    output += ` - ${props.emailAddress}`;
+  }
+  if (props.name) {
+    output += ` (${props.name})`;
+  }
+  if (props.query) {
+    output = output.replace(new RegExp(toValue(props.query), 'gi'), '<b>$&</b>');
+  }
+  return output;
+});
+</script>
+
+<template>
+  <!-- eslint-disable-next-line vue/no-v-html -->
+  <span v-html="formatedUser" />
+</template>

--- a/src/components/widgets/__tests__/JiraUser.spec.ts
+++ b/src/components/widgets/__tests__/JiraUser.spec.ts
@@ -1,0 +1,44 @@
+import { mount } from '@vue/test-utils';
+import JiraUser from '../JiraUser.vue';
+
+describe('JiraUser', () => {
+  it('renders correctly with only displayName', () => {
+    const wrapper = mount(JiraUser, {
+      props: { displayName: 'John Doe' },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with displayName and emailAddress', () => {
+    const wrapper = mount(JiraUser, {
+      props: {
+        displayName: 'John Doe',
+        emailAddress: 'john.doe@example.com',
+      },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with all props', () => {
+    const wrapper = mount(JiraUser, {
+      props: {
+        displayName: 'John Doe',
+        emailAddress: 'john.doe@example.com',
+        name: 'johndoe',
+        query: 'Doe',
+      },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('highlights the query text', () => {
+    const wrapper = mount(JiraUser, {
+      props: {
+        displayName: 'John Doe',
+        query: 'Doe',
+      },
+    });
+    expect(wrapper.html()).toContain('<b>Doe</b>');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});

--- a/src/components/widgets/__tests__/__snapshots__/JiraUser.spec.ts.snap
+++ b/src/components/widgets/__tests__/__snapshots__/JiraUser.spec.ts.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`JiraUser > highlights the query text 1`] = `
+"<!-- eslint-disable-next-line vue/no-v-html -->
+<span>John <b>Doe</b></span>"
+`;
+
+exports[`JiraUser > renders correctly with all props 1`] = `
+"<!-- eslint-disable-next-line vue/no-v-html -->
+<span>John <b>Doe</b> - john.<b>doe</b>@example.com (john<b>doe</b>)</span>"
+`;
+
+exports[`JiraUser > renders correctly with displayName and emailAddress 1`] = `
+"<!-- eslint-disable-next-line vue/no-v-html -->
+<span>John Doe - john.doe@example.com</span>"
+`;
+
+exports[`JiraUser > renders correctly with only displayName 1`] = `
+"<!-- eslint-disable-next-line vue/no-v-html -->
+<span>John Doe</span>"
+`;

--- a/src/composables/__tests__/useJiraContributors.spec.ts
+++ b/src/composables/__tests__/useJiraContributors.spec.ts
@@ -1,6 +1,6 @@
 import { getJiraIssue, searchJiraUsers } from '@/services/JiraService';
 import useJiraContributors from '../useJiraContributors';
-import type { ZodJiraContributorType, ZodJiraUserPickerType } from '@/types/zodJira';
+import type { ZodJiraContributorType, ZodJiraUserAssignableType } from '@/types/zodJira';
 
 vi.mock('@/services/JiraService', () => ({
   getJiraIssue: vi.fn().mockResolvedValue({}),
@@ -8,16 +8,18 @@ vi.mock('@/services/JiraService', () => ({
 }));
 
 describe('useJiraContributors', () => {
-  const mockUsers: ZodJiraUserPickerType[] = [
+  const mockUsers: ZodJiraUserAssignableType[] = [
     {
       displayName: 'Alvaro Tinoco',
       name: 'atinoco',
-      html: 'Alvaro <b>Tinoco</b>',
+      emailAddress: '',
+      avatarUrl: ''
     },
     {
       displayName: 'John Doe',
       name: 'jdoe',
-      html: 'John <b>Doe</b>',
+      emailAddress: '',
+      avatarUrl: ''
     },
   ];
 
@@ -78,7 +80,7 @@ describe('useJiraContributors', () => {
 
       const result = await searchContributors('Alvaro');
 
-      expect(searchJiraUsers).toHaveBeenCalledWith('Alvaro');
+      expect(searchJiraUsers).toHaveBeenCalledWith('Alvaro', 'task_key');
       expect(result).toEqual(mockUsers);
     });
 

--- a/src/composables/useJiraContributors.ts
+++ b/src/composables/useJiraContributors.ts
@@ -31,7 +31,7 @@ export default function useJiraContributors(task_key: string) {
       return [];
     }
     isLoadingContributors.value = true;
-    const users = await searchJiraUsers(query)
+    const users = await searchJiraUsers(query, task_key)
       .catch(createCatchHandler('Failed to search contributors', false));
     isLoadingContributors.value = false;
     return users?.data?.users ?? [];

--- a/src/services/JiraService.ts
+++ b/src/services/JiraService.ts
@@ -4,7 +4,7 @@ import { getNextAccessToken } from '@/services/OsidbAuthService';
 import {
   osimRuntime,
 } from '@/stores/osimRuntime';
-import type { ZodJiraUserPickerType, ZodJiraIssueType } from '@/types/zodJira';
+import type { ZodJiraUserAssignableType, ZodJiraIssueType } from '@/types/zodJira';
 
 type JiraFetchCallbacks = {
   beforeFetch?: (options: JiraFetchOptions) => Promise<void> | void;
@@ -93,11 +93,11 @@ export async function getJiraComments(taskId: string) {
   });
 }
 
-export async function searchJiraUsers(query: string) {
-  return jiraFetch<{ users: ZodJiraUserPickerType[] }>({
+export async function searchJiraUsers(query: string, issueKey: string) {
+  return jiraFetch<{ users: ZodJiraUserAssignableType[] }>({
     method: 'get',
-    url: '/rest/api/2/user/picker',
-    params: { query },
+    url: '/rest/internal/2/users/assignee',
+    params: { issueKey, query },
   });
 }
 

--- a/src/types/zodJira.ts
+++ b/src/types/zodJira.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
 
-export type ZodJiraUserPickerType = z.infer<typeof JiraUserPickerSchema>;
-export const JiraUserPickerSchema = z.object({
+export type ZodJiraUserAssignableType = z.infer<typeof JiraUserAssignableSchema>;
+export const JiraUserAssignableSchema = z.object({
   displayName: z.string(),
-  html: z.string(),
   name: z.string(),
+  emailAddress: z.string().email().optional(),
+  avatarUrl: z.string().url()
 });
 
 


### PR DESCRIPTION
# OSIDB-3189: Filter jira users by task key

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Filter out jira users that does not have access to the current project.

The endpoint `api/2/user/picker` does not allow to specify a task ID and returns all the jira users, currently there isn't an available endpoint from the public API that allows this kind of filtering while maintaining  the option to query by any part of the user (name, username or email).
I ended up using an internal endpoint `/internal/2/users/assignee` that allows filtering via task id and querying any part of the user (name, username or email)

## Considerations:

### Snapshot testing

I took the opportunity to do a small proof of concept about snapshot testing, so we can start using it from now on.
This kind of tests will prevent us for doing regressions like in #365 as they match the whole html tree of the component, so any change in classes, attributes or structure will make the test **fail**.

This will also simplify testing, instead of manually expecting multiple values to `exist` or to have an specific value.
As an example, all this code:
https://github.com/RedHatProductSecurity/osim/blob/c1683742d1eb032ec5aaf54c275f86cfa3829e39/src/components/__tests__/CvssNISTForm.spec.ts#L89-L97
can be replaced with:
```js
expect(wrapper.html()).toMatchSnapshot();
```

Here's the link to the [test file](https://github.com/RedHatProductSecurity/osim/blob/fix/OSIDB-3189-jira-user-search/src/components/widgets/__tests__/JiraUser.spec.ts) and the generated [snapshot](https://github.com/RedHatProductSecurity/osim/blob/fix/OSIDB-3189-jira-user-search/src/components/widgets/__tests__/__snapshots__/JiraUser.spec.ts.snap)

Closes OSIDB-3189