### PR TITLE
✨ Add query mode to advance search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Provide Bug ID information for trackers display (`OSIDB-2818`)
 * In the event of saving multiple trackers with some failing, the affect 
 trackers will be refreshed (`OSIDB-3402`)
+* Add query filter support on advance search (`OSIDB-3088`)
 
 ### Changed
 * Improved performance by reusing access token until is expired (`OSIDB-3373`)
@@ -26,7 +27,6 @@ trackers will be refreshed (`OSIDB-3402`)
 
 ### Removed
 * Removed `type` information for trackers display (`OSIDB-2818`)
-
 
 ## [2024.8.0]
 ### Added

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -2,12 +2,16 @@
 import { computed, ref, watch } from 'vue';
 import { flawImpacts, flawSources, flawIncidentStates } from '@/types/zodFlaw';
 import LabelCheckbox from '@/components/widgets/LabelCheckbox.vue';
+import Modal from '@/components/widgets/Modal.vue';
+import QueryFilterGuide from '@/components/QueryFilterGuide.vue';
+import { useModal } from '@/composables/useModal';
 import { flawFields } from '@/constants/flawFields';
 import { useSearchParams } from '@/composables/useSearchParams';
 import { descriptionRequiredStates } from '@/types/zodFlaw';
 import { affectAffectedness } from '@/types/zodAffect';
 import { sort } from 'ramda';
 const { facets, query, removeFacet, submitAdvancedSearch } = useSearchParams();
