### PR TITLE
OSIDB-3359: Fix toast colors after CSS purge

### DIFF
--- a/src/components/widgets/Toast.vue
+++ b/src/components/widgets/Toast.vue
@@ -7,14 +7,20 @@ import { useSettingsStore } from '@/stores/SettingsStore';
 
 const { settings } = useSettingsStore();
 
-const props = defineProps<{
+export interface ToastProps {
   title?: string,
   body: string,
   timestamp: DateTime,
   bodyHtml?: boolean,
   timeoutMs?: number,
   css?: 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info' | 'light' | 'dark',
-}>();
+}
+
+const props = withDefaults(defineProps<ToastProps>(), {
+  css: 'light',
+  title: '',
+  timeoutMs: undefined,
+});
 
 const emit = defineEmits<{
   close: [],
@@ -23,9 +29,18 @@ const emit = defineEmits<{
   stale: [],
 }>();
 
-const css = computed(() => {
-  return props.css ?? 'light';
-});
+const cssMapping: Record<NonNullable<ToastProps['css']>, string> = {
+  primary: 'text-bg-primary',
+  secondary: 'text-bg-secondary',
+  success: 'text-bg-success',
+  danger: 'text-bg-danger',
+  warning: 'text-bg-warning',
+  info: 'text-bg-info',
+  light: 'text-bg-light',
+  dark: 'text-bg-dark',
+};
+
+const css = computed(() => cssMapping[props.css]);
 
 const isStale = ref(false);
 const freshMs = 10000;  // ms for inactive toast to remain fresh
@@ -134,8 +149,7 @@ const transitionDurationMs = ref(16);
 const toastClasses = computed(() => {
   const classes: { [key: string]: boolean } = {};
 
-  const textBgKey: string = 'text-bg-' + css.value;
-  classes[textBgKey] = true;
+  classes[css.value] = true;
 
   const freshAndBecomingStale = !settings.showNotifications && !active.value && !isStale.value;
   classes['fresh-leave-active'] = freshAndBecomingStale;
@@ -185,9 +199,8 @@ const timeoutRingDiameterPx = computed(() => timeoutRingDiameter.value + 'px');
     </div>
     <div class="toast-body osim-toast-body">
       <slot name="body">
-        <!-- eslint-disable vue/no-v-html -->
+        <!-- eslint-disable-next-line vue/no-v-html -->
         <div v-if="bodyHtml" v-html="body"></div>
-        <!-- eslint-enable -->
         <div v-if="!bodyHtml">
           {{ body }}
         </div>
@@ -240,5 +253,4 @@ button.osim-toast-close-btn {
     transform: translateX(20px);
   }
 }
-
 </style>

--- a/src/components/widgets/__tests__/Toast.spec.ts
+++ b/src/components/widgets/__tests__/Toast.spec.ts
@@ -1,172 +1,70 @@
-import { VueWrapper, mount, flushPromises } from '@vue/test-utils';
-import { describe, it, expect } from 'vitest';
-import router from '@/router';
+import { mount, flushPromises } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
 
-import Toast from '../Toast.vue';
-import { useSettingsStore } from '@/stores/SettingsStore';
+import Toast, { type ToastProps } from '../Toast.vue';
 import { DateTime } from 'luxon';
-import ProgressRing from '../ProgressRing.vue';
 
-describe('Toast', async () => {
-  let subject: VueWrapper<InstanceType<typeof Toast>>;
+describe('Toast', () => {
+  const mountToast = (props?: Partial<ToastProps>) => {
+    return mount(Toast, {
+      props: {
+        timestamp: DateTime.fromISO('2024-08-28T10:10:10.000Z'),
+        body: 'Test body',
+        ...props,
+      },
+      global: {
+        plugins: [createTestingPinia()]
+      }
+    });
+  };
+
   beforeEach(() => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({
+      now: new Date('2024-08-28T11:10:10.000Z').getTime(),
+    });
   });
 
   afterEach(() => {
     vi.useRealTimers();
-    vi.clearAllMocks();
   });
 
-  it('render toast body, header', async () => {
-    const pinia = createTestingPinia({
-      createSpy: vitest.fn,
-      stubActions: false,
-    });
-    const settingStore = useSettingsStore(pinia);
-    settingStore.$state = {
-      settings: {
-        ...settingStore.$state.settings,
-        showNotifications: true,
-      }
-    };
-    subject = mount(Toast, {
-      global: {
-        plugins: [
-          pinia,
-          router,
-        ]
-      },
-      props: {
-        title: 'Toast',
-        body: 'body',
-        timestamp: DateTime.now(),
-        timeoutMs: 10000,
-      }
-    });
-    const toast = subject.find('.osim-toast');
-    expect(toast.exists()).toBeTruthy();
-    const toastHeader = toast.find('.toast-header');
-    expect(toastHeader.exists()).toBeTruthy();
-    const toastTitle = toastHeader.find('.me-auto');
-    expect(toastTitle.exists()).toBeTruthy();
-    expect(toastTitle.text()).toBe('Toast');
-    const toastBody = toast.find('.toast-body');
-    expect(toastBody.exists()).toBeTruthy();
-    const progressRingElement = subject.findAllComponents(ProgressRing);
-    expect(progressRingElement.length).toBe(1);
+
+  it.each<{ title: string, body: string, css: ToastProps['css'] }>([
+    { title: 'Success', body: 'Test body', css: 'success' },
+    { title: 'Error', body: 'Test body', css: 'danger' },
+    { title: 'Warn', body: 'Test body', css: 'warning' },
+    { title: 'Default', body: 'Test body', css: undefined },
+  ])('Should render component with title $title, body $body and $css style', ({ title, body, css }) => {
+    const wrapper = mountToast({ title, body, css });
+
+    expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it('trigger close event', async () => {
-    const pinia = createTestingPinia({
-      createSpy: vitest.fn,
-      stubActions: false,
-    });
-    const settingStore = useSettingsStore(pinia);
-    settingStore.$state = {
-      settings: {
-        ...settingStore.$state.settings,
-        showNotifications: true,
-      }
-    };
-    subject = mount(Toast, {
-      global: {
-        plugins: [
-          pinia,
-          router,
-        ]
-      },
-      props: {
-        title: 'Toast',
-        body: 'body',
-        timestamp: DateTime.now(),
-        timeoutMs: 10000,
-        onClose: vitest.fn,
-      }
-    });
-    const toast = subject.find('.osim-toast');
-    expect(toast.exists()).toBeTruthy();
-    const closeButton = toast.find('.btn-close');
-    expect(closeButton.exists()).toBeTruthy();
-    await closeButton.trigger('click');
-    expect(subject.emitted('close')).toBeTruthy();
+  it('Should close toast when close button is clicked', async () => {
+    const wrapper = mountToast();
+
+    await wrapper.find('.btn-close').trigger('click');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
   });
 
-  it('trigger close event after timeoutMs', async () => {
-    const pinia = createTestingPinia({
-      createSpy: vitest.fn,
-      stubActions: false,
-    });
-    const settingStore = useSettingsStore(pinia);
-    settingStore.$state = {
-      settings: {
-        ...settingStore.$state.settings,
-        showNotifications: true,
-      }
-    };
-    subject = mount(Toast, {
-      global: {
-        plugins: [
-          pinia,
-          router,
-        ]
-      },
-      props: {
-        title: 'Toast',
-        body: 'body',
-        timestamp: DateTime.now(),
-        timeoutMs: 1000,
-        onClose: vitest.fn,
-      }
-    });
-    const toast = subject.find('.osim-toast');
-    expect(toast.exists()).toBeTruthy();
-    const closeButton = toast.find('.btn-close');
-    expect(closeButton.exists()).toBeTruthy();
-    vi.advanceTimersByTime(7000);
+  it('Should close toast after timeoutMs', async () => {
+    const wrapper = mountToast({ timeoutMs: 500 });
+
+    vi.advanceTimersByTime(1000);
     await flushPromises();
-    expect(subject.emitted('close')).toBeTruthy();
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+    expect(wrapper.emitted('stale')).toBeFalsy();
   });
 
-  it('trigger stale event after freshMs', async () => {
-    const pinia = createTestingPinia({
-      createSpy: vitest.fn,
-      stubActions: false,
-    });
-    const settingStore = useSettingsStore(pinia);
-    settingStore.$state = {
-      settings: {
-        ...settingStore.$state.settings,
-        showNotifications: true,
-      }
-    };
-    subject = mount(Toast, {
-      global: {
-        plugins: [
-          pinia,
-          router,
-        ]
-      },
-      props: {
-        title: 'Toast',
-        body: 'body',
-        timestamp: DateTime.now(),
-        timeoutMs: 10000,
-        onClose: vitest.fn,
-        onStale: vitest.fn
-      }
-    });
-    const toast = subject.find('.osim-toast');
-    expect(toast.exists()).toBeTruthy();
-    const closeButton = toast.find('.btn-close');
-    expect(closeButton.exists()).toBeTruthy();
+  it('Should emit stale event after freshMs', async () => {
+    const wrapper = mountToast({ timeoutMs: 50000 });
+
     vi.advanceTimersByTime(11000);
     await flushPromises();
-    expect(subject.emitted('stale')).toBeTruthy();
-    vi.advanceTimersByTime(5000);
-    await flushPromises();
-    expect(subject.emitted('close')).toBeTruthy();
+
+    expect(wrapper.emitted('close')).toBeFalsy();
+    expect(wrapper.emitted('stale')).toBeTruthy();
   });
 });
-

--- a/src/components/widgets/__tests__/__snapshots__/Toast.spec.ts.snap
+++ b/src/components/widgets/__tests__/__snapshots__/Toast.spec.ts.snap
@@ -1,0 +1,57 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Toast > Should render component with title 'Default', body 'Test body' and undefined style 1`] = `
+"<div data-v-db9a8853="" class="osim-toast toast show text-bg-light fresh-leave-active" role="alert" aria-labelledby="modalTitle" aria-live="assertive" aria-atomic="true">
+  <!--:style="{display: show? 'block' : 'none'}"-->
+  <div data-v-db9a8853="" class="toast-header"><strong data-v-db9a8853="" class="me-auto">Default</strong><small data-v-db9a8853="" class="text-muted">1 hour ago</small><button data-v-db9a8853="" type="button" class="osim-toast-close-btn btn-close" aria-label="Close">
+      <!--v-if-->
+    </button></div>
+  <div data-v-db9a8853="" class="toast-body osim-toast-body">
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <!--v-if-->
+    <div data-v-db9a8853="">Test body</div>
+  </div>
+</div>"
+`;
+
+exports[`Toast > Should render component with title 'Error', body 'Test body' and 'danger' style 1`] = `
+"<div data-v-db9a8853="" class="osim-toast toast show text-bg-danger fresh-leave-active" role="alert" aria-labelledby="modalTitle" aria-live="assertive" aria-atomic="true">
+  <!--:style="{display: show? 'block' : 'none'}"-->
+  <div data-v-db9a8853="" class="toast-header"><strong data-v-db9a8853="" class="me-auto">Error</strong><small data-v-db9a8853="" class="text-muted">1 hour ago</small><button data-v-db9a8853="" type="button" class="osim-toast-close-btn btn-close" aria-label="Close">
+      <!--v-if-->
+    </button></div>
+  <div data-v-db9a8853="" class="toast-body osim-toast-body">
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <!--v-if-->
+    <div data-v-db9a8853="">Test body</div>
+  </div>
+</div>"
+`;
+
+exports[`Toast > Should render component with title 'Success', body 'Test body' and 'success' style 1`] = `
+"<div data-v-db9a8853="" class="osim-toast toast show text-bg-success fresh-leave-active" role="alert" aria-labelledby="modalTitle" aria-live="assertive" aria-atomic="true">
+  <!--:style="{display: show? 'block' : 'none'}"-->
+  <div data-v-db9a8853="" class="toast-header"><strong data-v-db9a8853="" class="me-auto">Success</strong><small data-v-db9a8853="" class="text-muted">1 hour ago</small><button data-v-db9a8853="" type="button" class="osim-toast-close-btn btn-close" aria-label="Close">
+      <!--v-if-->
+    </button></div>
+  <div data-v-db9a8853="" class="toast-body osim-toast-body">
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <!--v-if-->
+    <div data-v-db9a8853="">Test body</div>
+  </div>
+</div>"
+`;
+
+exports[`Toast > Should render component with title 'Warn', body 'Test body' and 'warning' style 1`] = `
+"<div data-v-db9a8853="" class="osim-toast toast show text-bg-warning fresh-leave-active" role="alert" aria-labelledby="modalTitle" aria-live="assertive" aria-atomic="true">
+  <!--:style="{display: show? 'block' : 'none'}"-->
+  <div data-v-db9a8853="" class="toast-header"><strong data-v-db9a8853="" class="me-auto">Warn</strong><small data-v-db9a8853="" class="text-muted">1 hour ago</small><button data-v-db9a8853="" type="button" class="osim-toast-close-btn btn-close" aria-label="Close">
+      <!--v-if-->
+    </button></div>
+  <div data-v-db9a8853="" class="toast-body osim-toast-body">
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <!--v-if-->
+    <div data-v-db9a8853="">Test body</div>
+  </div>
+</div>"
+`;

--- a/src/stores/ToastStore.ts
+++ b/src/stores/ToastStore.ts
@@ -1,16 +1,15 @@
 import { ref } from 'vue';
 import { defineStore } from 'pinia';
 import { DateTime } from 'luxon';
+import type { ToastProps } from '@/components/widgets/Toast.vue';
 
 
 export interface ToastNew {
   title?: string,
   body: string,
-  // timestamp: moment.Moment,
-  // key?: number,
   bodyHtml?: boolean,
   timeoutMs?: number,
-  css?: 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info' | 'light' | 'dark',
+  css?: ToastProps['css'],
 }
 
 interface ToastAdded extends ToastNew {

--- a/src/utils/typeHelpers.ts
+++ b/src/utils/typeHelpers.ts
@@ -1,3 +1,5 @@
 export type ValueOf<T> = T[keyof T];
 
 export type Nullable<T> = T | null | undefined;
+
+export type NonNullable<T> = T extends null | undefined ? never : T;


### PR DESCRIPTION
# OSIDB-3359: Fix toast colors after CSS purge

## Checklist:

- [x] Commits consolidated
- [ ] ~Changelog updated~
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

The Toast classes were generated dynamically by adding the severity (success, warning, danger...) to `text-bg-`. ie. `text-bg-success`

Dynamic class names are not supported with PurgeCSS because they can't be detected

## Changes:

- Created a mapping with the full class names
- Exported the types from `Toast` component to be reused in `ToastStore`
- Refactor the tests as they were throwing some pinia errors

## Considerations:

[Replace with any additional considerations, notes, or instructions for reviewers.]

Closes OSIDB-3359
