### PR TITLE
OSIDB-3189: Fix prop name

### DIFF
--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -386,7 +386,7 @@ const theAffects = computed(() => {
               @updateFlaw="updateFlaw"
               @update:model-value="onUnembargoed"
             />
-            <FlawFormOwner v-model="flaw.owner" :task_key="flaw.task_key" />
+            <FlawFormOwner v-model="flaw.owner" :taskKey="flaw.task_key" />
             <LabelStatic
               v-if="mode === 'edit'"
               :modelValue="createdDate"


### PR DESCRIPTION
# OSIDB-3189: Fix prop name

## Summary

`FlawFormOwner` prop is named `taskKey` but it was used as `task_key` in `FlawForm`