### PR TITLE
🐛 Affects CVSS CRUD operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * In the event of saving multiple trackers with some failing, the affect 
 trackers will be refreshed (`OSIDB-3402`)
 * Add query filter support on advance search (`OSIDB-3088`)
+* Display score on affect's CVSS column (`OSIDB-3397`)
+* Allow removing CVSS on affects (`OSIDB-3397`)
 
 ### Changed
 * Improved performance by reusing access token until is expired (`OSIDB-3373`)
@@ -24,6 +26,7 @@ trackers will be refreshed (`OSIDB-3402`)
 
 ### Fixed
 * Correct `affected module` information source on trackers display (`OSIDB-2818`)
+* Allow setting and modifying affect's CVSS (`OSIDB-3397`)
 
 ### Removed
 * Removed `type` information for trackers display (`OSIDB-2818`)

--- a/src/components/FlawAffects.vue
+++ b/src/components/FlawAffects.vue
@@ -1248,6 +1248,10 @@ function fileTrackersForAffects(affects: ZodAffectType[]) {
       height: 2rem;
       padding-block: 0;
       margin: .15rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 200px;
     }
 
     .clear-modules-btn {

--- a/src/components/FlawAffects.vue
+++ b/src/components/FlawAffects.vue
@@ -425,7 +425,7 @@ function selectAffects(event: Event) {
 
 // Affects Fields
 function affectCvss3Vector(affect: ZodAffectType) {
-  affect.cvss_scores.find(({ issuer, cvss_version }) => issuer === 'RH' && cvss_version === 'V3')
+  return affect.cvss_scores.find(({ issuer, cvss_version }) => issuer === 'RH' && cvss_version === 'V3')
     ?.vector
     || null;
 }
@@ -444,7 +444,7 @@ function affectRowTooltip(affect: ZodAffectType) {
   } else if (isModified(affect)) {
     return 'This affect will be updated on save changes';
   } else {
-    '';
+    return '';
   }
 }
 

--- a/src/components/FlawAffects.vue
+++ b/src/components/FlawAffects.vue
@@ -1409,6 +1409,10 @@ function fileTrackersForAffects(affects: ZodAffectType[]) {
             padding-block: .2rem;
             border-block: .2ch solid #e0e0e0;
             background-color: #e0e0e0;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 150px;
 
             .row-right-indicator {
               right: -42px;

--- a/src/components/FlawAffects.vue
+++ b/src/components/FlawAffects.vue
@@ -427,15 +427,23 @@ function selectAffects(event: Event) {
 function useAffectCvss3Vector(affect: ZodAffectType) {
   return computed({
     get() {
-      return affect.cvss_scores.find(({ issuer, cvss_version }) => issuer === 'RH' && cvss_version === 'V3')
-        ?.vector
-        || null;
-    },
-    set(newValue: string | null) {
-      const cvssScore = affect.cvss_scores.find(({ issuer, cvss_version }) => issuer === 'RH' && cvss_version === 'V3');
-      if (cvssScore) {
-        cvssScore.vector = newValue;
+      const cvss = affect.cvss_scores.find(({ issuer, cvss_version }) => issuer === 'RH' && cvss_version === 'V3');
+      if (cvss) {
+        return `${cvss.score} ${cvss.vector}`;
       } else {
+        return '';
+      }
+    },
+    set(newValue: string) {
+      const cvssScoreIndex = affect.cvss_scores.findIndex(
+        ({ issuer, cvss_version }) =>
+          issuer === 'RH' && cvss_version === 'V3'
+      );
+      if (newValue === '' && cvssScoreIndex !== -1) {
+        affect.cvss_scores.splice(cvssScoreIndex, 1);
+      } else if (cvssScoreIndex !== -1) {
+        affect.cvss_scores[cvssScoreIndex].vector = newValue;
+      } else if (newValue !== '') {
         affect.cvss_scores.push({
           issuer: 'RH',
           cvss_version: 'V3',
@@ -1347,11 +1355,11 @@ function fileTrackersForAffects(affects: ZodAffectType[]) {
             }
 
             &:nth-of-type(3) {
-              width: 20%;
+              width: 10%;
             }
 
             &:nth-of-type(4) {
-              width: 20%;
+              width: 14%;
             }
 
             &:nth-of-type(5) {
@@ -1367,7 +1375,7 @@ function fileTrackersForAffects(affects: ZodAffectType[]) {
             }
 
             &:nth-of-type(8) {
-              width: 8%;
+              width: 28%;
             }
 
             &:nth-of-type(9) {
@@ -1375,7 +1383,7 @@ function fileTrackersForAffects(affects: ZodAffectType[]) {
             }
 
             &:nth-of-type(10) {
-              width: 8%;
+              width: 6%;
             }
 
             &:nth-of-type(11) {

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -52,6 +52,7 @@ const {
   flawReferences,
   flawAcknowledgments,
   affectsToDelete,
+  affectCvssToDelete,
   rhCvss3String,
   highlightedNvdCvss3String,
   shouldDisplayEmailNistForm,
@@ -435,6 +436,7 @@ const createdDate = computed(() => {
             v-if="mode === 'edit'"
             :affects="flaw.affects"
             :affectsToDelete="affectsToDelete"
+            :affectCvssToDelete="affectCvssToDelete"
             :error="errors.affects"
             :flawId="flaw.uuid"
             :embargoed="flaw.embargoed"

--- a/src/components/FlawTrackers.vue
+++ b/src/components/FlawTrackers.vue
@@ -448,6 +448,15 @@ function increaseItemsPerPage() {
       padding: .25rem;
       padding-left: .5rem;
     }
+
+    tbody {
+      tr td {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 150px;
+      }
+    }
   }
 }
 

--- a/src/components/__tests__/__snapshots__/FlawAffects.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawAffects.spec.ts.snap
@@ -80,7 +80,7 @@ exports[`FlawAffects > Correctly renders the component when there are affects to
         </tr>
       </thead>
       <tbody data-v-0fd8a3c0="">
-        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -90,7 +90,7 @@ exports[`FlawAffects > Correctly renders the component when there are affects to
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">4</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -101,7 +101,7 @@ exports[`FlawAffects > Correctly renders the component when there are affects to
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -111,7 +111,7 @@ exports[`FlawAffects > Correctly renders the component when there are affects to
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">0</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -122,7 +122,7 @@ exports[`FlawAffects > Correctly renders the component when there are affects to
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -132,7 +132,7 @@ exports[`FlawAffects > Correctly renders the component when there are affects to
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">0</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -143,7 +143,7 @@ exports[`FlawAffects > Correctly renders the component when there are affects to
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -153,7 +153,7 @@ exports[`FlawAffects > Correctly renders the component when there are affects to
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">0</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -164,7 +164,7 @@ exports[`FlawAffects > Correctly renders the component when there are affects to
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -174,7 +174,7 @@ exports[`FlawAffects > Correctly renders the component when there are affects to
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">2</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -185,7 +185,7 @@ exports[`FlawAffects > Correctly renders the component when there are affects to
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="border-bottom border-gray" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="border-bottom border-gray" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -195,7 +195,7 @@ exports[`FlawAffects > Correctly renders the component when there are affects to
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">WONTFIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">CRITICAL</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">0</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -526,7 +526,7 @@ exports[`FlawAffects > Displays tracker manager for a selection of affects 1`] =
         </tr>
       </thead>
       <tbody data-v-0fd8a3c0="">
-        <tr data-v-0fd8a3c0="" class="selected" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="selected" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input" checked=""></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -536,7 +536,7 @@ exports[`FlawAffects > Displays tracker manager for a selection of affects 1`] =
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">4</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -547,7 +547,7 @@ exports[`FlawAffects > Displays tracker manager for a selection of affects 1`] =
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="selected" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="selected" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input" checked=""></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -557,7 +557,7 @@ exports[`FlawAffects > Displays tracker manager for a selection of affects 1`] =
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">0</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -568,7 +568,7 @@ exports[`FlawAffects > Displays tracker manager for a selection of affects 1`] =
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="selected" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="selected" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input" checked=""></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -578,7 +578,7 @@ exports[`FlawAffects > Displays tracker manager for a selection of affects 1`] =
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">0</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -589,7 +589,7 @@ exports[`FlawAffects > Displays tracker manager for a selection of affects 1`] =
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -599,7 +599,7 @@ exports[`FlawAffects > Displays tracker manager for a selection of affects 1`] =
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">0</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -610,7 +610,7 @@ exports[`FlawAffects > Displays tracker manager for a selection of affects 1`] =
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -620,7 +620,7 @@ exports[`FlawAffects > Displays tracker manager for a selection of affects 1`] =
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">2</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -631,7 +631,7 @@ exports[`FlawAffects > Displays tracker manager for a selection of affects 1`] =
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="border-bottom border-gray" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="border-bottom border-gray" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -641,7 +641,7 @@ exports[`FlawAffects > Displays tracker manager for a selection of affects 1`] =
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">WONTFIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">CRITICAL</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">0</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -908,7 +908,7 @@ exports[`FlawAffects > Displays tracker manager for individual affect 1`] = `
         </tr>
       </thead>
       <tbody data-v-0fd8a3c0="">
-        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -918,7 +918,7 @@ exports[`FlawAffects > Displays tracker manager for individual affect 1`] = `
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">4</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -929,7 +929,7 @@ exports[`FlawAffects > Displays tracker manager for individual affect 1`] = `
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -939,7 +939,7 @@ exports[`FlawAffects > Displays tracker manager for individual affect 1`] = `
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">0</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -950,7 +950,7 @@ exports[`FlawAffects > Displays tracker manager for individual affect 1`] = `
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -960,7 +960,7 @@ exports[`FlawAffects > Displays tracker manager for individual affect 1`] = `
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">0</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -971,7 +971,7 @@ exports[`FlawAffects > Displays tracker manager for individual affect 1`] = `
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -981,7 +981,7 @@ exports[`FlawAffects > Displays tracker manager for individual affect 1`] = `
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">0</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -992,7 +992,7 @@ exports[`FlawAffects > Displays tracker manager for individual affect 1`] = `
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -1002,7 +1002,7 @@ exports[`FlawAffects > Displays tracker manager for individual affect 1`] = `
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">2</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>
@@ -1013,7 +1013,7 @@ exports[`FlawAffects > Displays tracker manager for individual affect 1`] = `
             <!--v-if--><i data-v-0fd8a3c0="" class="row-right-indicator bi bi-caret-left-fill fs-4"></i>
           </td>
         </tr>
-        <tr data-v-0fd8a3c0="" class="border-bottom border-gray" style="cursor: pointer;">
+        <tr data-v-0fd8a3c0="" class="border-bottom border-gray" style="cursor: pointer;" title="">
           <td data-v-0fd8a3c0=""><i data-v-0fd8a3c0="" class="row-left-indicator bi bi-caret-right-fill fs-4"></i><input data-v-0fd8a3c0="" type="checkbox" class="form-check-input"></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
@@ -1023,7 +1023,7 @@ exports[`FlawAffects > Displays tracker manager for individual affect 1`] = `
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">WONTFIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">CRITICAL</span></td>
-          <td data-v-0fd8a3c0=""></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="affect-tracker-cell"><span data-v-0fd8a3c0="" class="me-2 my-auto">0</span><button data-v-0fd8a3c0="" type="button" class="btn btn-sm px-1 py-0 d-flex rounded-circle"><i data-v-0fd8a3c0="" class="bi bi-plus lh-sm m-auto"></i></button></div>
           </td>

--- a/src/services/AffectService.ts
+++ b/src/services/AffectService.ts
@@ -95,3 +95,12 @@ export async function postAffectCvssScore(affectId: string, cvssScoreObject: unk
     .then((response) => response.data)
     .catch(createCatchHandler('Problem updating affect CVSS scores:'));
 }
+
+export async function deleteAffectCvssScore(affectId: string, cvssScoresId: string) {
+  return osidbFetch({
+    method: 'delete',
+    url: `/osidb/api/v1/affects/${affectId}/cvss_scores/${cvssScoresId}`,
+  })
+    .then((response) => response.data)
+    .catch(createCatchHandler('Problem deleting affect CVSS scores:'));
+}


### PR DESCRIPTION
# OSIDB-3397 Fix Affects CVSS CRUD operations

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Fixes the bug of invalid CVSS field on the new affect section.
Implements the possibility to remove CVSS on affects.

## Changes:

- Fix affect's CVSS field
- Adjust affect table columns to correctly display CVSS vectors
- Adds truncation to flaw fields that have larger length than the table cell
- Adds the CVSS score to the affect CVSS vector when not editing it
- Implements the possibility to remove affect's CVSS

## Demo:
https://github.com/user-attachments/assets/253ab093-cbdd-4b5e-820e-d3fa7175fd3f


## Considerations:

- Possibly impacting on https://github.com/RedHatProductSecurity/osim/pull/401 @superbuggy 
- affect cvss "model" logic was placed within the affect component for simplicity (also considering the component will be refactored), but an independent composable with that logic could be considered in the future.

Closes OSIDB-3397
