### PR TITLE
Use DEFER in place of WONTFIX, restrict to LOW-impact Affects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Fixed
 * Allow saving flaws with historical affects (`OSIDB-3262`)
 
+### Changed
+* `DEFER` has replaced `WONTFIX` as an affect resolution, and cannot be selected when impact is not `LOW` (`OSIDB-3285`, `OSIDB-3286`, `OSIDB-3288`)
+
 ## [2024.7.2]
 ### Fixed
 * Fix comment#0 and description fields layout (`OSIDB-3174`)

--- a/src/components/AffectExpandableForm.vue
+++ b/src/components/AffectExpandableForm.vue
@@ -4,7 +4,7 @@ import { computed, toRef } from 'vue';
 
 import LabelCollapsible from '@/components/widgets/LabelCollapsible.vue';
 import AffectedOfferingForm from '@/components/AffectedOfferingForm.vue';
-import { type ZodAffectType } from '@/types/zodAffect';
+import { affectResolutions, type ZodAffectType } from '@/types/zodAffect';
 import { type UpdateStream } from '@/composables/useTrackers';
 
 const props = defineProps<{
@@ -44,9 +44,9 @@ const resolutionLabel = computed(() => {
   const resolution: string = props.affect.resolution || '';
   const resolutionValue = {
     [resolution]: resolution,
-    'DELEGATED': 'Delegated',
-    'WONTFIX': 'Won\'t Fix',
-    'OOSS': 'OOSS',
+    [affectResolutions.Delegated]: 'Delegated',
+    [affectResolutions.Defer]: 'Defer',
+    [affectResolutions.Ooss]: 'OOSS',
   }[resolution];
   return resolutionValue && `Resolution: ${resolutionValue}` || '';
 });

--- a/src/components/AffectExpandableForm.vue
+++ b/src/components/AffectExpandableForm.vue
@@ -4,7 +4,7 @@ import { computed, toRef } from 'vue';
 
 import LabelCollapsible from '@/components/widgets/LabelCollapsible.vue';
 import AffectedOfferingForm from '@/components/AffectedOfferingForm.vue';
-import { affectResolutions, type ZodAffectType } from '@/types/zodAffect';
+import { affectResolutions, affectAffectedness, type ZodAffectType } from '@/types/zodAffect';
 import { type UpdateStream } from '@/composables/useTrackers';
 
 const props = defineProps<{
@@ -33,9 +33,9 @@ const affectednessLabel = computed(() => {
   const affectedness: string = props.affect.affectedness || '';
   const affectednessValue = {
     [affectedness]: affectedness,
-    'NEW': 'New',
-    'AFFECTED': 'Affected',
-    'NOTAFFECTED': 'Not Affected',
+    [affectAffectedness.New]: 'New',
+    [affectAffectedness.Affected]: 'Affected',
+    [affectAffectedness.Notaffected]: 'Not Affected',
   }[affectedness];
   return affectednessValue && `Affectedness: ${affectednessValue}` || '';
 });

--- a/src/components/AffectedOfferingForm.vue
+++ b/src/components/AffectedOfferingForm.vue
@@ -15,8 +15,8 @@ import { formatDate, getRhCvss3 } from '@/utils/helpers';
 
 const { width: screenWidth } = useWindowSize();
 
-const resolutionOptions = computed(() => modelValue.value?.affectedness && modelValue.value?.impact
-  ? possibleAffectResolutions(modelValue.value.impact)[modelValue.value.affectedness]
+const resolutionOptions = computed(() => modelValue.value?.affectedness
+  ? possibleAffectResolutions(modelValue.value?.impact)[modelValue.value.affectedness]
   : []);
 
 defineProps<{

--- a/src/components/AffectedOfferingForm.vue
+++ b/src/components/AffectedOfferingForm.vue
@@ -6,7 +6,7 @@ import LabelSelect from '@/components/widgets/LabelSelect.vue';
 import { osimRuntime } from '@/stores/osimRuntime';
 import { trackerUrl } from '@/services/TrackerService';
 import {
-  AffectednessResolutionPairs,
+  possibleAffectResolutions,
   affectAffectedness,
   affectImpacts,
   type ZodAffectType,
@@ -14,13 +14,13 @@ import {
 import { formatDate, getRhCvss3 } from '@/utils/helpers';
 
 const { width: screenWidth } = useWindowSize();
-const resolutionOptions = computed(() =>
-  (modelValue.value?.affectedness && AffectednessResolutionPairs[modelValue.value?.affectedness]) || []
-);
-type NotUndefined<T> = Exclude<T, undefined>;
+
+const resolutionOptions = computed(() => modelValue.value?.affectedness && modelValue.value?.impact
+  ? possibleAffectResolutions(modelValue.value.impact)[modelValue.value.affectedness]
+  : []);
 
 defineProps<{
-  error: Record<string, NotUndefined<any>> | null;
+  error: Record<string, Exclude<any, undefined>> | null;
 }>();
 
 const isScreenSortaSmall = computed(() => screenWidth.value < 950);
@@ -50,9 +50,9 @@ watch(() => rhCvss3.value?.vector, () => {
   }
 });
 
-watch(() => modelValue.value?.affectedness, () => {
+watch([() => modelValue.value?.affectedness, () => modelValue.value?.impact], () => {
   if (modelValue.value) {
-    modelValue.value.resolution = '';
+    modelValue.value.resolution = Object.values(resolutionOptions.value)[0];
   }
 });
 

--- a/src/components/__tests__/AffectExpandableForm.spec.ts
+++ b/src/components/__tests__/AffectExpandableForm.spec.ts
@@ -6,7 +6,7 @@ import AffectedOfferingForm from '@/components/AffectedOfferingForm.vue';
 import LabelSelect from '@/components/widgets/LabelSelect.vue';
 import {
   affectAffectedness,
-  AffectednessResolutionPairs,
+  possibleAffectResolutions,
 } from '@/types/zodAffect';
 
 vi.mock('@/stores/osimRuntime', async () => {
@@ -152,7 +152,24 @@ describe('AffectExpandableForm', () => {
     expect(affectednessOptions).toStrictEqual(affectAffectedness);
     await affectednessSelectEl.find('select').setValue('AFFECTED');
     const resolutionOptions = resolutionSelectEL.props('options');
-    expect(resolutionOptions).toStrictEqual(AffectednessResolutionPairs['AFFECTED']);
+    expect(resolutionOptions).toStrictEqual(possibleAffectResolutions('IMPORTANT')['AFFECTED']);
+  });
+
+  it('should allow DEFER with impact LOW', async () => {
+    const formComponent = subject.findAllComponents(AffectedOfferingForm);
+    expect(formComponent.length).toBe(1);
+    const selectComponents = formComponent[0].findAllComponents(LabelSelect);
+    expect(selectComponents.length).toBe(3);
+    const affectednessSelect = selectComponents[0];
+    const resolutionSelect = selectComponents[1];
+    const impactSelect = selectComponents[2];
+    const affectednessOptions = affectednessSelect.props('options');
+    expect(affectednessOptions).toStrictEqual(affectAffectedness);
+    await affectednessSelect.setValue('AFFECTED');
+    const resolutionOptions = resolutionSelect.props('options');
+    impactSelect.setValue('LOW');
+    resolutionSelect.setValue('DEFER');
+    expect(resolutionOptions).toStrictEqual(possibleAffectResolutions('IMPORTANT')['AFFECTED']);
   });
 
   it('should render trackers with errata link', async () => {

--- a/src/components/__tests__/AffectExpandableForm.spec.ts
+++ b/src/components/__tests__/AffectExpandableForm.spec.ts
@@ -172,6 +172,23 @@ describe('AffectExpandableForm', () => {
     expect(resolutionOptions).toStrictEqual(possibleAffectResolutions('IMPORTANT')['AFFECTED']);
   });
 
+  it('should NOT allow DEFER without impact LOW', async () => {
+    const formComponent = subject.findAllComponents(AffectedOfferingForm);
+    expect(formComponent.length).toBe(1);
+    const selectComponents = formComponent[0].findAllComponents(LabelSelect);
+    expect(selectComponents.length).toBe(3);
+    const affectednessSelect = selectComponents[0];
+    const resolutionSelect = selectComponents[1];
+    const impactSelect = selectComponents[2];
+    const affectednessOptions = affectednessSelect.props('options');
+    expect(affectednessOptions).toStrictEqual(affectAffectedness);
+    await affectednessSelect.setValue('AFFECTED');
+    const resolutionValues = resolutionSelect.findAllComponents('option').map(wrapper => wrapper.element.nodeValue);
+    resolutionSelect.setValue('DEFER');
+    impactSelect.setValue('CRITICAL');
+    expect(resolutionValues.includes('DEFER')).toBe(false);
+  });
+
   it('should render trackers with errata link', async () => {
     const trackerEls = subject.findAll('.osim-tracker-card');
     expect(trackerEls.length).toBe(1);

--- a/src/composables/useTrackers.ts
+++ b/src/composables/useTrackers.ts
@@ -1,4 +1,4 @@
-import type { valueof } from './../utils/helpers';
+import type { ValueOf, Nullable } from '@/utils/typeHelpers';
 import { computed, ref, watch, type Ref } from 'vue';
 
 import { getTrackersForFlaws, type TrackersPost, fileTrackingFor } from '@/services/TrackerService';
@@ -54,15 +54,16 @@ export function useTrackers(flawUuid: string, affects: Ref<ZodAffectType[]>) {
     })
   );
 
-  function isResolutionTrackable(affect: ZodAffectType) {
-    const allowedResolutions: valueof<typeof affectResolutions>[] = [
-      affectResolutions.Delegated,
-      affectResolutions.Empty,
-    ];
+  type AllowedResolution = ValueOf<typeof affectResolutions>;
+  type AllowedResolutionGuard = ZodAffectType & typeof allowedResolutions[number];
 
-    return affect.resolution
-      ? allowedResolutions.includes(affect.resolution)
-      : false;
+  const allowedResolutions: Nullable<AllowedResolution>[] = [
+    affectResolutions.Delegated,
+    affectResolutions.Empty,
+  ];
+
+  function isResolutionTrackable(affect: ZodAffectType): affect is AllowedResolutionGuard {
+    return allowedResolutions.includes(affect.resolution);
   }
 
   const availableUpdateStreams = computed((): UpdateStream[] => moduleComponents.value

--- a/src/types/zodAffect.ts
+++ b/src/types/zodAffect.ts
@@ -19,7 +19,7 @@ export const affectAffectedness = AffectednessEnumWithBlank;
 
 type PossibleResolutions = Record<AffectednessEnum, Partial<typeof ResolutionEnumWithBlank>>;
 
-export function possibleAffectResolutions(impact?: valueof<typeof affectImpacts>): PossibleResolutions {
+export function possibleAffectResolutions(impact?: valueof<typeof affectImpacts> | null): PossibleResolutions {
   const pickResolution = (options: (keyof typeof ResolutionEnumWithBlank)[], resolutions: typeof affectResolutions) => {
     const possibleResolutions = options.filter(option => (
       impact === affectImpacts.Low && option === 'Defer' || option !== 'Defer'

--- a/src/types/zodAffect.ts
+++ b/src/types/zodAffect.ts
@@ -7,6 +7,8 @@ import {
 
 import { zodOsimDateTime, ImpactEnumWithBlank, ZodFlawClassification, ZodAlertSchema } from './zodShared';
 import { omit, pick } from 'ramda';
+import type { valueof } from '@/utils/helpers';
+
 
 const AffectednessEnumWithBlank = { 'Empty': '', ...AffectednessEnum } as const;
 const ResolutionEnumWithBlank = { 'Empty': '', ...ResolutionEnum } as const;
@@ -15,10 +17,9 @@ export const affectImpacts = { ...omit([''], ImpactEnumWithBlank), Empty: '' } a
 export const affectResolutions = ResolutionEnumWithBlank;
 export const affectAffectedness = AffectednessEnumWithBlank;
 
-type valueof<T> = T[keyof T];
 type PossibleResolutions = Record<AffectednessEnum, Partial<typeof ResolutionEnumWithBlank>>;
 
-export function possibleAffectResolutions(impact: valueof<typeof affectImpacts>): PossibleResolutions {
+export function possibleAffectResolutions(impact?: valueof<typeof affectImpacts>): PossibleResolutions {
   const pickResolution = (options: (keyof typeof ResolutionEnumWithBlank)[], resolutions: typeof affectResolutions) => {
     const possibleResolutions = options.filter(option => (
       impact === affectImpacts.Low && option === 'Defer' || option !== 'Defer'

--- a/src/types/zodAffect.ts
+++ b/src/types/zodAffect.ts
@@ -7,7 +7,7 @@ import {
 
 import { zodOsimDateTime, ImpactEnumWithBlank, ZodFlawClassification, ZodAlertSchema } from './zodShared';
 import { omit, pick } from 'ramda';
-import type { valueof } from '@/utils/helpers';
+import type { ValueOf } from '@/utils/typeHelpers';
 
 
 const AffectednessEnumWithBlank = { 'Empty': '', ...AffectednessEnum } as const;
@@ -19,7 +19,7 @@ export const affectAffectedness = AffectednessEnumWithBlank;
 
 type PossibleResolutions = Record<AffectednessEnum, Partial<typeof ResolutionEnumWithBlank>>;
 
-export function possibleAffectResolutions(impact?: valueof<typeof affectImpacts> | null): PossibleResolutions {
+export function possibleAffectResolutions(impact?: ValueOf<typeof affectImpacts> | null): PossibleResolutions {
   const pickResolution = (options: (keyof typeof ResolutionEnumWithBlank)[], resolutions: typeof affectResolutions) => {
     const possibleResolutions = options.filter(option => (
       impact === affectImpacts.Low && option === 'Defer' || option !== 'Defer'

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,6 +2,8 @@ import { toRaw, isRef, isReactive, isProxy, ref, toRef, watch, unref } from 'vue
 import { DateTime } from 'luxon';
 import * as R from 'ramda';
 
+export type valueof<T> = T[keyof T];
+
 export function watchedPropRef(prop: Record<string, any>, property: string, defaultValue: any) {
   const reffedProp = toRef(prop, property);
   const flexRef = reffedProp.value === undefined ? ref(defaultValue) : reffedProp;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,8 +2,6 @@ import { toRaw, isRef, isReactive, isProxy, ref, toRef, watch, unref } from 'vue
 import { DateTime } from 'luxon';
 import * as R from 'ramda';
 
-export type valueof<T> = T[keyof T];
-
 export function watchedPropRef(prop: Record<string, any>, property: string, defaultValue: any) {
   const reffedProp = toRef(prop, property);
   const flexRef = reffedProp.value === undefined ? ref(defaultValue) : reffedProp;

--- a/src/utils/typeHelpers.ts
+++ b/src/utils/typeHelpers.ts
@@ -1,0 +1,3 @@
+export type ValueOf<T> = T[keyof T];
+
+export type Nullable<T> = T | null | undefined;


### PR DESCRIPTION
# OSIDB-3281

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Replaces WONTFIX with DEFER, as well as limits this selection to Affects with `LOW` impact. 

## Changes:

Makes possible affect resolutions dependent on impact value, dynamically calculations possible resolution values.

## Considerations:

1. _**Depends on OSIDB-related subtasks and deployment of backend changes.**_
2.  @C-Valen  points out that
> ...that this merge will go before the affect section redesign, so it will be dependent on this (requiring adjustment from the new types and test cases).
> 
> #371



Closes OSIDB-3285. Closes OSIDB-3286. Closes OSIDB-3288.
