### PR TITLE
OSIDB-3373: Reuse access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OSIM Changelog
 
+## [Unreleased]
+### Changed
+* Improved performance by reusing access token until is expired (`OSIDB-3373`)
+
 ## [2024.8.0]
 ### Added
 * Add button to Bugzilla on public and private comments

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,0 +1,23 @@
+import { createHmac } from 'crypto';
+
+export const encodeJWT = (payload: unknown) => {
+  const encoding = (str: string) =>
+    str.replace(/=/g, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+
+  const segments = [
+    { typ: 'JWT', alg: 'HS256' },
+    payload
+  ].map((segment) => JSON.stringify(segment))
+    .map(btoa)
+    .map(encoding);
+
+  const signature = encoding(
+    createHmac('sha256', 'TEST-SECRET')
+      .update(segments.join('.'))
+      .digest('base64')
+  );
+
+  return segments.concat(signature).join('.');
+};

--- a/src/services/OsidbAuthService.ts
+++ b/src/services/OsidbAuthService.ts
@@ -126,6 +126,9 @@ export async function getNextAccessToken() {
   const url = `${osimRuntime.value.backends.osidb}/auth/token/refresh`;
   const userStore = useUserStore();
   let response;
+  if (userStore.accessToken && !userStore.isAccessTokenExpired) {
+    return userStore.accessToken;
+  }
   try {
     const fetchResponse = await fetch(url, {
       method: 'post',
@@ -148,6 +151,7 @@ export async function getNextAccessToken() {
   try {
     const responseBody = response;
     const parsedBody = RefreshResponse.parse(responseBody);
+    userStore.accessToken = parsedBody.access;
     return parsedBody.access;
   } catch (e) {
     console.error('OsidbAuthService::getNextAccessToken() Error getting access token', e);

--- a/src/services/__tests__/OsidbAuthService.spec.ts
+++ b/src/services/__tests__/OsidbAuthService.spec.ts
@@ -3,31 +3,11 @@ import { setupServer } from 'msw/node';
 import { getNextAccessToken } from '../OsidbAuthService';
 import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
-import { createHmac } from 'crypto';
 import { DateTime } from 'luxon';
 import { useUserStore } from '@/stores/UserStore';
+import { encodeJWT } from '@/__tests__/helpers';
 
-const encodeJWT = (payload: any) => {
-  const encoding = (str: string) =>
-    str.replace(/=/g, '')
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_');
 
-  const segments = [
-    { typ: 'JWT', alg: 'HS256' },
-    payload
-  ].map((segment) => JSON.stringify(segment))
-    .map(btoa)
-    .map(encoding);
-
-  const signature = encoding(
-    createHmac('sha256', 'TEST-SECRET')
-      .update(segments.join('.'))
-      .digest('base64')
-  );
-
-  return segments.concat(signature).join('.');
-};
 
 describe('OsidbAuthService', () => {
   const accessJWT = encodeJWT({

--- a/src/stores/UserStore.ts
+++ b/src/stores/UserStore.ts
@@ -73,19 +73,13 @@ export const useUserStore = defineStore('UserStore', () => {
 
   const accessToken = ref<string>();
   const isAccessTokenExpired = computed<boolean>(() => {
-    if (accessToken.value == null) {
+    try {
+      const exp = accessToken.value ? jwtDecode<JwtPayload>(accessToken.value)?.exp : null;
+      return !exp || DateTime.now().toSeconds() >= exp - 60;
+    } catch (e) {
+      console.debug('UserStore: access token not a valid JWT', accessToken.value, e);
       return true;
     }
-    const exp = jwtDecode<JwtPayload>(accessToken.value)?.exp;
-    if (!exp) {
-      return true;
-    }
-
-    // get timestamp in seconds minus 1 minute to account for clock drift
-    const now = Math.floor(DateTime.now().minus({ minutes: 1 }).toSeconds());
-    const expiration = Math.floor(DateTime.fromSeconds(exp).toSeconds());
-
-    return now >= expiration;
   });
 
   const whoami = computed<WhoamiType | null>(() => {

--- a/src/stores/__tests__/UserStore.spec.ts
+++ b/src/stores/__tests__/UserStore.spec.ts
@@ -2,13 +2,22 @@ import { describe, it, expect } from 'vitest';
 import { useUserStore } from '../UserStore';
 import { createPinia, setActivePinia } from 'pinia';
 import { getJiraUsername } from '@/services/JiraService';
+import { encodeJWT } from '@/__tests__/helpers';
+import { DateTime } from 'luxon';
 
 describe('UserStore', () => {
   let userStore: ReturnType<typeof useUserStore>;
 
   beforeEach(() => {
     setActivePinia(createPinia());
+    vi.useFakeTimers({
+      now: new Date('2024-01-01T00:00:00Z'),
+    });
+
     userStore = useUserStore();
+  });
+
+  afterEach(() => {
     vi.clearAllMocks();
   });
 
@@ -18,7 +27,8 @@ describe('UserStore', () => {
     expect(userStore.whoami === null).toBe(true);
     expect(userStore.jiraUsername === '').toBe(true);
   });
-  it('fetches Jira username from Jira API when missing in store', async() => {
+
+  it('fetches Jira username from Jira API when missing in store', async () => {
     vi.mock('@/services/JiraService', () => ({
       getJiraUsername: vi.fn(() => {
         return new Promise<string>((resolve) => {
@@ -31,13 +41,50 @@ describe('UserStore', () => {
     expect(getJiraUsername).toHaveBeenCalledTimes(0);
     await userStore.updateJiraUsername();
     expect(getJiraUsername).toHaveBeenCalledTimes(1);
-    console.log(userStore.jiraUsername);
     expect(userStore.jiraUsername === 'skynet').toBe(true);
   });
-  it('gets Jira username from userstore preferably', async() => {
+
+  it('gets Jira username from userstore preferably', async () => {
     expect(getJiraUsername).toHaveBeenCalledTimes(0);
     await userStore.updateJiraUsername();
     expect(getJiraUsername).toHaveBeenCalledTimes(0);
     expect(userStore.jiraUsername === 'skynet').toBe(true);
+  });
+
+  it('should set `isAccessTokenExpired` to true when access token is undefined', () => {
+    userStore.accessToken = undefined;
+    expect(userStore.isAccessTokenExpired).toBe(true);
+  });
+
+  it('should set `isAccessTokenExpired` to true when access token is about to expire', () => {
+    userStore.accessToken = encodeJWT({
+      'token_type': 'access',
+      'exp': Math.floor(DateTime.now().minus({ minutes: 1 }).toSeconds()),
+      'iat': Math.floor(DateTime.now().toSeconds()),
+      'jti': '0000',
+      'user_id': 1337
+    });
+
+    expect(userStore.isAccessTokenExpired).toBe(true);
+  });
+
+  it('should set `isAccessTokenExpired` to false when access token is active', () => {
+    userStore.accessToken = encodeJWT({
+      'token_type': 'access',
+      'exp': Math.floor(DateTime.now().plus({ minutes: 5 }).toSeconds()),
+      'iat': Math.floor(DateTime.now().toSeconds()),
+      'jti': '0000',
+      'user_id': 1337
+    });
+
+    expect(userStore.isAccessTokenExpired).toBe(false);
+  });
+
+  it('should not throw when access token is invalid', () => {
+    expect(() => {
+      userStore.accessToken = 'invalid';
+
+      expect(userStore.isAccessTokenExpired).toBe(true);
+    }).not.toThrow();
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig(configEnv =>
         exclude: [...configDefaults.exclude, 'e2e/*'],
         root: fileURLToPath(new URL('./', import.meta.url)),
         globals: true,
+        onConsoleLog: (_, type) => type === 'stderr',
         globalSetup: [
           // './src/__tests__/global-setup.ts',
         ],


### PR DESCRIPTION
# OSIDB-3373: Reuse access token

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Save access token in memory and use it until it is about to expire.
I added a 1 minute difference to account for clock shift, slow network or other possible problems

## Changes:

* Modified `UserStore` to save the `accessToken`
* Modified `getNextAccessToken` to check the store

## Considerations:

Closes OSIDB-3373
