### PR TITLE
OSIDB-3214: Save test reports as junit when on CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ coverage
 *.py[co]
 __pycache__
 *.env
+venv
+reports

--- a/scripts/run_automation_test.sh
+++ b/scripts/run_automation_test.sh
@@ -2,28 +2,42 @@
 
 # run this script on root dir or osim codebase, ./scripts/run_automation_test.sh
 
-if ! behave features/login.feature; then
+
+run_behave() {
+    args="$@"
+
+    # set arguments if "ci" argument is passed
+    if [[ -v CI ]]; then
+        args="$@ --junit --junit-directory=reports --no-summary"
+    fi
+    
+     behave $args
+     return $?
+}
+
+
+if ! run_behave features/login.feature; then
     echo "login to osim failed, skip the rest of tests"
     exit 1
 fi
 
-if behave features/flaw_create_embargo.feature; then
-    behave features/flaw_detail_embargo.feature --tags=~@skip
+if run_behave features/flaw_create_embargo.feature; then
+    run_behave features/flaw_detail_embargo.feature --tags=~@skip
 else
     echo "flaw_create_embargo.feature failed, skip flaw_detail_embargo.feature"
 fi
 
-if behave features/flaw_create_public.feature; then
-    behave features/flaw_detail_public.feature --tags=~@skip
+if run_behave features/flaw_create_public.feature; then
+    run_behave features/flaw_detail_public.feature --tags=~@skip
 else
     echo "flaw_create_public.feature failed, skip flaw_detail_public.feature"
 fi
 
 if [ -e flaw_id.txt ]
 then
-    behave features/advance_search.feature
-    behave features/flaw_list.feature
-    behave features/quick_search.feature
+    run_behave features/advance_search.feature
+    run_behave features/flaw_list.feature
+    run_behave features/quick_search.feature
 else
     echo "All flaw for test created failed, skip advance_search.feature,
     flaw_list.feature, quick_search.feature"


### PR DESCRIPTION
# OSIDB-3214: Save test reports as junit when on CI

In preparation for sending the tests reports via email, I changed the `run_automation_test` script to add parameters to `behave` when running on the pipeline

Closes OSIDB-3214
