### PR TITLE
✨ Multifields emptiness advanced search support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 ### Added
 * Add query filter support on advance search (`OSIDB-3088`)
 * Support saving query filter on default user search (`OSIDB-3387`)
-* Add query filter support on advance search (`OSIDB-3088`)
-* Support saving query filter on default user search (`OSIDB-3387`)
+* Allow emptiness advanced search on supported fields (`OSIDB-3389`)
 
 ### Fixed
 * Fix swapped values on trackers `Modules` and `Stream` values (`OSIDB-3443`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Added
 * Add query filter support on advance search (`OSIDB-3088`)
 * Support saving query filter on default user search (`OSIDB-3387`)
+* Add query filter support on advance search (`OSIDB-3088`)
+* Support saving query filter on default user search (`OSIDB-3387`)
 
 ### Fixed
 * Fix swapped values on trackers `Modules` and `Stream` values (`OSIDB-3443`)

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -212,7 +212,7 @@ onUnmounted(() => {
           Search
         </button>
         <button
-          class="btn btn-primary me-2"
+          class="save-default-btn btn btn-primary me-2"
           type="button"
           :disabled="isLoading"
           @click="emit('filter:save')"

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -133,6 +133,14 @@ onUnmounted(() => {
           type="text"
           class="form-control"
         />
+        <button
+          class="btn btn-sm btn-secondary rounded-0 py-0"
+          title="Clear query"
+          type="button"
+          @click="query = ''"
+        >
+          <i class="bi bi-eraser fs-5"></i>
+        </button>
         <button class="btn btn-secondary py-0" type="button" @click="() => queryFilterVisible = false">
           <i class="bi bi-x fs-5" aria-label="hide query filter" />
         </button>
@@ -186,6 +194,14 @@ onUnmounted(() => {
             <i class="bi bi-slash-circle fs-5" />
           </button>
         </div>
+        <button
+          class="btn btn-sm btn-primary rounded-0 py-0"
+          title="Clear field"
+          type="button"
+          @click="facet.value = ''"
+        >
+          <i class="bi bi-eraser fs-5"></i>
+        </button>
         <button class="btn btn-primary py-0" type="button" @click="removeFacet(index)">
           <i class="bi-x fs-5" aria-label="remove field"></i>
         </button>

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -207,12 +207,18 @@ onUnmounted(() => {
         </button>
       </div>
       <div class="mt-2">
-        <button class="btn btn-primary me-2" type="submit" :disabled="props.isLoading">
+        <button
+          class="btn btn-primary me-2"
+          type="submit"
+          :disabled="props.isLoading"
+          aria-label="Advance search button"
+        >
           <div v-if="props.isLoading" class="spinner-border spinner-border-sm"></div>
           Search
         </button>
         <button
-          class="save-default-btn btn btn-primary me-2"
+          class="btn btn-primary me-2"
+          aria-label="Save filters as default"
           type="button"
           :disabled="isLoading"
           @click="emit('filter:save')"

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -12,7 +12,7 @@ import { useModal } from '@/composables/useModal';
 import { useSearchParams } from '@/composables/useSearchParams';
 
 import { flawImpacts, flawSources, flawIncidentStates, descriptionRequiredStates } from '@/types/zodFlaw';
-import { flawFields } from '@/constants/flawFields';
+import { allowedEmptyFieldMapping, flawFields } from '@/constants/flawFields';
 import { affectAffectedness } from '@/types/zodAffect';
 import { osimRuntime } from '@/stores/osimRuntime';
 
@@ -25,7 +25,7 @@ const { closeModal, isModalOpen, openModal } = useModal();
 
 const queryFilterVisible = ref(true);
 
-const emptinessSupportedFields = ['cve_id', 'cve_description', 'statement', 'mitigation', 'owner', 'cwe_id'];
+const emptinessSupportedFields = Object.keys(allowedEmptyFieldMapping);
 
 const djangoCompletion = ref();
 

--- a/src/components/__tests__/IssueSearchAdvanced.spec.ts
+++ b/src/components/__tests__/IssueSearchAdvanced.spec.ts
@@ -98,7 +98,8 @@ describe('issueSearchAdvanced', () => {
     const wrapper = await mountIssueSearchAdvanced();
     const router = vi.mocked(useRouter());
 
-    await wrapper.find('input[type="checkbox"]').setValue(true);
+    await wrapper.find('select').setValue('cve_description');
+    await wrapper.findAll('.input-group .btn-group .btn')[1].trigger('click');
     await wrapper.find('form').trigger('submit');
 
     expect(router.replace).toHaveBeenNthCalledWith(1, { query: { cve_description: 'nonempty' } });
@@ -109,7 +110,7 @@ describe('issueSearchAdvanced', () => {
 
     await wrapper.find('select').setValue('cve_description');
     await wrapper.find('.input-group input').setValue('some value');
-    await wrapper.findAll('form div button[type="button"]').at(4)!.trigger('click');
+    await wrapper.find('.save-default-btn').trigger('click');
 
     expect(wrapper.emitted()).toHaveProperty('filter:save');
   });

--- a/src/components/__tests__/IssueSearchAdvanced.spec.ts
+++ b/src/components/__tests__/IssueSearchAdvanced.spec.ts
@@ -110,7 +110,7 @@ describe('issueSearchAdvanced', () => {
 
     await wrapper.find('select').setValue('cve_description');
     await wrapper.find('.input-group input').setValue('some value');
-    await wrapper.find('.save-default-btn').trigger('click');
+    await wrapper.find('button[aria-label="Save filters as default"]').trigger('click');
 
     expect(wrapper.emitted()).toHaveProperty('filter:save');
   });

--- a/src/components/__tests__/__snapshots__/IssueSearchAdvanced.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/IssueSearchAdvanced.spec.ts.snap
@@ -62,9 +62,9 @@ exports[`issueSearchAdvanced > should add new facet when last facet is populated
       </select><input data-v-21c9158a="" type="text" class="form-control" disabled="">
       <!--v-if--><button data-v-21c9158a="" class="btn btn-sm btn-primary rounded-0 py-0" title="Clear field" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button>
     </div>
-    <div data-v-21c9158a="" class="mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit">
+    <div data-v-21c9158a="" class="mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit" aria-label="Advance search button">
         <!--v-if--> Search
-      </button><button data-v-21c9158a="" class="save-default-btn btn btn-primary me-2" type="button"> Save as Default </button>
+      </button><button data-v-21c9158a="" class="btn btn-primary me-2" aria-label="Save filters as default" type="button"> Save as Default </button>
       <!--v-if-->
     </div>
   </form>
@@ -112,9 +112,9 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is false 1`] = `
       </select><input data-v-21c9158a="" type="text" class="form-control" disabled="">
       <!--v-if--><button data-v-21c9158a="" class="btn btn-sm btn-primary rounded-0 py-0" title="Clear field" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button>
     </div>
-    <div data-v-21c9158a="" class="mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit">
+    <div data-v-21c9158a="" class="mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit" aria-label="Advance search button">
         <!--v-if--> Search
-      </button><button data-v-21c9158a="" class="save-default-btn btn btn-primary me-2" type="button"> Save as Default </button>
+      </button><button data-v-21c9158a="" class="btn btn-primary me-2" aria-label="Save filters as default" type="button"> Save as Default </button>
       <!--v-if-->
     </div>
   </form>
@@ -162,9 +162,9 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is true 1`] = `
       </select><input data-v-21c9158a="" type="text" class="form-control" disabled="">
       <!--v-if--><button data-v-21c9158a="" class="btn btn-sm btn-primary rounded-0 py-0" title="Clear field" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button>
     </div>
-    <div data-v-21c9158a="" class="mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit" disabled="">
+    <div data-v-21c9158a="" class="mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit" disabled="" aria-label="Advance search button">
         <div data-v-21c9158a="" class="spinner-border spinner-border-sm"></div> Search
-      </button><button data-v-21c9158a="" class="save-default-btn btn btn-primary me-2" type="button" disabled=""> Save as Default </button>
+      </button><button data-v-21c9158a="" class="btn btn-primary me-2" aria-label="Save filters as default" type="button" disabled=""> Save as Default </button>
       <!--v-if-->
     </div>
   </form>

--- a/src/components/__tests__/__snapshots__/IssueSearchAdvanced.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/IssueSearchAdvanced.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`issueSearchAdvanced > should add new facet when last facet is populated
   <summary data-v-21c9158a="" class="mb-1">Advanced Search</summary>
   <form data-v-21c9158a="" class="mb-2">
     <div data-v-21c9158a="" class="input-group my-1">
-      <div data-v-21c9158a="" type="button" class="form-control bg-secondary text-white pe-none py-0 d-flex" style="max-width: 13.125%;"><span data-v-21c9158a="" class="my-auto">Query Filter</span><button data-v-21c9158a="" class="btn btn-sm p-0 ms-auto my-auto text-white pe-auto border-0" type="button"><i data-v-21c9158a="" class="bi bi-question-circle-fill fs-5" aria-label="hide query filter"></i></button></div><textarea data-v-21c9158a="" id="query" type="text" class="form-control"></textarea><button data-v-21c9158a="" class="btn btn-secondary py-0" type="button"><i data-v-21c9158a="" class="bi bi-x fs-5" aria-label="hide query filter"></i></button>
+      <div data-v-21c9158a="" type="button" class="form-control bg-secondary text-white pe-none py-0 d-flex" style="max-width: 13.125%;"><span data-v-21c9158a="" class="my-auto">Query Filter</span><button data-v-21c9158a="" class="btn btn-sm p-0 ms-auto my-auto text-white pe-auto border-0" type="button"><i data-v-21c9158a="" class="bi bi-question-circle-fill fs-5" aria-label="hide query filter"></i></button></div><textarea data-v-21c9158a="" id="query" type="text" class="form-control"></textarea><button data-v-21c9158a="" class="btn btn-sm btn-secondary rounded-0 py-0" title="Clear query" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-secondary py-0" type="button"><i data-v-21c9158a="" class="bi bi-x fs-5" aria-label="hide query filter"></i></button>
     </div>
     <div data-v-21c9158a="" class="input-group my-1"><select data-v-21c9158a="" class="form-select search-facet-field">
         <!--v-if-->
@@ -32,7 +32,9 @@ exports[`issueSearchAdvanced > should add new facet when last facet is populated
         <option data-v-21c9158a="" value="title">Title</option>
         <option data-v-21c9158a="" value="affects__trackers__external_system_id">Tracker External System ID</option>
         <option data-v-21c9158a="" value="uuid">UUID</option>
-      </select><input data-v-21c9158a="" type="text" class="form-control"><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button></div>
+      </select><input data-v-21c9158a="" type="text" class="form-control">
+      <div data-v-21c9158a="" class="btn-group"><button data-v-21c9158a="" class="btn btn-sm btn-primary rounded-0 py-0" title="Non empty field search" type="button"><i data-v-21c9158a="" class="bi bi-circle fs-5"></i></button><button data-v-21c9158a="" class="btn btn-sm btn-primary rounded-0 py-0" title="Empty field search" type="button"><i data-v-21c9158a="" class="bi bi-slash-circle fs-5"></i></button></div><button data-v-21c9158a="" class="btn btn-sm btn-primary rounded-0 py-0" title="Clear field" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button>
+    </div>
     <div data-v-21c9158a="" class="input-group my-1"><select data-v-21c9158a="" class="form-select search-facet-field">
         <option data-v-21c9158a="" selected="" disabled="" value="">Select field...</option>
         <option data-v-21c9158a="" value="acknowledgments__name">Acknowledgment Author</option>
@@ -57,12 +59,13 @@ exports[`issueSearchAdvanced > should add new facet when last facet is populated
         <option data-v-21c9158a="" value="title">Title</option>
         <option data-v-21c9158a="" value="affects__trackers__external_system_id">Tracker External System ID</option>
         <option data-v-21c9158a="" value="uuid">UUID</option>
-      </select><input data-v-21c9158a="" type="text" class="form-control" disabled=""><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button></div>
+      </select><input data-v-21c9158a="" type="text" class="form-control" disabled="">
+      <!--v-if--><button data-v-21c9158a="" class="btn btn-sm btn-primary rounded-0 py-0" title="Clear field" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button>
+    </div>
     <div data-v-21c9158a="" class="mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit">
         <!--v-if--> Search
-      </button><button data-v-21c9158a="" class="btn btn-primary me-2" type="button"> Save as Default </button>
+      </button><button data-v-21c9158a="" class="save-default-btn btn btn-primary me-2" type="button"> Save as Default </button>
       <!--v-if-->
-      <div data-v-5fd32c51="" data-v-21c9158a="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-5fd32c51="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-5fd32c51="" class="d-inline-block form-check-input" type="checkbox"><span data-v-5fd32c51="" class="form-check-label">Non Empty CVE Description</span></label></div>
     </div>
   </form>
 </details>
@@ -79,7 +82,7 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is false 1`] = `
   <summary data-v-21c9158a="" class="mb-1">Advanced Search</summary>
   <form data-v-21c9158a="" class="mb-2">
     <div data-v-21c9158a="" class="input-group my-1">
-      <div data-v-21c9158a="" type="button" class="form-control bg-secondary text-white pe-none py-0 d-flex" style="max-width: 13.125%;"><span data-v-21c9158a="" class="my-auto">Query Filter</span><button data-v-21c9158a="" class="btn btn-sm p-0 ms-auto my-auto text-white pe-auto border-0" type="button"><i data-v-21c9158a="" class="bi bi-question-circle-fill fs-5" aria-label="hide query filter"></i></button></div><textarea data-v-21c9158a="" id="query" type="text" class="form-control"></textarea><button data-v-21c9158a="" class="btn btn-secondary py-0" type="button"><i data-v-21c9158a="" class="bi bi-x fs-5" aria-label="hide query filter"></i></button>
+      <div data-v-21c9158a="" type="button" class="form-control bg-secondary text-white pe-none py-0 d-flex" style="max-width: 13.125%;"><span data-v-21c9158a="" class="my-auto">Query Filter</span><button data-v-21c9158a="" class="btn btn-sm p-0 ms-auto my-auto text-white pe-auto border-0" type="button"><i data-v-21c9158a="" class="bi bi-question-circle-fill fs-5" aria-label="hide query filter"></i></button></div><textarea data-v-21c9158a="" id="query" type="text" class="form-control"></textarea><button data-v-21c9158a="" class="btn btn-sm btn-secondary rounded-0 py-0" title="Clear query" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-secondary py-0" type="button"><i data-v-21c9158a="" class="bi bi-x fs-5" aria-label="hide query filter"></i></button>
     </div>
     <div data-v-21c9158a="" class="input-group my-1"><select data-v-21c9158a="" class="form-select search-facet-field">
         <option data-v-21c9158a="" selected="" disabled="" value="">Select field...</option>
@@ -106,12 +109,13 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is false 1`] = `
         <option data-v-21c9158a="" value="title">Title</option>
         <option data-v-21c9158a="" value="affects__trackers__external_system_id">Tracker External System ID</option>
         <option data-v-21c9158a="" value="uuid">UUID</option>
-      </select><input data-v-21c9158a="" type="text" class="form-control" disabled=""><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button></div>
+      </select><input data-v-21c9158a="" type="text" class="form-control" disabled="">
+      <!--v-if--><button data-v-21c9158a="" class="btn btn-sm btn-primary rounded-0 py-0" title="Clear field" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button>
+    </div>
     <div data-v-21c9158a="" class="mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit">
         <!--v-if--> Search
-      </button><button data-v-21c9158a="" class="btn btn-primary me-2" type="button"> Save as Default </button>
+      </button><button data-v-21c9158a="" class="save-default-btn btn btn-primary me-2" type="button"> Save as Default </button>
       <!--v-if-->
-      <div data-v-5fd32c51="" data-v-21c9158a="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-5fd32c51="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-5fd32c51="" class="d-inline-block form-check-input" type="checkbox"><span data-v-5fd32c51="" class="form-check-label">Non Empty CVE Description</span></label></div>
     </div>
   </form>
 </details>
@@ -128,7 +132,7 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is true 1`] = `
   <summary data-v-21c9158a="" class="mb-1">Advanced Search</summary>
   <form data-v-21c9158a="" class="mb-2">
     <div data-v-21c9158a="" class="input-group my-1">
-      <div data-v-21c9158a="" type="button" class="form-control bg-secondary text-white pe-none py-0 d-flex" style="max-width: 13.125%;"><span data-v-21c9158a="" class="my-auto">Query Filter</span><button data-v-21c9158a="" class="btn btn-sm p-0 ms-auto my-auto text-white pe-auto border-0" type="button"><i data-v-21c9158a="" class="bi bi-question-circle-fill fs-5" aria-label="hide query filter"></i></button></div><textarea data-v-21c9158a="" id="query" type="text" class="form-control"></textarea><button data-v-21c9158a="" class="btn btn-secondary py-0" type="button"><i data-v-21c9158a="" class="bi bi-x fs-5" aria-label="hide query filter"></i></button>
+      <div data-v-21c9158a="" type="button" class="form-control bg-secondary text-white pe-none py-0 d-flex" style="max-width: 13.125%;"><span data-v-21c9158a="" class="my-auto">Query Filter</span><button data-v-21c9158a="" class="btn btn-sm p-0 ms-auto my-auto text-white pe-auto border-0" type="button"><i data-v-21c9158a="" class="bi bi-question-circle-fill fs-5" aria-label="hide query filter"></i></button></div><textarea data-v-21c9158a="" id="query" type="text" class="form-control"></textarea><button data-v-21c9158a="" class="btn btn-sm btn-secondary rounded-0 py-0" title="Clear query" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-secondary py-0" type="button"><i data-v-21c9158a="" class="bi bi-x fs-5" aria-label="hide query filter"></i></button>
     </div>
     <div data-v-21c9158a="" class="input-group my-1"><select data-v-21c9158a="" class="form-select search-facet-field">
         <option data-v-21c9158a="" selected="" disabled="" value="">Select field...</option>
@@ -155,12 +159,13 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is true 1`] = `
         <option data-v-21c9158a="" value="title">Title</option>
         <option data-v-21c9158a="" value="affects__trackers__external_system_id">Tracker External System ID</option>
         <option data-v-21c9158a="" value="uuid">UUID</option>
-      </select><input data-v-21c9158a="" type="text" class="form-control" disabled=""><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button></div>
+      </select><input data-v-21c9158a="" type="text" class="form-control" disabled="">
+      <!--v-if--><button data-v-21c9158a="" class="btn btn-sm btn-primary rounded-0 py-0" title="Clear field" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button>
+    </div>
     <div data-v-21c9158a="" class="mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit" disabled="">
         <div data-v-21c9158a="" class="spinner-border spinner-border-sm"></div> Search
-      </button><button data-v-21c9158a="" class="btn btn-primary me-2" type="button" disabled=""> Save as Default </button>
+      </button><button data-v-21c9158a="" class="save-default-btn btn btn-primary me-2" type="button" disabled=""> Save as Default </button>
       <!--v-if-->
-      <div data-v-5fd32c51="" data-v-21c9158a="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-5fd32c51="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-5fd32c51="" class="d-inline-block form-check-input" type="checkbox"><span data-v-5fd32c51="" class="form-check-label">Non Empty CVE Description</span></label></div>
     </div>
   </form>
 </details>

--- a/src/composables/useFlawsFetching.ts
+++ b/src/composables/useFlawsFetching.ts
@@ -6,7 +6,7 @@ import { allowedEmptyFieldMapping } from '@/constants/flawFields';
 function finializeRequestParams(params: any = {}) {
   const requestParams: Record<string, any> = {};
   for (const key in params) {
-    if (['', 'nonempty'].includes(params[key]) && allowedEmptyFieldMapping[key]) {
+    if (['isempty', 'nonempty'].includes(params[key]) && allowedEmptyFieldMapping[key]) {
       requestParams[allowedEmptyFieldMapping[key]] = params[key] === '' ? 1 : 0;
     } else {
       requestParams[key] = params[key];

--- a/src/stores/SearchStore.ts
+++ b/src/stores/SearchStore.ts
@@ -12,7 +12,7 @@ const defaultValues: SearchSchema = { searchFilters: {}, queryFilter: '' };
 
 const _searchStoreKey = 'SearchStore';
 const search = useLocalStorage(_searchStoreKey, defaultValues);
-function saveFilter(filters: Record<string, string>, query: string = '') {
+function saveFilter(filters: Record<string, string>, query: string) {
   search.value.searchFilters = filters;
   search.value.queryFilter = query;
 }

--- a/src/views/FlawSearchView.vue
+++ b/src/views/FlawSearchView.vue
@@ -58,9 +58,7 @@ function saveFilter() {
     },
     {} as Record<string, string>,
   );
-  if (query?.value) {
-    searchStore.saveFilter(filters, query.value);
-  }
+  searchStore.saveFilter(filters, query.value);
   addToast({
     title: 'Default Filter',
     body: 'User\'s default filter saved',

--- a/src/views/IndexView.vue
+++ b/src/views/IndexView.vue
@@ -50,7 +50,7 @@ onDeactivated(() => {
 
 const defaultFilters = computed(() => {
   return {
-    query: searchStore.queryFilter,
+    ...(searchStore.queryFilter ? { query: searchStore.queryFilter } : {}),
     ...searchStore.searchFilters,
   };
 });


### PR DESCRIPTION
# OSIDB-3389 Multifields emptiness advanced search support

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Allow search empty / nonempty on advanced search specific fields (ones supported by OSIDB).

## Changes:

- Removes previous checkbox and code for `cve_description` nonempty
- Adds conditional buttons for empty / nonempty searches on supported fields
- Changes empty param value from empty to word `isempty`
- Adds button to clear any advanced search field
- Adds button to clear query filter
- Updates test cases

## Considerations:

- Empty field searches are now using param value `isempty`
- Non empty field searches remain using `nonempty`
- Depends on https://github.com/RedHatProductSecurity/osim/pull/398

Closes OSIDB-3389
