### PR TITLE
OSIDB-3262: Remove historical affects validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 * Add button to Bugzilla on public and private comments
 
+### Fixed
+* Allow saving flaws with historical affects (`OSIDB-3262`)
+
 ## [2024.7.2]
 ### Fixed
 * Fix comment#0 and description fields layout (`OSIDB-3174`)

--- a/src/types/zodAffect.ts
+++ b/src/types/zodAffect.ts
@@ -78,9 +78,9 @@ export const AffectCVSSSchema = z.object({
   alerts: z.array(ZodAlertSchema).default([]),
 });
 
-export type ZodAffectType = z.infer<typeof _ZodAffectSchema>;
-export type AffectSchemaType = typeof _ZodAffectSchema;
-const _ZodAffectSchema = z.object({
+export type ZodAffectType = z.infer<typeof ZodAffectSchema>;
+export type AffectSchemaType = typeof ZodAffectSchema;
+export const ZodAffectSchema = z.object({
   uuid: z.string().uuid().nullish(),
   flaw: z.string().nullish(),
   affectedness: z.nativeEnum(AffectednessEnumWithBlank).nullish(),
@@ -110,5 +110,3 @@ const _ZodAffectSchema = z.object({
   updated_dt: zodOsimDateTime().nullish(), // $date-time,
   alerts: z.array(ZodAlertSchema).default([]),
 });
-
-export const ZodAffectSchema = _ZodAffectSchema;

--- a/src/types/zodAffect.ts
+++ b/src/types/zodAffect.ts
@@ -111,15 +111,4 @@ const _ZodAffectSchema = z.object({
   alerts: z.array(ZodAlertSchema).default([]),
 });
 
-export const ZodAffectSchema = _ZodAffectSchema.superRefine((data, zodContext) => {
-  if (data.affectedness) {
-    const resolution = AffectednessResolutionPairs[data.affectedness];
-    if (!Object.values(resolution).includes(data.resolution!)){
-      zodContext.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Resolution is not valid',
-        path: ['resolution']
-      });
-    }
-  }
-});
+export const ZodAffectSchema = _ZodAffectSchema;


### PR DESCRIPTION
# OSIDB-3262 Historical affects should not block flaw save

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases not added/updated
- [x] Jira ticket updated

## Summary:

OSIM should allow users to save flaws even if there are affects with historical resolution values.

## Changes:

- Removes validation for resolution pairs in `ZodAffect`

## Considerations:

I considered removing the existing `ZodAffect` validation, that way users wont be prevented to save flaws with historical affect, and users are still not able to create affects with invalid combinations cause historical options are hidden and also OSIDB handles it's own validation for that valid affects (which provides even more detailed information than OSIM was).

Closes OSIDB-3262
