### PR TITLE
OSIDB-3416: Mock osimRuntime globally

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,0 +1,33 @@
+vi.mock('@/stores/osimRuntime', async (importOriginal) => {
+  const { ref } = await import('vue');
+  const osimRuntime = await importOriginal<typeof import('@/stores/osimRuntime')>();
+
+  return ({
+    OsimRuntimeStatus: osimRuntime.OsimRuntimeStatus,
+    setup: vi.fn(),
+    osimRuntimeStatus: ref(osimRuntime.OsimRuntimeStatus.READY),
+    osidbHealth: ref({
+      env: 'test',
+      revision: '1',
+      version: '1.0.0',
+    }),
+    osimRuntime: ref({
+      readOnly: false,
+      env: 'test',
+      osimVersion: { rev: '1', tag: '1.0.0', timestamp: new Date('2024-08-29T14:00:00Z').toISOString() },
+      error: 'OSIDB is not ready',
+      backends: {
+        osidb: '',
+        osidbAuth: 'credentials',
+        bugzilla: '',
+        jira: '',
+        errata: '',
+        jiraDisplay: '',
+      },
+    }),
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});

--- a/src/components/__tests__/App.spec.ts
+++ b/src/components/__tests__/App.spec.ts
@@ -18,24 +18,6 @@ const mountApp = () => shallowMount(App, {
 });
 
 describe('app', () => {
-  vi.mock('@/stores/osimRuntime', async (importOriginal) => {
-    const { ref } = await import('vue');
-    const osimRuntime = await importOriginal<typeof import('@/stores/osimRuntime')>();
-
-    return {
-      ...osimRuntime,
-      setup: vi.fn(),
-      osimRuntimeStatus: ref(osimRuntime.OsimRuntimeStatus.READY),
-      osimRuntime: ref({
-        readOnly: false,
-        env: 'dev',
-        osimVersion: { rev: '1', tag: '1.0.0', timestamp: '2024-08-29' },
-        error: 'OSIDB is not ready',
-        backends: {},
-      }),
-    };
-  });
-
   afterEach(() => {
     vi.resetAllMocks();
   });

--- a/src/components/__tests__/FlawComments.spec.ts
+++ b/src/components/__tests__/FlawComments.spec.ts
@@ -9,39 +9,6 @@ import { searchJiraUsers } from '@/services/JiraService';
 
 createTestingPinia();
 
-vi.mock('@/stores/osimRuntime', async () => {
-  const osimRuntimeValue = {
-    env: 'unittest',
-    backends: {
-      osidb: 'http://osidb-backend',
-      bugzilla: 'http://bugzilla-backend',
-      jira: 'http://jira-backend',
-      errata: 'http://errata',
-      jiraDisplay: 'http://jira-backend',
-    },
-    osimVersion: {
-      rev: 'osimrev', tag: 'osimtag', timestamp: '1970-01-01T00:00:00Z', dirty: true,
-    },
-    error: '',
-  };
-  return {
-    setup: vi.fn(() => { }),
-    osimRuntimeStatus: 1,
-    osidbHealth: {
-      revision: '',
-    },
-    osimRuntime: {
-      value: osimRuntimeValue,
-      ...osimRuntimeValue,
-    },
-    OsimRuntimeStatus: {
-      INIT: 0,
-      READY: 1,
-      ERROR: 2,
-    },
-  };
-});
-
 vi.mock('@/services/JiraService', () => ({
   searchJiraUsers: vi.fn(() => Promise.resolve([])),
   jiraTaskUrl: vi.fn((taskKey: string) => `http://jira-backend/browse/${taskKey}`),

--- a/src/components/__tests__/Navbar.spec.ts
+++ b/src/components/__tests__/Navbar.spec.ts
@@ -65,14 +65,6 @@ describe('navbar', () => {
       createSpy: vitest.fn,
       stubActions: false,
     });
-    vi.mock('@/stores/osimRuntime', async () => {
-      const osimRuntimeValue = { env: 'unittest' };
-      return {
-        osimRuntime: {
-          ...osimRuntimeValue,
-        },
-      };
-    });
     subject = mount(Navbar, {
       global: {
         plugins: [

--- a/src/components/__tests__/__snapshots__/App.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/App.spec.ts.snap
@@ -14,8 +14,8 @@ exports[`app > renders the App component when OSIDB is READY 1`] = `
   <!--TODO add active request count-->
   <!--<div>[ Requests: {{ activeRequestCount }} ]</div>-->
   <change-log-stub></change-log-stub>
-  <div> [ OSIM | env: dev | <span title="1"> tag: 1.0.0</span> | ts : () ] </div>
-  <div> [ OSIDB | env: | <span title="">ver: </span> ] </div>
+  <div> [ OSIM | env: test | <span title="1"> tag: 1.0.0</span> | ts : 2024-08-29 () ] </div>
+  <div> [ OSIDB | env: test | <span title="1">ver: 1.0.0</span> ] </div>
   <div class="osim-status-osidb-err"> [err: OSIDB is not ready] </div>
 </footer>"
 `;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,9 @@ export default defineConfig(configEnv =>
         root: fileURLToPath(new URL('./', import.meta.url)),
         globals: true,
         onConsoleLog: (_, type) => type === 'stderr',
+        setupFiles: [
+          './src/__tests__/setup.ts',
+        ],
         globalSetup: [
           // './src/__tests__/global-setup.ts',
         ],


### PR DESCRIPTION
# OSIDB-3416: Mock osimRuntime globally

## Checklist:

- [x] Commits consolidated
- [ ] ~Changelog updated~
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Some tests were indirectly calling the `setup` function of `osimRuntime` which tried to fetch `/runtime.json` and also OSIDB api.
Since `osimRuntime` only returns an object with runtime information, I decided to provide a global mock, fixing the network requests issues and also removing the need to manually mock it on each test when needed 

## Changes:

Configured vitest **setupFiles** for global test configuration.

## Considerations:

Closes OSIDB-3416