### PR TITLE
OSIDB-3373: Fetch flaws in the background to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@
 * Re-design of affects view (`OSIDB-2818`)
 * Re-design of trackers view (`OSIDB-2818`)
 * Modified layout of trackers manager (`OSIDB-2818`)
+* Fetch flaws on the background to improve performance (`OSIDB-3373`)
 
 ### Fixed
 * Correct `affected module` information source on trackers display (`OSIDB-2818`)
 
 ### Removed
 * Removed `type` information for trackers display (`OSIDB-2818`)
+
 
 ## [2024.8.0]
 ### Added

--- a/src/App.vue
+++ b/src/App.vue
@@ -54,7 +54,11 @@ onBeforeUnmount(() => {
     </header>
     <div class="osim-content-layered">
       <ToastContainer />
-      <RouterView class="osim-page-view" />
+      <RouterView v-slot="{ Component }" class="osim-page-view">
+        <KeepAlive include="IndexView">
+          <component :is="Component" />
+        </KeepAlive>
+      </RouterView>
     </div>
     <footer ref="elFooter" class="fixed-bottom osim-status-bar">
       <!--TODO add active request count-->

--- a/src/components/__tests__/__snapshots__/App.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/App.spec.ts.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`App > Renders the App component when OSIDB is NOT READY 1`] = `"<div class="osim-backend-error">OSIDB is not ready</div>"`;
+
+exports[`App > Renders the App component when OSIDB is READY 1`] = `
+"<header>
+  <navbar-stub></navbar-stub>
+</header>
+<div class="osim-content-layered">
+  <toast-container-stub></toast-container-stub>
+  <router-view-stub name="default" class="osim-page-view"></router-view-stub>
+</div>
+<footer class="fixed-bottom osim-status-bar">
+  <!--TODO add active request count-->
+  <!--<div>[ Requests: {{ activeRequestCount }} ]</div>-->
+  <change-log-stub></change-log-stub>
+  <div> [ OSIM | env: dev | <span title="1"> tag: 1.0.0</span> | ts : () ] </div>
+  <div> [ OSIDB | env: | <span title="">ver: </span> ] </div>
+  <div class="osim-status-osidb-err"> [err: OSIDB is not ready] </div>
+</footer>"
+`;

--- a/src/views/IndexView.vue
+++ b/src/views/IndexView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch, type Ref } from 'vue';
+import { computed, onDeactivated, ref, watch, type Ref } from 'vue';
 import IssueQueue from '../components/IssueQueue.vue';
 import { useFlawsFetching } from '../composables/useFlawsFetching';
 import { useSearchStore } from '@/stores/SearchStore';
@@ -41,6 +41,9 @@ function setTableFilters(newFilters: Ref<Record<string, string>>) {
   };
 }
 
+onDeactivated(() => {
+  loadFlaws(params);
+});
 </script>
 
 <template>


### PR DESCRIPTION
# OSIDB-3373: Fetch flaws in the background to improve performance

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Instead of fetching the flaws each time we mount the IndexView, we fetch them when the component is unmounted so the data is there the next time the user loads the view, leaving the caching of the state to the `KeepAlive` vue component

## Changes:

* Added `KeepAlive` component to the `RouterView` to "cache" `IndexView` component
* Used `onDeactivated` lifecycle hook on `IndexView` component to fetch flaws on unmount
* Refactor the `App` tests as they were fetching OSIDB and also throwing some warnings on the console

## Considerations:

Closes OSIDB-3372
