### PR TITLE
OSIDB-2335: Content Security Policy changes

### DIFF
--- a/build/entrypoint.d/50-nginx-csp.sh
+++ b/build/entrypoint.d/50-nginx-csp.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Nginx does not support loading environment variables in the configuration files.
+# So we need to generate the configuration files with the environment variables.
+cat <<EOF >/tmp/osim-nginx-csp.conf
+add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; upgrade-insecure-requests; frame-ancestors 'none'; connect-src 'self' $OSIM_BACKENDS_OSIDB $OSIM_BACKENDS_JIRA; style-src 'self' 'unsafe-inline';";
+EOF

--- a/build/nginx-default.d-osim.conf
+++ b/build/nginx-default.d-osim.conf
@@ -3,7 +3,8 @@ listen 8080;
 index index.html;
 
 # Prevent the app from sending unexpected requests
-add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; upgrade-insecure-requests; frame-ancestors 'none'";
+include /tmp/osim-nginx-csp.conf;
+
 # Force HTTPS; 3 week max-age
 add_header Strict-Transport-Security: "max-age=1814400; includeSubDomains";
 


### PR DESCRIPTION
# OSIDB-2335: Content Security Policy changes

## Checklist:

- [x] Commits consolidated
- [ ] ~Changelog updated~
- [ ] ~Test cases added/updated~
- [x] Jira ticket updated

## Summary:

Configure CSP with the dynamic values of the OSIDB backend to remove errors

## Changes:

Moved the `add_header` rule to its own file to inject environment variables in the `Content-Security-Policy`.
I also added 'self' to remove the error when loading the `runtime.json` and `style-src 'self' 'unsafe-inline';` to allow inline styles

Closes OSIDB-2335
