### PR TITLE
OSIDB-3227: Duplicated CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
+    "@fullhuman/postcss-purgecss": "^6.0.0",
     "@openapitools/openapi-generator-cli": "^2.6.0",
     "@pinia/testing": "^0.1.3",
     "@stylistic/eslint-plugin": "^2.1.0",

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,32 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const purgecss = require('@fullhuman/postcss-purgecss');
+
+
+/**
+ * See Vue guide for extractor and safelist
+ * https://purgecss.com/guides/vue.html#usage
+ *
+ */
+module.exports = {
+  plugins: [
+    purgecss({
+      content: ['./src/**/*.{vue,js,ts,css,scss,html}'],
+      extractors: [
+        {
+          extractor(content) {
+            const contentWithoutStyleBlocks = content.replace(/<style[^]+?<\/style>/gi, '');
+            return contentWithoutStyleBlocks.match(/[A-Za-z0-9-_/:]*[A-Za-z0-9-_/]+/g) || [];
+          },
+          extensions: ['vue']
+        }
+      ],
+      safelist: [
+        /-(leave|enter|appear)(|-(to|from|active))$/,
+        /^(?!(|.*?:)cursor-move).+-move$/,
+        /^router-link(|-exact)-active$/,
+        /data-v-.*/,
+        /data-bs.*/, // Bootstrap 5 javascript data attributes
+      ],
+    })
+  ]
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,11 +8,9 @@ import router from './router';
 import { InputLabelDirective } from '@/directives/InputLabelDirective.js';
 import { LoadingAnimationDirective } from '@/directives/LoadingAnimationDirective.js';
 
-import 'bootstrap/scss/bootstrap.scss';
-import 'bootstrap-icons/font/bootstrap-icons.scss';
 import './scss/index.scss';
 import './assets/main.css';
-import 'bootstrap/js/index.esm.js';
+import 'bootstrap';
 
 const app = createApp(App);
 const pinia = createPinia();

--- a/src/scss/bootstrap-customization.scss
+++ b/src/scss/bootstrap-customization.scss
@@ -1,0 +1,18 @@
+$custom-colors: (
+  'light-light-gray': $light-light-gray,
+  'light-light-orange': $light-light-orange,
+  'light-gray': $light-gray,
+  'light-purple': $light-purple,
+  'light-green': $light-green,
+  'light-yellow': $light-yellow,
+  'light-orange': $light-orange,
+  'light-info': $light-info,
+  'light-teal': $light-teal,
+  'custom-color': #900,
+  'black': $black,
+  'blue': $blue,
+  'gray': $gray,
+);
+
+// Merge the maps
+$theme-colors: map-merge($theme-colors, $custom-colors);

--- a/src/scss/bootstrap-overrides.scss
+++ b/src/scss/bootstrap-overrides.scss
@@ -19,23 +19,9 @@ $font-family-base: 'Red Hat Text';
 $font-family-monospace: 'Red Hat Mono', monospace;
 $font-family-code: $font-family-monospace;
 
-// A variable with !default flag will default to the previously set value of
-//  this variable (if any available). As all bootstrap variables have this flag, 
-//  you could import your custom-variables.scss before the bootstrap/scss/bootstrap;
-$redhat-primary: $redhat-red-50;
-$redhat-secondary: $redhat-gray-50;
-$primary: $redhat-primary;
-$secondary: $redhat-secondary;
-$danger: $redhat-danger-50;
-$success: $redhat-success-40;
-$black: $redhat-gray-95;
-$info: $redhat-teal-40;
-$light-teal: $redhat-teal-10;
+// Custom colors
 $light-info: $redhat-teal-10;
-$warning: $redhat-yellow-30;
-$gray: $redhat-gray-20;
-$blue: $redhat-blue-40;
-$link-color: $blue;
+$light-teal: $redhat-teal-10;
 $light-gray: $redhat-gray-10;
 $light-light-gray: #fcfcfc;
 $light-light-orange: #fffaf3;
@@ -43,32 +29,18 @@ $light-purple: $redhat-purple-10;
 $light-green: $redhat-success-10;
 $light-yellow: $redhat-yellow-10;
 $light-orange: $redhat-orange-10;
-$theme-colors: (
-  'black': $black,
-  'blue': $blue,
-  'gray': $gray,
-  'light-light-gray': $light-light-gray,
-  'light-light-orange': $light-light-orange,
-  'light-gray': $light-gray,
-  'light-purple': $light-purple,
-  'light-green': $light-green,
-  'light-yellow': $light-yellow,
-  'light-orange': $light-orange,
-  'light-info': $light-info,
-  'light-teal': $light-teal,
-  'primary': $primary,
-  'secondary': $secondary,
-  'info': $info,
-  'success': $success,
-  'danger': $danger,
-  'warning': $warning,
-);
+$redhat-primary: $redhat-red-50;
+$redhat-secondary: $redhat-gray-50;
 
-// Create your own map
-$custom-colors: (
-  'custom-color': #900,
-);
 
-// Merge the maps
-$theme-colors: map-merge($theme-colors, $custom-colors);
-
+// Bootstrap color overrides
+$primary: $redhat-primary;
+$secondary: $redhat-secondary;
+$danger: $redhat-danger-50;
+$success: $redhat-success-40;
+$black: $redhat-gray-95;
+$info: $redhat-teal-40;
+$warning: $redhat-yellow-30;
+$gray: $redhat-gray-20;
+$blue: $redhat-blue-40;
+$link-color: $blue;

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -1,2 +1,14 @@
+// Override Bootstrap variables here
 @import "./bootstrap-overrides";
-@import "../node_modules/bootstrap/scss/bootstrap"
+
+// Import Bootstrap functions and variables
+@import "bootstrap/scss/functions";
+@import "bootstrap/scss/variables";
+@import "bootstrap/scss/variables-dark";
+
+// Extend Bootstrap with customizations
+@import "./bootstrap-customization";
+
+// Import Bootstrap
+@import "bootstrap/scss/bootstrap";
+@import 'bootstrap-icons/font/bootstrap-icons.css'; // Vite scss loader is broken. See https://github.com/twbs/icons/issues/1381

--- a/yarn.lock
+++ b/yarn.lock
@@ -504,6 +504,13 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
+"@fullhuman/postcss-purgecss@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-6.0.0.tgz#c6c27075aa5c5edc53f7fcf08e8f625ca48bf40e"
+  integrity sha512-sUvk5PV7O5xvTJcxDYrQ00xlKtSxivvJdZrwgxE8F1GmNMs7w9U+dSbr83N/qEs9b+f+6QsZKXDs0k8nMjBIqA==
+  dependencies:
+    purgecss "^6.0.0"
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"
@@ -1806,6 +1813,11 @@ commander@^10.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
+commander@^12.0.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -2586,6 +2598,18 @@ glob@7.2.3, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^10.3.10:
+  version "10.4.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
+  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
 
 glob@^10.3.3:
   version "10.4.2"
@@ -3873,6 +3897,14 @@ postcss-selector-parser@^6.0.15, postcss-selector-parser@^6.1.0:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
+postcss-selector-parser@^6.0.7:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz#27ecb41fb0e3b6ba7a1ec84fff347f734c7929de"
+  integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
 postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
@@ -3885,6 +3917,15 @@ postcss@^8.3.11, postcss@^8.4.0, postcss@^8.4.27, postcss@^8.4.38:
   dependencies:
     nanoid "^3.3.7"
     picocolors "^1.0.0"
+    source-map-js "^1.2.0"
+
+postcss@^8.4.4:
+  version "8.4.41"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.41.tgz#d6104d3ba272d882fe18fc07d15dc2da62fa2681"
+  integrity sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.0.1"
     source-map-js "^1.2.0"
 
 prelude-ls@^1.2.1:
@@ -3927,6 +3968,16 @@ punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+purgecss@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/purgecss/-/purgecss-6.0.0.tgz#ffea0a4d32092f660402a4ba14250e927c1a4cfe"
+  integrity sha512-s3EBxg5RSWmpqd0KGzNqPiaBbWDz1/As+2MzoYVGMqgDqRTLBhJW6sywfTBek7OwNfoS/6pS0xdtvChNhFj2cw==
+  dependencies:
+    commander "^12.0.0"
+    glob "^10.3.10"
+    postcss "^8.4.4"
+    postcss-selector-parser "^6.0.7"
 
 querystringify@^2.1.1:
   version "2.2.0"


### PR DESCRIPTION
# OSIDB-3227: Duplicated CSS

## Checklist:

- [x] Commits consolidated
- [ ] Changelog updated
- [ ] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Fix Bootstrap imports and reduce CSS delivery

## Changes:

While working on fixing the CSS duplication, I discovered that the bootstrap scss overrides was broken and only worked because we had duplicate code.

The variable `$theme-colors` is an special variable that is expanded by bootstrap with the `utils.scss`, this file generates all the `text-[color]` classes (among others), because we were **overwriting** the map instead of **extending** it, all this classes failed to create, for example `text-dark`, **but** because we imported bootstrap twice, in `main.ts` and `index.scss` 
the classes `text-[color]` were created by the `main.ts` import before the `index.scss` overrides.

Bootstrap overrides needs to be declared before importing bootstrap, so all the variables defined with `!default` are not created, but `maps` needs to be modified after importing `functions, variables and variables-dark`, as you can see in the docs [Add to map](https://getbootstrap.com/docs/5.3/customize/sass/#remove-from-map).

With the order of import fixed, the duplicated CSS code was removed but we were still importing `400kB` of **all** the bootstrap CSS. Since `vite` uses `postcss` under the hood, I installed [PurgeCSS](https://purgecss.com/) to remove all the CSS that is unused.


Here's a comparation of the bundle before and after all the changes (removed unrelated output):
```
vite v4.5.3 building for production...
✓ 935 modules transformed.
dist/index.html                                                0.56 kB │ gzip:   0.34 kB
dist/assets/vendor-cc057500.css                              301.27 kB │ gzip:  44.00 kB
dist/assets/index-bebddbe6.css                               333.41 kB │ gzip:  42.69 kB
dist/assets/index-d743ee3d.js                                189.85 kB │ gzip:  60.62 kB │ map: 1,441.35 kB
dist/assets/vendor-83af3c16.js                               600.45 kB │ gzip: 199.98 kB │ map: 3,109.32 kB

✓ built in 8.84s
Done in 9.15s.
```
> Before code de-duplication and purge css, 634.68kB of styles

```
vite v4.5.3 building for production...
✓ 907 modules transformed.
dist/index.html                                                0.50 kB │ gzip:   0.33 kB
dist/assets/index-5fc002f7.css                               116.54 kB │ gzip:  19.40 kB
dist/assets/index-e8726221.js                                189.85 kB │ gzip:  60.62 kB │ map: 1,441.24 kB
dist/assets/vendor-b5510954.js                               600.70 kB │ gzip: 199.80 kB │ map: 3,104.64 kB

✓ built in 8.51s
Done in 8.88s.
```
> After code de-duplication and purge css, 116.54kB of styles

## Considerations:

Since this change affects the generated code, I tried to make sure everything works as expected (modals, dropdowns, toast notifications...) but I may have left something behind, so keep a close eye after merging this (or checkout the PR locally and test)

Closes OSIDB-3327
