### PR TITLE
✨ Support saving query filter on default user search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ trackers will be refreshed (`OSIDB-3402`)
 * Display score on affect's CVSS column (`OSIDB-3397`)
 * Allow removing CVSS on affects (`OSIDB-3397`)
 * Support saving query filter on default user search (`OSIDB-3387`)
+* Add query filter support on advance search (`OSIDB-3088`)
 
 ### Changed
 * Improved performance by reusing access token until is expired (`OSIDB-3373`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ trackers will be refreshed (`OSIDB-3402`)
 * Display score on affect's CVSS column (`OSIDB-3397`)
 * Allow removing CVSS on affects (`OSIDB-3397`)
 * Support saving query filter on default user search (`OSIDB-3387`)
-* Add query filter support on advance search (`OSIDB-3088`)
 
 ### Changed
 * Improved performance by reusing access token until is expired (`OSIDB-3373`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ trackers will be refreshed (`OSIDB-3402`)
 * Add query filter support on advance search (`OSIDB-3088`)
 * Display score on affect's CVSS column (`OSIDB-3397`)
 * Allow removing CVSS on affects (`OSIDB-3397`)
+* Support saving query filter on default user search (`OSIDB-3387`)
 
 ### Changed
 * Improved performance by reusing access token until is expired (`OSIDB-3373`)

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -4,9 +4,13 @@ import { DateTime } from 'luxon';
 import IssueQueueItem from '@/components/IssueQueueItem.vue';
 import LabelCheckbox from '@/components/widgets/LabelCheckbox.vue';
 import { useUserStore } from '@/stores/UserStore';
+import { useSearchStore } from '@/stores/SearchStore';
 import { FlawClassificationStateEnum } from '@/generated-client';
+import { useToastStore } from '@/stores/ToastStore';
 
 const userStore = useUserStore();
+const searchStore = useSearchStore();
+const { addToast } = useToastStore();
 
 const emit = defineEmits(['flaws:fetch', 'flaws:load-more']);
 
@@ -171,6 +175,14 @@ const nameForOption = (fieldName: string) => {
   name = name.replace(/_/g, ' ');
   return name.charAt(0).toUpperCase() + name.slice(1);
 };
+
+function clearDefaultFilter() {
+  searchStore.resetFilter();
+  addToast({
+    title: 'Default Filter',
+    body: 'User\'s default filter cleared',
+  });
+}
 </script>
 
 <template>
@@ -199,18 +211,23 @@ const nameForOption = (fieldName: string) => {
         :class="{'text-secondary': isLoading}"
       > Loaded {{ issues.length }} of {{ total }}</span>
     </div>
-    <details v-if="showFilter" class="osim-default-filter">
-      <summary>Default Filters</summary>
-      <div class="my-2">
-        <span
-          v-for="(value, key) in defaultFilters"
-          :key="key"
-          class="badge bg-secondary me-1"
-        >
-          {{ nameForOption(key) }} : {{ value }}
-        </span>
-      </div>
-    </details>
+    <div v-if="showFilter" class="d-flex gap-2">
+      <details class="osim-default-filter">
+        <summary>Default Filters
+          <button class="btn btn-sm btn-primary lh-0 py-0" @click="clearDefaultFilter()">
+            clear
+          </button></summary>
+        <div class="my-2">
+          <span
+            v-for="(value, key) in defaultFilters"
+            :key="key"
+            class="badge bg-secondary me-1"
+          >
+            {{ nameForOption(key) }} : {{ value }}
+          </span>
+        </div>
+      </details>
+    </div>
     <div ref="tableContainerEl" class="osim-incident-list">
       <table class="table align-middle" :class="{ 'osim-table-loading': isLoading }">
         <thead class="sticky-top">

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -200,12 +200,12 @@ const nameForOption = (fieldName: string) => {
       > Loaded {{ issues.length }} of {{ total }}</span>
     </div>
     <details v-if="showFilter" class="osim-default-filter">
-      <summary class="mb-2">Default Filters</summary>
-      <div>
+      <summary>Default Filters</summary>
+      <div class="my-2">
         <span
           v-for="(value, key) in defaultFilters"
           :key="key"
-          class="badge rounded-pill bg-primary text-light border me-2 mb-1 pe-auto"
+          class="badge bg-secondary me-1"
         >
           {{ nameForOption(key) }} : {{ value }}
         </span>
@@ -293,6 +293,7 @@ const nameForOption = (fieldName: string) => {
 
   .osim-default-filter{
     padding-left: 0.75rem;
+    user-select: none;
   }
 
   &:hover i {

--- a/src/components/__tests__/FlawSearchView.spec.ts
+++ b/src/components/__tests__/FlawSearchView.spec.ts
@@ -134,7 +134,7 @@ describe('FlawSearchView', () => {
     await flushPromises();
     expect(useRouter().replace).toHaveBeenCalled();
     expect(useRouter().replace.mock.calls[0][0])
-      .toStrictEqual({ query: { query: 'test', search: 'search' } });
+      .toStrictEqual({ query: { query: 'test' } });
   });
 
   it('should call saveFilter on save filter button click', async () => {
@@ -199,7 +199,7 @@ describe('FlawSearchView', () => {
     await flushPromises();
     expect(useRouter().replace).toHaveBeenCalled();
     expect(useRouter().replace.mock.calls[0][0])
-      .toStrictEqual({ query: { query: 'test', requires_cve_description: 'REQUESTED', search: 'search' } });
+      .toStrictEqual({ query: { query: 'search', requires_cve_description: 'REQUESTED' } });
   });
 
   it('should call loadFlaws with major_incident_state on search', async () => {
@@ -219,7 +219,7 @@ describe('FlawSearchView', () => {
     await flushPromises();
     expect(useRouter().replace).toHaveBeenCalled();
     expect(useRouter().replace.mock.calls[0][0])
-      .toStrictEqual({ query: { query: 'test', major_incident_state: 'REQUESTED', search: 'search' } });
+      .toStrictEqual({ query: { query: 'search', major_incident_state: 'REQUESTED' } });
   });
 
   it('should call loadFlaws with affectedness on search', async () => {
@@ -239,6 +239,6 @@ describe('FlawSearchView', () => {
     await flushPromises();
     expect(useRouter().replace).toHaveBeenCalled();
     expect(useRouter().replace.mock.calls[0][0])
-      .toStrictEqual({ query: { query: 'test', affects__affectedness: 'NEW', search: 'search' } });
+      .toStrictEqual({ query: { query: 'search', affects__affectedness: 'NEW' } });
   });
 });

--- a/src/components/__tests__/IndexView.spec.ts
+++ b/src/components/__tests__/IndexView.spec.ts
@@ -94,7 +94,8 @@ describe('IndexView', () => {
     expect(useFlawsFetching().loadFlaws).toHaveBeenCalledOnce();
     expect(useFlawsFetching().loadFlaws.mock.calls[0][0]._value).toStrictEqual({
       'order': '-created_dt',
-      'affects__ps_component': 'test'
+      'affects__ps_component': 'test',
+      'query': '',
     });
   });
 
@@ -102,7 +103,8 @@ describe('IndexView', () => {
     expect(useFlawsFetching().loadFlaws).toHaveBeenCalledOnce();
     expect(useFlawsFetching().loadFlaws.mock.calls[0][0]._value).toStrictEqual({
       'order': '-created_dt',
-      'affects__ps_component': 'test'
+      'affects__ps_component': 'test',
+      'query': '',
     });
     const filterEl = wrapper.find('div.osim-incident-filter');
     expect(filterEl.exists()).toBeTruthy();

--- a/src/composables/useSearchParams.ts
+++ b/src/composables/useSearchParams.ts
@@ -48,7 +48,7 @@ export function useSearchParams() {
     if (parsedRoute.query.search) {
       params.search = parsedRoute.query.search;
     }
-    search.value = parsedRoute.query.query || '';
+    query.value = parsedRoute.query.query || '';
     if (parsedRoute.query.query) {
       params.query = parsedRoute.query.query;
     }

--- a/src/stores/SearchStore.ts
+++ b/src/stores/SearchStore.ts
@@ -1,31 +1,34 @@
 import { defineStore } from 'pinia';
-import { z } from 'zod';
 import { useLocalStorage } from '@vueuse/core';
 import { computed } from 'vue';
 
-export const SearchSchema = z.object({
-  searchFilters: z.record(z.string())
-});
+export type SearchSchema = {
+  searchFilters: Record<string, string>,
+  queryFilter: string,
+}
 
-export type SearchType = z.infer<typeof SearchSchema>;
-const defaultValues: SearchType = { searchFilters: {} };
+const defaultValues: SearchSchema = { searchFilters: {}, queryFilter: '' };
 
 const _searchStoreKey = 'SearchStore';
 const search = useLocalStorage(_searchStoreKey, defaultValues);
 
 export const useSearchStore = defineStore('SearchStore', () => {
   const searchFilters = computed(() => search.value.searchFilters || {});
+  const queryFilter = computed(() => search.value.queryFilter || '');
 
-  function saveFilter(filters: Record<string, string>) {
+  function saveFilter(filters: Record<string, string>, query: string = '') {
     search.value.searchFilters = filters;
+    search.value.queryFilter = query;
   }
 
   function resetFilter() {
     search.value.searchFilters = {};
+    search.value.queryFilter = '';
   }
 
   return {
     searchFilters,
+    queryFilter,
     saveFilter,
     resetFilter
   };

--- a/src/views/FlawSearchView.vue
+++ b/src/views/FlawSearchView.vue
@@ -9,7 +9,7 @@ import { useToastStore } from '@/stores/ToastStore';
 import { allowedEmptyFieldMapping } from '@/constants/flawFields';
 
 const { issues, isLoading, isFinalPageFetched, total, loadFlaws, loadMoreFlaws } = useFlawsFetching();
-const { getSearchParams, facets } = useSearchParams();
+const { getSearchParams, facets, query } = useSearchParams();
 
 const searchStore = useSearchStore();
 const { addToast } = useToastStore();
@@ -58,7 +58,7 @@ function saveFilter() {
     },
       {} as Record<string, string>,
   );
-  searchStore.saveFilter(filters);
+  searchStore.saveFilter(filters, query.value);
   addToast({
     title: 'Default Filter',
     body: 'User\'s default filter saved',

--- a/src/views/IndexView.vue
+++ b/src/views/IndexView.vue
@@ -11,7 +11,7 @@ const { issues, isLoading, isFinalPageFetched, total, loadFlaws, loadMoreFlaws }
 const tableFilters = ref<Record<string, string>>({});
 
 const showFilter = computed(() =>
-  Object.keys(searchStore.searchFilters).length > 0
+  Object.keys(searchStore.searchFilters).length > 0 || searchStore.queryFilter !== ''
 );
 
 const isDefaultFilterSelected = ref<boolean>(showFilter.value);
@@ -19,7 +19,8 @@ const isDefaultFilterSelected = ref<boolean>(showFilter.value);
 const params = computed(() => {
   const paramsObj = {
     ...tableFilters.value,
-    ...isDefaultFilterSelected.value && searchStore.searchFilters
+    ...isDefaultFilterSelected.value && searchStore.searchFilters,
+    ...isDefaultFilterSelected.value && { query: searchStore.queryFilter },
   };
 
   return paramsObj;
@@ -44,6 +45,14 @@ function setTableFilters(newFilters: Ref<Record<string, string>>) {
 onDeactivated(() => {
   loadFlaws(params);
 });
+
+const defaultFilters = computed(() => {
+  return {
+    query: searchStore.queryFilter,
+    ...searchStore.searchFilters,
+  };
+});
+
 </script>
 
 <template>
@@ -55,7 +64,7 @@ onDeactivated(() => {
       :total="total"
       :isFinalPageFetched="isFinalPageFetched"
       :showFilter="showFilter"
-      :defaultFilters="searchStore.searchFilters"
+      :defaultFilters="defaultFilters"
       @flaws:fetch="setTableFilters"
       @flaws:load-more="fetchMoreFlaws"
     />


### PR DESCRIPTION
# OSIDB-3387 Support saving query filter on default user search

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Add support to save query filter on user's default search store.

## Changes:

- Handles query filter if present when saving default search
- Displays query filter badge if present on active default filters from index view
- Fixes a bug where query filter field was not being set if present in router params
- Adapt test cases

## Considerations:

- Depends on https://github.com/RedHatProductSecurity/osim/pull/397

Closes OSIDB-3387
