### PR TITLE
♻️ Remove validation for impact on DEFER affect resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@
 ## [Unreleased]
 ### Added
 * Add button to Bugzilla on public and private comments
-* `DEFER` is now a possible affect resolution, but can only be selected when impact is `LOW` (`OSIDB-3285`, `OSIDB-3286`, `OSIDB-3288`)
+* `DEFER` is now a possible affect resolution (`OSIDB-3286`, `OSIDB-3288`)
 
 ### Fixed
 * Allow saving flaws with historical affects (`OSIDB-3262`)
 
 ## [2024.7.2]
 ### Fixed
-* Fix comment#0 and description fields layout (`OSIDB-3174`)
+* Fix comment#0 and description fields layout (`OSIDB-3174`)$$
 * Indicate when single tracker successfully filed (`OSIDB-3144`)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## [2024.7.2]
 ### Fixed
-* Fix comment#0 and description fields layout (`OSIDB-3174`)$$
+* Fix comment#0 and description fields layout (`OSIDB-3174`)
 * Indicate when single tracker successfully filed (`OSIDB-3144`)
 
 ### Added

--- a/src/components/AffectedOfferingForm.vue
+++ b/src/components/AffectedOfferingForm.vue
@@ -16,7 +16,7 @@ import { formatDate, getRhCvss3 } from '@/utils/helpers';
 const { width: screenWidth } = useWindowSize();
 
 const resolutionOptions = computed(() => modelValue.value?.affectedness
-  ? possibleAffectResolutions(modelValue.value?.impact)[modelValue.value.affectedness]
+  ? possibleAffectResolutions[modelValue.value.affectedness]
   : []);
 
 defineProps<{

--- a/src/components/__tests__/AffectExpandableForm.spec.ts
+++ b/src/components/__tests__/AffectExpandableForm.spec.ts
@@ -152,7 +152,7 @@ describe('AffectExpandableForm', () => {
     expect(affectednessOptions).toStrictEqual(affectAffectedness);
     await affectednessSelectEl.find('select').setValue('AFFECTED');
     const resolutionOptions = resolutionSelectEL.props('options');
-    expect(resolutionOptions).toStrictEqual(possibleAffectResolutions('IMPORTANT')['AFFECTED']);
+    expect(resolutionOptions).toStrictEqual(possibleAffectResolutions['AFFECTED']);
   });
 
   it('should allow DEFER with impact LOW', async () => {
@@ -169,7 +169,7 @@ describe('AffectExpandableForm', () => {
     const resolutionOptions = resolutionSelect.props('options');
     impactSelect.setValue('LOW');
     resolutionSelect.setValue('DEFER');
-    expect(resolutionOptions).toStrictEqual(possibleAffectResolutions('IMPORTANT')['AFFECTED']);
+    expect(resolutionOptions).toStrictEqual(possibleAffectResolutions['AFFECTED']);
   });
 
   it('should NOT allow DEFER without impact LOW', async () => {

--- a/src/types/zodAffect.ts
+++ b/src/types/zodAffect.ts
@@ -7,7 +7,6 @@ import {
 
 import { zodOsimDateTime, ImpactEnumWithBlank, ZodFlawClassification, ZodAlertSchema } from './zodShared';
 import { omit, pick } from 'ramda';
-import type { ValueOf } from '@/utils/typeHelpers';
 
 const AffectednessEnumWithBlank = { 'Empty': '', ...AffectednessEnum } as const;
 const ResolutionEnumWithBlank = { 'Empty': '', ...ResolutionEnum } as const;
@@ -17,22 +16,11 @@ export const affectResolutions = ResolutionEnumWithBlank;
 export const affectAffectedness = AffectednessEnumWithBlank;
 
 type PossibleResolutions = Record<AffectednessEnum, Partial<typeof ResolutionEnumWithBlank>>;
-
-export function possibleAffectResolutions(impact?: ValueOf<typeof affectImpacts> | null): PossibleResolutions {
-  const pickResolution = (options: (keyof typeof ResolutionEnumWithBlank)[], resolutions: typeof affectResolutions) => {
-    const possibleResolutions = options.filter(option => (
-      impact === affectImpacts.Low && option === 'Defer' || option !== 'Defer'
-    ));
-    return pick(possibleResolutions, resolutions);
-  };
-
-  return {
-    AFFECTED: pickResolution(['Delegated', 'Defer', 'Wontfix', 'Ooss'], affectResolutions),
-    NEW: pickResolution(['Empty', 'Defer', 'Wontfix', 'Ooss'], affectResolutions),
-    NOTAFFECTED: pickResolution(['Empty'], affectResolutions),
-  };
-}
-
+export const possibleAffectResolutions: PossibleResolutions = {
+  AFFECTED: pick(['Delegated', 'Defer', 'Wontfix', 'Ooss'], affectResolutions),
+  NEW: pick(['Empty', 'Defer', 'Wontfix', 'Ooss'], affectResolutions),
+  NOTAFFECTED: pick(['Empty'], affectResolutions),
+};
 
 export type ErratumSchemaType = typeof ErratumSchema;
 export const ErratumSchema = z.object({


### PR DESCRIPTION
# OSIDB-3329 Allow DEFER to have any impact level

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Allow Affects with any impact to have DEFER resolution.

## Changes:

Removes validation that prevents higher than LOW severity affects to have DEFER.

## Considerations:

Blessed be the users.

Closes OSIDB-3329.
