### PR TITLE
OSIDB-3340: Ruse access token

### DIFF
--- a/src/services/OsidbAuthService.ts
+++ b/src/services/OsidbAuthService.ts
@@ -126,7 +126,7 @@ export async function getNextAccessToken() {
   const url = `${osimRuntime.value.backends.osidb}/auth/token/refresh`;
   const userStore = useUserStore();
   let response;
-  if (userStore.accessToken && !userStore.isAccessTokenExpired) {
+  if (userStore.accessToken && !userStore.isAccessTokenExpired()) {
     return userStore.accessToken;
   }
   try {

--- a/src/services/__tests__/OsidbAuthService.spec.ts
+++ b/src/services/__tests__/OsidbAuthService.spec.ts
@@ -1,8 +1,7 @@
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { getNextAccessToken } from '../OsidbAuthService';
-import { setActivePinia } from 'pinia';
-import { createTestingPinia } from '@pinia/testing';
+import { createPinia, setActivePinia } from 'pinia';
 import { DateTime } from 'luxon';
 import { useUserStore } from '@/stores/UserStore';
 import { encodeJWT } from '@/__tests__/helpers';
@@ -29,7 +28,7 @@ describe('OsidbAuthService', () => {
   });
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia());
+    setActivePinia(createPinia());
 
     vi.useFakeTimers({
       now: new Date('2024-08-29T11:42:58.000Z')
@@ -72,14 +71,15 @@ describe('OsidbAuthService', () => {
   it('Should refresh expired access token', async () => {
     const expiredAccessJWT = encodeJWT({
       'token_type': 'access',
-      'exp': Math.floor(DateTime.fromISO('2024-08-28T10:35:58.000Z').toSeconds()),
-      'iat': Math.floor(DateTime.fromISO('2024-08-29T11:30:58.000Z').toSeconds()),
+      'exp': Math.floor(DateTime.fromISO('2024-08-29T11:47:58.000Z').toSeconds()),
+      'iat': Math.floor(DateTime.fromISO('2024-08-29T11:42:58.000Z').toSeconds()),
       'jti': '0000',
       'user_id': 1337
     });
     const userStore = useUserStore();
     userStore.accessToken = expiredAccessJWT;
 
+    vi.advanceTimersByTime(4 * 60 * 1000);
     const token = await getNextAccessToken();
 
     expect(token).toEqual(accessJWT);

--- a/src/stores/UserStore.ts
+++ b/src/stores/UserStore.ts
@@ -72,7 +72,7 @@ export const useUserStore = defineStore('UserStore', () => {
   });
 
   const accessToken = ref<string>();
-  const isAccessTokenExpired = computed<boolean>(() => {
+  const isAccessTokenExpired = () => {
     try {
       const exp = accessToken.value ? jwtDecode<JwtPayload>(accessToken.value)?.exp : null;
       return !exp || DateTime.now().toSeconds() >= exp - 60;
@@ -80,7 +80,7 @@ export const useUserStore = defineStore('UserStore', () => {
       console.debug('UserStore: access token not a valid JWT', accessToken.value, e);
       return true;
     }
-  });
+  };
 
   const whoami = computed<WhoamiType | null>(() => {
     return _userStoreSession.value.whoami || null;

--- a/src/stores/__tests__/UserStore.spec.ts
+++ b/src/stores/__tests__/UserStore.spec.ts
@@ -53,7 +53,7 @@ describe('UserStore', () => {
 
   it('should set `isAccessTokenExpired` to true when access token is undefined', () => {
     userStore.accessToken = undefined;
-    expect(userStore.isAccessTokenExpired).toBe(true);
+    expect(userStore.isAccessTokenExpired()).toBe(true);
   });
 
   it('should set `isAccessTokenExpired` to true when access token is about to expire', () => {
@@ -65,7 +65,7 @@ describe('UserStore', () => {
       'user_id': 1337
     });
 
-    expect(userStore.isAccessTokenExpired).toBe(true);
+    expect(userStore.isAccessTokenExpired()).toBe(true);
   });
 
   it('should set `isAccessTokenExpired` to false when access token is active', () => {
@@ -77,14 +77,14 @@ describe('UserStore', () => {
       'user_id': 1337
     });
 
-    expect(userStore.isAccessTokenExpired).toBe(false);
+    expect(userStore.isAccessTokenExpired()).toBe(false);
   });
 
   it('should not throw when access token is invalid', () => {
     expect(() => {
       userStore.accessToken = 'invalid';
 
-      expect(userStore.isAccessTokenExpired).toBe(true);
+      expect(userStore.isAccessTokenExpired()).toBe(true);
     }).not.toThrow();
   });
 });


### PR DESCRIPTION
# OSIDB-3340: Ruse access token

## Checklist:

- [x] Commits consolidated
- [ ] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Because the `isAccessTokenExpired` was a `computed` property it wasn't updating properly, always returning `false` which caused unauthenticated issues

## Changes:

Removed the `computed` and return the function directly


Closes OSIDB-3340