+const { isModalOpen, openModal, closeModal } = useModal();
 
 const props = defineProps<{
   isLoading: boolean;
@@ -113,7 +117,7 @@ watch(queryFilterVisible, () => {
       <div v-if="queryFilterVisible" class="input-group my-1">
         <div type="button" class="form-control bg-secondary text-white pe-none py-0 d-flex" style="max-width: 13.125%;">
           <span class="my-auto">Query Filter</span>
-          <button class="btn btn-sm p-0 ms-auto my-auto text-white pe-auto border-0" type="button">
+          <button class="btn btn-sm p-0 ms-auto my-auto text-white pe-auto border-0" type="button" @click="openModal()">
             <i class="bi bi-question-circle-fill fs-5" aria-label="hide query filter" />
           </button>
         </div>
@@ -188,6 +192,29 @@ watch(queryFilterVisible, () => {
       </div>
     </form>
   </details>
+  <Modal :show="isModalOpen" style="max-width: 75%;" @close="closeModal()">
+    <template #header>
+      <h1>Query Filter Guide</h1>
+      <button
+        type="button"
+        class="btn-close ms-auto"
+        aria-label="Close"
+        @click="closeModal()"
+      />
+    </template>
+    <template #body>
+      <QueryFilterGuide />
+    </template>
+    <template #footer>
+      <button
+        type="button"
+        class="btn btn-secondary m-0"
+        @click="closeModal()"
+      >
+        Close
+      </button>
+    </template>
+  </Modal>
 </template>
 
 <style lang="scss" scoped>

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -7,7 +7,7 @@ import { useSearchParams } from '@/composables/useSearchParams';
 import { descriptionRequiredStates } from '@/types/zodFlaw';
 import { affectAffectedness } from '@/types/zodAffect';
 import { sort } from 'ramda';
-const { facets, removeFacet, submitAdvancedSearch } = useSearchParams();
+const { facets, query, removeFacet, submitAdvancedSearch } = useSearchParams();
 
 const props = defineProps<{
   isLoading: boolean;
@@ -18,6 +18,8 @@ const emit = defineEmits(['filter:save']);
 const isNonEmptyDescriptionSelected = ref(false);
 
 const descriptionParamValue = computed(() => facets.value.find(facet => facet.field === 'cve_description')?.value);
+
+const queryFilterVisible = ref(true);
 
 watch(isNonEmptyDescriptionSelected, () => {
   const facet = facets.value.find(facet => facet.field === 'cve_description');
@@ -77,7 +79,6 @@ const chosenFields = computed(() => facets.value.map(({ field }) => field));
 const unchosenFields = (chosenField: string) =>
   sortFieldNames(flawFields.filter((field) => !chosenFields.value.includes(field) || field === chosenField));
 
-
 const optionsFor = (field: string) =>
   ({
     source: flawSources,
@@ -95,14 +96,37 @@ const optionsFor = (field: string) =>
     major_incident_state: flawIncidentStates,
     affects__affectedness: affectAffectedness,
   })[field] || null;
+
 const shouldShowAdvanced = ref(true);
+
+watch(queryFilterVisible, () => {
+  if (!queryFilterVisible.value) {
+    query.value = '';
+  }
+});
 </script>
 
 <template>
-  <details :open="shouldShowAdvanced" class="osim-advanced-search-container">
-    <summary class="mb-2" @click="shouldShowAdvanced = true">Advanced Search</summary>
+  <details :open="shouldShowAdvanced" class="osim-advanced-search-container container-fluid">
+    <summary class="mb-1" @click="shouldShowAdvanced = true">Advanced Search</summary>
     <form class="mb-2" @submit.prevent="submitAdvancedSearch">
-      <div v-for="(facet, index) in facets" :key="facet.field" class="input-group mb-2">
+      <div v-if="queryFilterVisible" class="input-group my-1">
+        <div type="button" class="form-control bg-secondary text-white pe-none py-0 d-flex" style="max-width: 13.125%;">
+          <span class="my-auto">Query Filter</span>
+          <button class="btn btn-sm p-0 ms-auto my-auto text-white pe-auto border-0" type="button">
+            <i class="bi bi-question-circle-fill fs-5" aria-label="hide query filter" />
+          </button>
+        </div>
+        <input
+          v-model="query"
+          type="text"
+          class="form-control"
+        />
+        <button class="btn btn-secondary py-0" type="button" @click="() => queryFilterVisible = false">
+          <i class="bi bi-x fs-5" aria-label="hide query filter" />
+        </button>
+      </div>
+      <div v-for="(facet, index) in facets" :key="facet.field" class="input-group my-1">
         <select v-model="facet.field" class="form-select search-facet-field" @submit.prevent>
           <option
             v-if="!facet.field"
@@ -131,33 +155,45 @@ const shouldShowAdvanced = ref(true);
           class="form-control"
           :disabled="!facet.field"
         />
-        <button class="btn btn-outline-primary" type="button" @click="removeFacet(index)">
-          <i class="bi-x" aria-label="remove field"></i>
+        <button class="btn btn-primary py-0" type="button" @click="removeFacet(index)">
+          <i class="bi-x fs-5" aria-label="remove field"></i>
         </button>
       </div>
-      <button class="btn btn-primary me-3" type="submit" :disabled="props.isLoading">
-        <div v-if="props.isLoading" class="spinner-border spinner-border-sm"></div>
-        Search
-      </button>
-      <button
-        class="btn btn-primary me-3"
-        type="button"
-        :disabled="isLoading"
-        @click="emit('filter:save')"
-      >
-        Save as Default
-      </button>
-      <LabelCheckbox
-        v-model="isNonEmptyDescriptionSelected"
-        label="Non Empty CVE Description"
-        class="d-inline-block"
-      />
+      <div class="mt-2">
+        <button class="btn btn-primary me-2" type="submit" :disabled="props.isLoading">
+          <div v-if="props.isLoading" class="spinner-border spinner-border-sm"></div>
+          Search
+        </button>
+        <button
+          class="btn btn-primary me-2"
+          type="button"
+          :disabled="isLoading"
+          @click="emit('filter:save')"
+        >
+          Save as Default
+        </button>
+        <button
+          v-if="!queryFilterVisible"
+          class="btn btn-secondary"
+          type="button"
+          @click="() => queryFilterVisible = true"
+        >
+          Show Query Filter
+        </button>
+        <LabelCheckbox
+          v-model="isNonEmptyDescriptionSelected"
+          label="Non Empty CVE Description"
+          class="d-inline-block"
+        />
+      </div>
     </form>
   </details>
 </template>
 
 <style lang="scss" scoped>
 .osim-advanced-search-container {
+  width: 97.5%;
+
   i {
     cursor: pointer;
   }

--- a/src/components/QueryFilterGuide.vue
+++ b/src/components/QueryFilterGuide.vue
@@ -70,9 +70,6 @@
           feature that pops up automatically and suggests all available options.
           If you're not sure what the field name is, then pick one of the options displayed.
         </p>
-        <p>
-          <strong>TODO: OSIDB Fields Table?</strong>
-        </p>
       </div>
       <div class="module">
         <h2 id="related-models">Related models</h2>

--- a/src/components/QueryFilterGuide.vue
+++ b/src/components/QueryFilterGuide.vue
@@ -1,0 +1,352 @@
+<script setup lang="ts">
+
+</script>
+
+<template>
+  <div class="p-2">
+    <div id="content-main">
+      <div class="module">
+        <h2 id="search-conditions">Search conditions</h2>
+        <p>
+          A search condition is a basic search query building block. It always
+          consists of 3 elements: <code>field</code>,
+          <code>comparison operator</code> and <code>value</code>, placed exactly
+          in this order from left to right.
+        </p>
+        <p>
+          <strong>Example 1</strong>
+          - looking for flaws with customer source, where <code>source</code> is a <code>field</code>,
+          <code>=</code> is a <code>comparison operator</code> and <code>"CUSTOMER"</code> is a <code>value</code>:
+        </p>
+        <pre>source = "CUSTOMER"</pre>
+        <p>
+          <strong>Example 2</strong> - looking for flaws created in 2017 or later:
+        </p>
+        <pre>created_dt >= "2017-01-01"</pre>
+        <p><strong>Example 3</strong> - looking for a flaw title pattern matching:</p>
+        <pre>title startswith "RHEL"</pre>
+        <p><strong>Example 4</strong> - finding all flaws whose impacts are in a given list:</p>
+        <pre>impact in ("LOW", "MODERATE")</pre>
+      </div>
+      <div class="module">
+        <h2 id="multiple-search-conditions">Multiple search conditions</h2>
+        <p>
+          You can combine multiple search conditions together using the logical
+          operators <code>and</code> (both conditions must be true) and
+          <code>or</code> (at least one of the conditions must be true, no matter
+          which one).
+        </p>
+        <p class="warn"><strong>Important:</strong> logical operators must be written in lowercase:
+          <code>and</code> and <code>or</code> is correct, and <code>AND</code> or
+          <code>OR</code> is incorrect and will cause an error.
+        </p>
+        <p>
+          <strong>Example 5</strong> - looking for flaws with owner "John@example.com" <code>and</code>
+          updated in 2017 or later. Please note that we have 2 search
+          conditions here, joined with <code>and</code>:
+        </p>
+        <pre>owner = "John@example.com" and updated_dt >= "2017-01-01"</pre>
+        <p>
+          <strong>Example 6</strong> - looking for flaws which have 'RHEL' either in the title
+          <code>or</code> the description:
+        </p>
+        <pre>title ~ "RHEL" or cve_description ~ "RHEL"</pre>
+        <p class="info">
+          <strong>Tip:</strong> if your query contains both
+          <code>and</code> and <code>or</code> operators, we strongly encourage
+          to use parenthesis to specify the precedence of operators.
+        </p>
+        <p>
+          <strong>Example 7</strong> - get flaws which are either in triage state <code>or</code> with nvd source,
+          <code>and</code> created in 2017 or later.
+        </p>
+        <pre>(classification.state = "TRIAGE" or source = "NVD") and created_dt > "2017-01-01"</pre>
+      </div>
+      <div class="module">
+        <h2 id="fields">OSIDB Fields</h2>
+        <p>
+          In a search query, you should reference the osidb model's fields
+          exactly as they're defined. Search query input has an auto-completion
+          feature that pops up automatically and suggests all available options.
+          If you're not sure what the field name is, then pick one of the options displayed.
+        </p>
+        <p>
+          <strong>TODO: OSIDB Fields Table?</strong>
+        </p>
+      </div>
+      <div class="module">
+        <h2 id="related-models">Related models</h2>
+        <p>
+          Query filter automatically handles model relations under the hood. Use the
+          <code>.</code> dot separator to designate related models and their
+          fields.
+        </p>
+        <p><strong>Example 8</strong>:</p>
+        <pre>classification.state in ("NEW", "TRIAGE")</pre>
+        <p>
+          When you'd like to find records that are linked (or not linked)
+          to any related models of that kind. In such a case, you should compare
+          the related model to a special <code>None</code> value, like this:
+        </p>
+        <p><strong>Example 9</strong>:</p>
+        <pre>affects = None</pre>
+        <p>
+          The example above would search for flaws that don't have any affect.
+          If you'd like to find all flaws that contains at least one affect instead, use <code>!= None</code>:
+        </p>
+        <pre>affects != None</pre>
+      </div>
+      <div class="module">
+        <h2 id="comparison-operators">Comparison operators</h2>
+        <table class="w-100">
+          <thead>
+            <tr>
+              <th>Operator</th>
+              <th>Meaning</th>
+              <th>Example</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>=</td>
+              <td>equals</td>
+              <td>first_name = "John"</td>
+            </tr>
+            <tr>
+              <td>!=</td>
+              <td>does not equal</td>
+              <td>id != 42</td>
+            </tr>
+            <tr>
+              <td>~</td>
+              <td>contains a substring</td>
+              <td>email ~ "@gmail.com"</td>
+            </tr>
+            <tr>
+              <td>!~</td>
+              <td>does not contain a substring</td>
+              <td>username !~ "test"</td>
+            </tr>
+            <tr>
+              <td>startswith</td>
+              <td>starts with a substring</td>
+              <td>last_name startswith "do"</td>
+            </tr>
+            <tr>
+              <td>not startswith</td>
+              <td>does not start with a substring</td>
+              <td>last_name not startswith "do"</td>
+            </tr>
+            <tr>
+              <td>endswith</td>
+              <td>ends with a substring</td>
+              <td>last_name endswith "oe"</td>
+            </tr>
+            <tr>
+              <td>not endswith</td>
+              <td>does not end with a substring</td>
+              <td>last_name not endswith "oe"</td>
+            </tr>
+            <tr>
+              <td>&gt;</td>
+              <td>greater</td>
+              <td>date_joined > "2017-02-28"</td>
+            </tr>
+            <tr>
+              <td>&gt;=</td>
+              <td>greater or equal</td>
+              <td>id >= 9000</td>
+            </tr>
+            <tr>
+              <td>&lt;</td>
+              <td>less</td>
+              <td>id &lt; 9000</td>
+            </tr>
+            <tr>
+              <td>&lt;=</td>
+              <td>less or equal</td>
+              <td>last_login &lt;= "2017-02-28 14:53" </td>
+            </tr>
+            <tr>
+              <td>in</td>
+              <td>value is in the list</td>
+              <td>first_name in ("John", "Jack", "Jason")</td>
+            </tr>
+            <tr>
+              <td>not in</td>
+              <td>value is not in the list</td>
+              <td>id not in (42, 9000)</td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="info">Notes:
+          <ol>
+            <li>
+              <code>~</code> and <code>!~</code> operators can be applied only to
+              string and date/datetime fields. A date/datetime field will be handled
+              as a string one (ex., <code>payment_date ~ "2020-12-01"</code>)
+            </li>
+            <li>
+              <code>startswith</code>, <code>not startswith</code>,
+              <code>endswith</code>, and <code>not endswith</code> can be applied
+              to string fields only;
+            </li>
+            <li>
+              <code>True</code>, <code>False</code> and <code>None</code> values can
+              be combined only with <code>=</code> and <code>!=</code>;
+            </li>
+            <li>
+              <code>in</code> and <code>not in</code> operators must be written in
+              lowercase. <code>IN</code> or <code>NOT IN</code> is incorrect and
+              will cause an error.
+            </li>
+          </ol>
+        </p>
+      </div>
+      <div class="module">
+        <h2 id="values">Values</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>Examples</th>
+              <th>Comments</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>string</td>
+              <td nowrap><code>"this is a string"</code></td>
+              <td>
+                Strings must be enclosed in double quotes, like
+                <code>"this"</code>. If your string contains double quote
+                symbols in it, you should escape them with a backslash,
+                like this: <code>"this is a string with \"quoted\" text"</code>.
+              </td>
+            </tr>
+            <tr>
+              <td>int</td>
+              <td nowrap><code>42</code>, <code>0</code>, <code>-9000</code></td>
+              <td>
+                Integer numbers are just digits with optional unary minus. If
+                you're typing big numbers please don't use thousand separators,
+                DjangoQL doesn't understand them.
+              </td>
+            </tr>
+            <tr>
+              <td>float</td>
+              <td nowrap>
+                <code>3.14</code>, <code>-0.5</code>, <code>5.972e24</code>
+              </td>
+              <td>
+                Floating point numbers look like integer numbers with optional
+                fractional part separated with dot. You can also use
+                <code>e</code> notation to specify power of ten. For example,
+                <code>5.972e24</code> means <code>5.972 * 10<sup>24</sup></code>.
+              </td>
+            </tr>
+            <tr>
+              <td>bool</td>
+              <td nowrap>
+                <code>True</code>, <code>False</code>
+              </td>
+              <td>
+                Boolean is a special type that accepts only two values:
+                <code>True</code> or <code>False</code>. These values are
+                case-sensitive, you should write <code>True</code> or
+                <code>False</code> exactly like this, with the first letter in
+                uppercase and others in lowercase, without quotes.
+              </td>
+            </tr>
+            <tr>
+              <td>date</td>
+              <td nowrap>
+                <code>"2017-02-28"</code>
+              </td>
+              <td>
+                Dates are represented as strings in <code>"YYYY-MM-DD"</code>
+                format.
+              </td>
+            </tr>
+            <tr>
+              <td>datetime</td>
+              <td nowrap>
+                <code>"2017-02-28 14:53"</code><br>
+                <code>"2017-02-28 14:53:07"</code>
+              </td>
+              <td>
+                Date and time can be represented as a string in
+                <code>"YYYY-MM-DD HH:MM"</code> format, or optionally with seconds
+                in <code>"YYYY-MM-DD HH:MM:SS"</code> format (24-hour clock).
+                Please note that comparisons with date and time are performed in
+                the server's timezone, which is usually UTC.
+              </td>
+            </tr>
+            <tr>
+              <td>null</td>
+              <td nowrap>
+                <code>None</code>
+              </td>
+              <td>
+                This is a special value that represents an absence of any value:
+                <code>None</code>. It should be written exactly like this, with
+                the first letter in uppercase and others in lowercase, without
+                quotes. Use it when some field in the database is
+                nullable (i.e. can contain NULL in SQL terms) and you'd like to
+                search for records which either have no value
+                (<code>some_field = None</code>) or have some value
+                (<code>some_field != None</code>).
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@import '@/scss/bootstrap-overrides';
+
+h1, h2, h3, h4, h5 {
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+}
+
+p {
+    margin-block: 0.75rem;
+    margin-bottom: 0.25rem !important;
+}
+
+pre {
+    background-color: $redhat-gray-30;
+    padding: 1ch;
+    margin-bottom: 0.25rem !important;
+    border-radius: 0.25rem;
+}
+
+code {
+    font-size: 1.5ch;
+}
+
+p.info, p.warn {
+    border: 0.1rem solid $redhat-teal-30;
+    border-radius: 0.25rem;
+    padding: 0.75ch;
+}
+
+p.info {
+    background-color: $redhat-teal-10;
+    border: 0.1rem solid $redhat-teal-30;
+}
+
+p.warn {
+    background-color: $redhat-yellow-10;
+    border: 0.1rem solid $redhat-yellow-30;
+}
+
+
+#search-conditions {
+    margin-top: 0 !important;
+}
+</style>

--- a/src/components/__tests__/FlawSearchView.spec.ts
+++ b/src/components/__tests__/FlawSearchView.spec.ts
@@ -116,7 +116,7 @@ describe('FlawSearchView', () => {
     expect(useFlawsFetching().loadFlaws).toHaveBeenCalledOnce();
     expect(useFlawsFetching().loadFlaws.mock.calls[0][0]._value).toStrictEqual({
       'order': '-created_dt',
-      'search': 'search',
+      'query': 'search',
     });
   });
 
@@ -134,7 +134,7 @@ describe('FlawSearchView', () => {
     await flushPromises();
     expect(useRouter().replace).toHaveBeenCalled();
     expect(useRouter().replace.mock.calls[0][0])
-      .toStrictEqual({ query: { query: 'search', acknowledgments__name: 'test' } });
+      .toStrictEqual({ query: { query: 'test', search: 'search' } });
   });
 
   it('should call saveFilter on save filter button click', async () => {
@@ -157,7 +157,7 @@ describe('FlawSearchView', () => {
     });
     const searchStore = useSearchStore();
     const toastStore = useToastStore();
-    const saveButton = wrapper.find('button[type="button"].btn-primary.me-3');
+    const saveButton = wrapper.find('button[type="button"].btn-primary.me-2');
     expect(saveButton.exists()).toBeTruthy();
     expect(saveButton.text()).toBe('Save as Default');
     await saveButton.trigger('click');
@@ -178,7 +178,7 @@ describe('FlawSearchView', () => {
     expect(useFlawsFetching().loadFlaws).toHaveBeenCalledOnce();
     expect(useFlawsFetching().loadFlaws.mock.calls[0][0]._value).toStrictEqual({ 'affects__ps_component': 'test',
       'order': '-created_dt',
-      'search': 'search',
+      'query': 'search',
     });
   });
 
@@ -199,7 +199,7 @@ describe('FlawSearchView', () => {
     await flushPromises();
     expect(useRouter().replace).toHaveBeenCalled();
     expect(useRouter().replace.mock.calls[0][0])
-      .toStrictEqual({ query: { query: 'search', requires_cve_description: 'REQUESTED' } });
+      .toStrictEqual({ query: { query: 'test', requires_cve_description: 'REQUESTED', search: 'search' } });
   });
 
   it('should call loadFlaws with major_incident_state on search', async () => {
@@ -219,7 +219,7 @@ describe('FlawSearchView', () => {
     await flushPromises();
     expect(useRouter().replace).toHaveBeenCalled();
     expect(useRouter().replace.mock.calls[0][0])
-      .toStrictEqual({ query: { query: 'search', major_incident_state: 'REQUESTED' } });
+      .toStrictEqual({ query: { query: 'test', major_incident_state: 'REQUESTED', search: 'search' } });
   });
 
   it('should call loadFlaws with affectedness on search', async () => {
@@ -239,6 +239,6 @@ describe('FlawSearchView', () => {
     await flushPromises();
     expect(useRouter().replace).toHaveBeenCalled();
     expect(useRouter().replace.mock.calls[0][0])
-      .toStrictEqual({ query: { query: 'search', affects__affectedness: 'NEW' } });
+      .toStrictEqual({ query: { query: 'test', affects__affectedness: 'NEW', search: 'search' } });
   });
 });

--- a/src/components/__tests__/IssueSearchAdvanced.spec.ts
+++ b/src/components/__tests__/IssueSearchAdvanced.spec.ts
@@ -56,7 +56,7 @@ describe('IssueSearchAdvanced', () => {
     await flushPromises();
     expect(useRouter().replace).toHaveBeenCalled();
     expect(useRouter().replace.mock.calls[0][0])
-      .toStrictEqual({ query: { query: 'search', acknowledgments__name: 'test' } });
+      .toStrictEqual({ query: { query: 'test' } });
   });
 
   it('shouldn\'t render duplicate options on dropdown', () => {
@@ -71,7 +71,7 @@ describe('IssueSearchAdvanced', () => {
   it('should render save filter button', async () => {
     let filterSaveEvents = wrapper.emitted('filter:save');
     expect(filterSaveEvents).toBeFalsy();
-    const saveButton = wrapper.find('button[type="button"].btn-primary.me-3');
+    const saveButton = wrapper.find('button[type="button"].btn-primary.me-2');
     expect(saveButton.exists()).toBeTruthy();
     expect(saveButton.text()).toBe('Save as Default');
     await saveButton.trigger('click');
@@ -94,6 +94,6 @@ describe('IssueSearchAdvanced', () => {
     await flushPromises();
     expect(useRouter().replace).toHaveBeenCalled();
     expect(useRouter().replace.mock.calls[0][0])
-      .toStrictEqual({ query: { query: 'search', cve_id: '' } });
+      .toStrictEqual({ query: { cve_id: '' } });
   });
 });

--- a/src/composables/__tests__/useSearchParams.spec.ts
+++ b/src/composables/__tests__/useSearchParams.spec.ts
@@ -41,7 +41,7 @@ describe('useSearchParams', () => {
     expect(search.value).toBe('search');
     expect(useRouter().push).toHaveBeenCalled();
     expect(useRouter().push.mock.calls[0][0])
-      .toStrictEqual({ name: 'search', query: { query: 'search' } });
+      .toStrictEqual({ name: 'search', query: { search: 'search' } });
   });
 
   it('update facets on addFacet', () => {
@@ -76,7 +76,7 @@ describe('useSearchParams', () => {
     const { getSearchParams } = useSearchParams();
     const searchParams = getSearchParams();
     expect(searchParams).toStrictEqual({
-      'search': 'search',
+      'query': 'search',
       'affects__ps_component': 'test'
     });
   });

--- a/src/views/FlawSearchView.vue
+++ b/src/views/FlawSearchView.vue
@@ -69,12 +69,10 @@ function saveFilter() {
 
 <template>
   <main class="mt-3">
-    <div>
-      <IssueSearchAdvanced
-        :isLoading="isLoading"
-        @filter:save="saveFilter"
-      />
-    </div>
+    <IssueSearchAdvanced
+      :isLoading="isLoading"
+      @filter:save="saveFilter"
+    />
     <IssueQueue
       :issues="issues"
       :isLoading="isLoading"

--- a/src/views/FlawSearchView.vue
+++ b/src/views/FlawSearchView.vue
@@ -20,9 +20,13 @@ defineEmits<{
 }>();
 
 const params = computed(() => {
+  const searchParams = getSearchParams();
+  if (searchParams.order) {
+    searchParams.order += ',' + tableFilters.value.order;
+  }
   const paramsObj = {
     ...tableFilters.value,
-    ...getSearchParams()
+    ...searchParams,
   };
 
   return paramsObj;
@@ -65,7 +69,7 @@ function saveFilter() {
 
 <template>
   <main class="mt-3">
-    <div class="container">
+    <div>
       <IssueSearchAdvanced
         :isLoading="isLoading"
         @filter:save="saveFilter"


### PR DESCRIPTION
# OSIDB-3088 Add query mode to advanced search

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Provides support for query filters on advanced search using the new library implemented in OSIDB.

## Changes:

- Adds new optional input for the query filter on the advance search view
- Implement the logic for handling the query parameter on searchs or getting params
- Adapt test cases for advanced search by including new parameter
- Adds a modal for query guide and examples on advanced search 

## Considerations:

- This is the base feature for advanced search redesign, and the first to be merged

Closes OSIDB-3088
