### PR TITLE
OSIDB-3415: Create `useSetup` helper for testing composables

### DIFF
--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,3 +1,6 @@
+import type { App } from 'vue';
+import { createApp } from 'vue';
+
 import { createHmac } from 'node:crypto';
 
 const encoding = (str: string) =>
@@ -21,3 +24,15 @@ export const encodeJWT = (payload: unknown) => {
 
   return segments.concat(signature).join('.');
 };
+
+export function withSetup<T>(composable: () => T): [T, App] {
+  let result: T;
+  const app = createApp({
+    setup() {
+      result = composable();
+      return () => { };
+    },
+  });
+  app.mount(document.createElement('div'));
+  return [result!, app];
+}

--- a/src/composables/useSearchParams.ts
+++ b/src/composables/useSearchParams.ts
@@ -10,10 +10,6 @@ type Facet = {
   value: string;
 };
 
-const facets = ref<Facet[]>([]);
-const query = ref<string>('');
-const search = ref('');
-
 const searchQuery = z.object({
   query: z.object({
     search: z.string().nullish(),
@@ -21,9 +17,12 @@ const searchQuery = z.object({
   }),
 });
 
+const facets = ref<Facet[]>([]);
+const query = ref<string>('');
+const search = ref('');
+
 export function useSearchParams() {
   const route = useRoute();
-
   const router = useRouter();
 
   const populateFacets = (): Facet[] => {
@@ -66,6 +65,8 @@ export function useSearchParams() {
 
   onMounted(() => {
     facets.value = populateFacets();
+    search.value = `${route.query.search || ''}`;
+    query.value = `${route.query.query || ''}`;
   });
 
   watchEffect(() => {


### PR DESCRIPTION
# OSIDB-3415: Create `useSetup` helper for testing composables

## Checklist:

- [x] Commits consolidated
- [ ] ~Changelog updated~
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Created `useSetup` helper for testing composables that need lifecyle hooks.
Fixed `useSeachParams` tests

## Changes:

Using lifecycle hooks outside of Vue throws a warning on the console:
```
[Vue warn]: onMounted is called when there is no active component instance to be associated with.
Lifecycle injection APIs can only be used during execution of setup().
If you are using async setup(), make sure to register lifecycle hooks before the first await statement.
```
The `useSetup` helper creates a volatile Vue app to mount the composable inside so the lifecycle hooks are triggered. This not only makes the test output cleaner but also the tests itself is more robust, as prior to this the lifecycle hooks were not triggering

## Considerations:

> [!NOTE]
> Depends on the changes made to `FlawSearchView.spec.ts` in #400

Closes OSIDB-3415