### PR TITLE
Allow using default ordering in flaw list page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # OSIM Changelog
 
 ## [Unreleased]
+### Added
+* Allow using default ordering in flaw list page (`OSIDB-3187`)
+
 ### Changed
 * Improved performance by reusing access token until is expired (`OSIDB-3373`)
 

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -32,7 +32,7 @@ const props = defineProps<{
 const isDefaultFilterSelected = defineModel<boolean>('isDefaultFilterSelected', { default: true });
 
 const issues = computed<any[]>(() => props.issues.map(relevantFields));
-const selectedSortField = ref<ColumnField>('created_dt');
+const selectedSortField = ref<ColumnField | null>('created_dt');
 const isSortedByAscending = ref(false);
 const isMyIssuesSelected = ref(false);
 const isOpenIssuesSelected = ref(false);
@@ -63,12 +63,15 @@ const params = computed(() => {
     paramsObj.workflow_state = filteredStates.value;
   }
 
-  const sortOrderPrefix = isSortedByAscending.value ? '' : '-';
-  paramsObj.order = {
-    [selectedSortField.value]: `${sortOrderPrefix}${selectedSortField.value}`,
-    id: `${sortOrderPrefix}cve_id,${sortOrderPrefix}uuid`,
-    state: `${sortOrderPrefix}workflow_state`,
-  }[selectedSortField.value];
+  if (selectedSortField.value) {
+    const sortOrderPrefix = isSortedByAscending.value ? '' : '-';
+    paramsObj.order = {
+      [selectedSortField.value]: `${sortOrderPrefix}${selectedSortField.value}`,
+      id: `${sortOrderPrefix}cve_id,${sortOrderPrefix}uuid`,
+      state: `${sortOrderPrefix}workflow_state`,
+    }[selectedSortField.value];
+  }
+
   return paramsObj;
 });
 
@@ -88,9 +91,18 @@ const relevantIssues = computed<FilteredIssue[]>(() => {
 });
 
 function selectSortField(field: ColumnField) {
-  isSortedByAscending.value =
-    selectedSortField.value === field ? !isSortedByAscending.value : false;
-  selectedSortField.value = field;
+  // Toggle between descending, ascending and no ordering
+  // If selecting a new field, set to descending
+  if (selectedSortField.value === field) {
+    if (!isSortedByAscending.value) {
+      isSortedByAscending.value = true;
+    } else {
+      selectedSortField.value = null;
+    }
+  } else {
+    isSortedByAscending.value = false;
+    selectedSortField.value = field;
+  }
 }
 
 function relevantFields(issue: any) {

--- a/src/components/__tests__/IssueQueue.spec.ts
+++ b/src/components/__tests__/IssueQueue.spec.ts
@@ -185,6 +185,9 @@ describe('IssueQueue', () => {
     expect(fetchEvents[1][0]._value).toEqual({
       order: 'cve_id,uuid',
     });
+    // remove order
+    await idColumn.trigger('click');
+    expect(fetchEvents[1][0]._value).toEqual({});
     const impactColumn = wrapper.findAll('th').at(1);
     await impactColumn.trigger('click');
     expect(fetchEvents[1][0]._value).toEqual({


### PR DESCRIPTION


# OSIDB-3187: Sort results for exact matches at the top

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

The flaw list page allows the user to order the results in descending or ascending order by any of the fields in the header column. By default, it orders the results by created date in descending order (newest flaws first).

This commit adds the option to use the default ordering by OSIDB, by toggling between descending, ascending, and no order when clicking on a field in the header row. This is useful when using the search as OSIDB will return the results ordered based on relevancy. For example, when searching for a CVE, we may want to see the closest matches first, instead of the most recent flaws.

## Changes:

When clicking on a header field, instead of just toggling between descending and ascending order on that field, clicking it a third time will remove the ordering.

Closes OSIDB-3187.