### PR TITLE
OSIDB-3417: Catch network requests on tests

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,0 +1,33 @@
+vi.mock('@/stores/osimRuntime', async (importOriginal) => {
+  const { ref } = await import('vue');
+  const osimRuntime = await importOriginal<typeof import('@/stores/osimRuntime')>();
+
+  return ({
+    OsimRuntimeStatus: osimRuntime.OsimRuntimeStatus,
+    setup: vi.fn(),
+    osimRuntimeStatus: ref(osimRuntime.OsimRuntimeStatus.READY),
+    osidbHealth: ref({
+      env: 'test',
+      revision: '1',
+      version: '1.0.0',
+    }),
+    osimRuntime: ref({
+      readOnly: false,
+      env: 'test',
+      osimVersion: { rev: '1', tag: '1.0.0', timestamp: new Date('2024-08-29T14:00:00Z').toISOString() },
+      error: 'OSIDB is not ready',
+      backends: {
+        osidb: '',
+        osidbAuth: 'credentials',
+        bugzilla: '',
+        jira: '',
+        errata: '',
+        jiraDisplay: '',
+      },
+    }),
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});

--- a/src/components/__tests__/App.spec.ts
+++ b/src/components/__tests__/App.spec.ts
@@ -18,24 +18,6 @@ const mountApp = () => shallowMount(App, {
 });
 
 describe('app', () => {
-  vi.mock('@/stores/osimRuntime', async (importOriginal) => {
-    const { ref } = await import('vue');
-    const osimRuntime = await importOriginal<typeof import('@/stores/osimRuntime')>();
-
-    return {
-      ...osimRuntime,
-      setup: vi.fn(),
-      osimRuntimeStatus: ref(osimRuntime.OsimRuntimeStatus.READY),
-      osimRuntime: ref({
-        readOnly: false,
-        env: 'dev',
-        osimVersion: { rev: '1', tag: '1.0.0', timestamp: '2024-08-29' },
-        error: 'OSIDB is not ready',
-        backends: {},
-      }),
-    };
-  });
-
   afterEach(() => {
     vi.resetAllMocks();
   });

--- a/src/components/__tests__/FlawAffects.spec.ts
+++ b/src/components/__tests__/FlawAffects.spec.ts
@@ -8,6 +8,11 @@ import { osimEmptyFlawTest, osimFullFlawTest } from './test-suite-helpers';
 
 createTestingPinia();
 
+vi.mock('@/composables/useTrackers', () => ({
+  useTrackers: vi.fn().mockReturnValue({
+    trackersToFile: [],
+  }),
+}));
 describe('flawAffects', () => {
   let subject;
 

--- a/src/components/__tests__/FlawComments.spec.ts
+++ b/src/components/__tests__/FlawComments.spec.ts
@@ -9,39 +9,6 @@ import { searchJiraUsers } from '@/services/JiraService';
 
 createTestingPinia();
 
-vi.mock('@/stores/osimRuntime', async () => {
-  const osimRuntimeValue = {
-    env: 'unittest',
-    backends: {
-      osidb: 'http://osidb-backend',
-      bugzilla: 'http://bugzilla-backend',
-      jira: 'http://jira-backend',
-      errata: 'http://errata',
-      jiraDisplay: 'http://jira-backend',
-    },
-    osimVersion: {
-      rev: 'osimrev', tag: 'osimtag', timestamp: '1970-01-01T00:00:00Z', dirty: true,
-    },
-    error: '',
-  };
-  return {
-    setup: vi.fn(() => { }),
-    osimRuntimeStatus: 1,
-    osidbHealth: {
-      revision: '',
-    },
-    osimRuntime: {
-      value: osimRuntimeValue,
-      ...osimRuntimeValue,
-    },
-    OsimRuntimeStatus: {
-      INIT: 0,
-      READY: 1,
-      ERROR: 2,
-    },
-  };
-});
-
 vi.mock('@/services/JiraService', () => ({
   searchJiraUsers: vi.fn(() => Promise.resolve([])),
   jiraTaskUrl: vi.fn((taskKey: string) => `http://jira-backend/browse/${taskKey}`),

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -1,4 +1,3 @@
-import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { describe, it, expect, vi, type Mock } from 'vitest';
 import { useRouter } from 'vue-router';
@@ -19,12 +18,13 @@ import LabelStatic from '@/components/widgets/LabelStatic.vue';
 
 import { blankFlaw } from '@/composables/useFlawModel';
 
+import { server } from '@/__tests__/setup';
+import { flawSources } from '@/types/zodFlaw';
 import { useToastStore } from '@/stores/ToastStore';
 import { LoadingAnimationDirective } from '@/directives/LoadingAnimationDirective.js';
 import {
   Source521Enum,
 } from '@/generated-client';
-import { flawSources } from '@/types/zodFlaw';
 
 import IssueFieldEmbargo from '../IssueFieldEmbargo.vue';
 import { osimFullFlawTest } from './test-suite-helpers';
@@ -47,8 +47,6 @@ const putHandler = http.put(`${FLAW_BASE_URI}/:id`, async ({ request }) => {
   const requestBody = decoder.decode(result.value);
   return HttpResponse.json(JSON.parse(requestBody));
 });
-
-const server = setupServer(putHandler);
 
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual('vue-router');
@@ -99,8 +97,6 @@ describe('flawForm', () => {
       },
     });
 
-    server.listen({ onUnhandledRequest: 'error' });
-
     (useRouter as Mock).mockReturnValue({
       currentRoute: { value: { fullPath: '/flaws/uuiddddd' } },
     });
@@ -129,8 +125,9 @@ describe('flawForm', () => {
     });
   });
 
-  afterEach(() => server.resetHandlers());
-  afterAll(() => server.close());
+  beforeEach(() => {
+    server.use(putHandler);
+  });
 
   it('mounts and renders', async () => {
     expect(subject.exists()).toBe(true);

--- a/src/components/__tests__/FlawTrackers.spec.ts
+++ b/src/components/__tests__/FlawTrackers.spec.ts
@@ -7,6 +7,11 @@ import FlawTrackers from '@/components/FlawTrackers.vue';
 import { osimFullFlawTest, osimRequiredFlawTest } from './test-suite-helpers';
 
 createTestingPinia();
+vi.mock('@/composables/useTrackers', () => ({
+  useTrackers: vi.fn().mockReturnValue({
+    trackersToFile: [],
+  }),
+}));
 
 describe('flawTrackers', () => {
   let subject;

--- a/src/components/__tests__/Navbar.spec.ts
+++ b/src/components/__tests__/Navbar.spec.ts
@@ -65,14 +65,6 @@ describe('navbar', () => {
       createSpy: vitest.fn,
       stubActions: false,
     });
-    vi.mock('@/stores/osimRuntime', async () => {
-      const osimRuntimeValue = { env: 'unittest' };
-      return {
-        osimRuntime: {
-          ...osimRuntimeValue,
-        },
-      };
-    });
     subject = mount(Navbar, {
       global: {
         plugins: [

--- a/src/components/__tests__/__snapshots__/App.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/App.spec.ts.snap
@@ -14,8 +14,8 @@ exports[`app > renders the App component when OSIDB is READY 1`] = `
   <!--TODO add active request count-->
   <!--<div>[ Requests: {{ activeRequestCount }} ]</div>-->
   <change-log-stub></change-log-stub>
-  <div> [ OSIM | env: dev | <span title="1"> tag: 1.0.0</span> | ts : () ] </div>
-  <div> [ OSIDB | env: | <span title="">ver: </span> ] </div>
+  <div> [ OSIM | env: test | <span title="1"> tag: 1.0.0</span> | ts : 2024-08-29 () ] </div>
+  <div> [ OSIDB | env: test | <span title="1">ver: 1.0.0</span> ] </div>
   <div class="osim-status-osidb-err"> [err: OSIDB is not ready] </div>
 </footer>"
 `;

--- a/src/components/__tests__/__snapshots__/FlawAffects.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawAffects.spec.ts.snap
@@ -776,7 +776,7 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
         <div data-v-a347fd2c="" class="modal-body">
           <div data-v-4977998e="" data-v-0fd8a3c0="" class="trackers-manager py-3 px-4">
             <!--v-if-->
-            <div data-v-4977998e="" class="trackers-search-bar gap-2"><input data-v-4977998e="" type="text" class="form-control form-control-sm" placeholder="Filter by stream or component name"><button data-v-4977998e="" type="button" disabled="" class="btn btn-sm btn-black"><i data-v-4977998e="" class="bi bi-check-all"></i> Select All </button><button data-v-4977998e="" type="button" disabled="" class="btn btn-sm btn-black"><i data-v-4977998e="" class="bi bi-x-square"></i> Deselect All </button></div>
+            <div data-v-4977998e="" class="trackers-search-bar gap-2"><input data-v-4977998e="" type="text" class="form-control form-control-sm" placeholder="Filter by stream or component name"><button data-v-4977998e="" type="button" class="btn btn-sm btn-black"><i data-v-4977998e="" class="bi bi-check-all"></i> Select All </button><button data-v-4977998e="" type="button" class="btn btn-sm btn-black"><i data-v-4977998e="" class="bi bi-x-square"></i> Deselect All </button></div>
             <div class="row mt-3" data-v-4977998e="">
               <div class="col" data-v-4977998e="">
                 <h5 class="d-inline-block fs-5" data-v-4977998e="">Available Trackers</h5><span class="fst-italic" data-v-4977998e=""> (<i class="bi bi-box-arrow-in-right" data-v-4977998e=""></i> indicates a Suggested Tracker) </span>
@@ -788,27 +788,27 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             <div data-v-4977998e="" class="row">
               <div data-v-4977998e="" class="col">
                 <div data-v-4977998e="" class="mb-2">
-                  <div data-v-4977998e="" class="ms-2 mb-1"><span data-v-4977998e="" class="spinner-border spinner-border-sm" role="status"><span data-v-4977998e="" class="visually-hidden">Loading...</span></span><span data-v-4977998e="">Loading trackers…</span></div>
                   <!--v-if-->
+                  <div data-v-4977998e="" class="osim-tracker-list"></div>
                 </div>
               </div>
               <div data-v-4977998e="" class="col">
                 <div data-v-4977998e="" class="mb-2">
-                  <div data-v-4977998e="" class="ms-2 mb-1"><span data-v-4977998e="" class="spinner-border spinner-border-sm" role="status"><span data-v-4977998e="" class="visually-hidden">Loading...</span></span><span data-v-4977998e="">Loading trackers…</span></div>
                   <!--v-if-->
+                  <div data-v-4977998e="" class="osim-tracker-list"></div>
                 </div>
               </div>
             </div>
             <div data-v-4977998e="" class="row mt-4">
               <div data-v-4977998e="" class="col mb-2">
                 <h5 data-v-4977998e="">Already Filed</h5>
-                <div data-v-4977998e="" class="ms-2 mb-1"><span data-v-4977998e="" class="spinner-border spinner-border-sm" role="status"><span data-v-4977998e="" class="visually-hidden">Loading...</span></span><span data-v-4977998e="">Loading trackers…</span></div>
                 <!--v-if-->
+                <div data-v-4977998e="" class="osim-tracker-list"></div>
               </div>
               <div data-v-4977998e="" class="col">
                 <div data-v-4977998e="">
                   <h5 data-v-4977998e="">Untrackable Affects <i data-v-4977998e="" class="bi bi-exclamation-circle text-danger" title="These affects do not have available trackers. This may indicate an issue with product defintions. Please contact the OSIDB/OSIM team for assistance."></i></h5>
-                  <div data-v-4977998e="" class="ms-2 mb-1"><span data-v-4977998e="" class="spinner-border spinner-border-sm" role="status"><span data-v-4977998e="" class="visually-hidden">Loading...</span></span><span data-v-4977998e="">Loading trackers…</span></div>
+                  <!--v-if-->
                   <!--v-if-->
                   <!--v-if-->
                 </div>
@@ -1158,7 +1158,7 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
         <div data-v-a347fd2c="" class="modal-body">
           <div data-v-4977998e="" data-v-0fd8a3c0="" class="trackers-manager py-3 px-4">
             <!--v-if-->
-            <div data-v-4977998e="" class="trackers-search-bar gap-2"><input data-v-4977998e="" type="text" class="form-control form-control-sm" placeholder="Filter by stream or component name"><button data-v-4977998e="" type="button" disabled="" class="btn btn-sm btn-black"><i data-v-4977998e="" class="bi bi-check-all"></i> Select All </button><button data-v-4977998e="" type="button" disabled="" class="btn btn-sm btn-black"><i data-v-4977998e="" class="bi bi-x-square"></i> Deselect All </button></div>
+            <div data-v-4977998e="" class="trackers-search-bar gap-2"><input data-v-4977998e="" type="text" class="form-control form-control-sm" placeholder="Filter by stream or component name"><button data-v-4977998e="" type="button" class="btn btn-sm btn-black"><i data-v-4977998e="" class="bi bi-check-all"></i> Select All </button><button data-v-4977998e="" type="button" class="btn btn-sm btn-black"><i data-v-4977998e="" class="bi bi-x-square"></i> Deselect All </button></div>
             <div class="row mt-3" data-v-4977998e="">
               <div class="col" data-v-4977998e="">
                 <h5 class="d-inline-block fs-5" data-v-4977998e="">Available Trackers</h5><span class="fst-italic" data-v-4977998e=""> (<i class="bi bi-box-arrow-in-right" data-v-4977998e=""></i> indicates a Suggested Tracker) </span>
@@ -1170,27 +1170,27 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             <div data-v-4977998e="" class="row">
               <div data-v-4977998e="" class="col">
                 <div data-v-4977998e="" class="mb-2">
-                  <div data-v-4977998e="" class="ms-2 mb-1"><span data-v-4977998e="" class="spinner-border spinner-border-sm" role="status"><span data-v-4977998e="" class="visually-hidden">Loading...</span></span><span data-v-4977998e="">Loading trackers…</span></div>
                   <!--v-if-->
+                  <div data-v-4977998e="" class="osim-tracker-list"></div>
                 </div>
               </div>
               <div data-v-4977998e="" class="col">
                 <div data-v-4977998e="" class="mb-2">
-                  <div data-v-4977998e="" class="ms-2 mb-1"><span data-v-4977998e="" class="spinner-border spinner-border-sm" role="status"><span data-v-4977998e="" class="visually-hidden">Loading...</span></span><span data-v-4977998e="">Loading trackers…</span></div>
                   <!--v-if-->
+                  <div data-v-4977998e="" class="osim-tracker-list"></div>
                 </div>
               </div>
             </div>
             <div data-v-4977998e="" class="row mt-4">
               <div data-v-4977998e="" class="col mb-2">
                 <h5 data-v-4977998e="">Already Filed</h5>
-                <div data-v-4977998e="" class="ms-2 mb-1"><span data-v-4977998e="" class="spinner-border spinner-border-sm" role="status"><span data-v-4977998e="" class="visually-hidden">Loading...</span></span><span data-v-4977998e="">Loading trackers…</span></div>
                 <!--v-if-->
+                <div data-v-4977998e="" class="osim-tracker-list"></div>
               </div>
               <div data-v-4977998e="" class="col">
                 <div data-v-4977998e="">
                   <h5 data-v-4977998e="">Untrackable Affects <i data-v-4977998e="" class="bi bi-exclamation-circle text-danger" title="These affects do not have available trackers. This may indicate an issue with product defintions. Please contact the OSIDB/OSIM team for assistance."></i></h5>
-                  <div data-v-4977998e="" class="ms-2 mb-1"><span data-v-4977998e="" class="spinner-border spinner-border-sm" role="status"><span data-v-4977998e="" class="visually-hidden">Loading...</span></span><span data-v-4977998e="">Loading trackers…</span></div>
+                  <!--v-if-->
                   <!--v-if-->
                   <!--v-if-->
                 </div>

--- a/src/components/__tests__/__snapshots__/FlawTrackers.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawTrackers.spec.ts.snap
@@ -258,7 +258,7 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
   </div>
   <div data-v-4977998e="" data-v-7006d35c="" class="trackers-manager py-3 px-4 embedded">
     <h4 data-v-4977998e="" class="mb-2 d-flex"> Trackers Manager </h4>
-    <div data-v-4977998e="" class="trackers-search-bar gap-2"><input data-v-4977998e="" type="text" class="form-control form-control-sm" placeholder="Filter by stream or component name"><button data-v-4977998e="" type="button" disabled="" class="btn btn-sm btn-black"><i data-v-4977998e="" class="bi bi-check-all"></i> Select All </button><button data-v-4977998e="" type="button" disabled="" class="btn btn-sm btn-black"><i data-v-4977998e="" class="bi bi-x-square"></i> Deselect All </button></div>
+    <div data-v-4977998e="" class="trackers-search-bar gap-2"><input data-v-4977998e="" type="text" class="form-control form-control-sm" placeholder="Filter by stream or component name"><button data-v-4977998e="" type="button" class="btn btn-sm btn-black"><i data-v-4977998e="" class="bi bi-check-all"></i> Select All </button><button data-v-4977998e="" type="button" class="btn btn-sm btn-black"><i data-v-4977998e="" class="bi bi-x-square"></i> Deselect All </button></div>
     <div class="row mt-3" data-v-4977998e="">
       <div class="col" data-v-4977998e="">
         <h5 class="d-inline-block fs-5" data-v-4977998e="">Available Trackers</h5><span class="fst-italic" data-v-4977998e=""> (<i class="bi bi-box-arrow-in-right" data-v-4977998e=""></i> indicates a Suggested Tracker) </span>
@@ -270,27 +270,27 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
     <div data-v-4977998e="" class="row">
       <div data-v-4977998e="" class="col">
         <div data-v-4977998e="" class="mb-2">
-          <div data-v-4977998e="" class="ms-2 mb-1"><span data-v-4977998e="" class="spinner-border spinner-border-sm" role="status"><span data-v-4977998e="" class="visually-hidden">Loading...</span></span><span data-v-4977998e="">Loading trackers…</span></div>
           <!--v-if-->
+          <div data-v-4977998e="" class="osim-tracker-list"></div>
         </div>
       </div>
       <div data-v-4977998e="" class="col">
         <div data-v-4977998e="" class="mb-2">
-          <div data-v-4977998e="" class="ms-2 mb-1"><span data-v-4977998e="" class="spinner-border spinner-border-sm" role="status"><span data-v-4977998e="" class="visually-hidden">Loading...</span></span><span data-v-4977998e="">Loading trackers…</span></div>
           <!--v-if-->
+          <div data-v-4977998e="" class="osim-tracker-list"></div>
         </div>
       </div>
     </div>
     <div data-v-4977998e="" class="row mt-4">
       <div data-v-4977998e="" class="col mb-2">
         <h5 data-v-4977998e="">Already Filed</h5>
-        <div data-v-4977998e="" class="ms-2 mb-1"><span data-v-4977998e="" class="spinner-border spinner-border-sm" role="status"><span data-v-4977998e="" class="visually-hidden">Loading...</span></span><span data-v-4977998e="">Loading trackers…</span></div>
         <!--v-if-->
+        <div data-v-4977998e="" class="osim-tracker-list"></div>
       </div>
       <div data-v-4977998e="" class="col">
         <div data-v-4977998e="">
           <h5 data-v-4977998e="">Untrackable Affects <i data-v-4977998e="" class="bi bi-exclamation-circle text-danger" title="These affects do not have available trackers. This may indicate an issue with product defintions. Please contact the OSIDB/OSIM team for assistance."></i></h5>
-          <div data-v-4977998e="" class="ms-2 mb-1"><span data-v-4977998e="" class="spinner-border spinner-border-sm" role="status"><span data-v-4977998e="" class="visually-hidden">Loading...</span></span><span data-v-4977998e="">Loading trackers…</span></div>
+          <!--v-if-->
           <!--v-if-->
           <!--v-if-->
         </div>

--- a/src/services/__tests__/OsidbAuthService.spec.ts
+++ b/src/services/__tests__/OsidbAuthService.spec.ts
@@ -1,10 +1,10 @@
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
 import { createPinia, setActivePinia } from 'pinia';
 import { DateTime } from 'luxon';
 
 import { useUserStore } from '@/stores/UserStore';
 import { encodeJWT } from '@/__tests__/helpers';
+import { server } from '@/__tests__/setup';
 
 import { getNextAccessToken } from '../OsidbAuthService';
 
@@ -21,14 +21,9 @@ describe('osidbAuthService', () => {
     return HttpResponse.json({ access: accessJWT });
   });
 
-  const server = setupServer(refreshEndpoint);
-
-  beforeAll(() => {
-    server.listen({ onUnhandledRequest: 'error' });
-  });
-
   beforeEach(() => {
     setActivePinia(createPinia());
+    server.use(refreshEndpoint);
 
     vi.useFakeTimers({
       now: new Date('2024-08-29T11:42:58.000Z'),
@@ -36,7 +31,6 @@ describe('osidbAuthService', () => {
   });
 
   afterEach(() => {
-    server.restoreHandlers();
     vi.clearAllTimers();
     vi.useRealTimers();
   });
@@ -63,7 +57,6 @@ describe('osidbAuthService', () => {
 
     const token = await getNextAccessToken();
 
-    expect(refreshEndpoint.isUsed).toBeFalsy();
     expect(token).toEqual(accessToken);
   });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,9 @@ export default defineConfig(configEnv =>
         root: fileURLToPath(new URL('./', import.meta.url)),
         globals: true,
         onConsoleLog: (_, type) => type === 'stderr',
+        setupFiles: [
+          './src/__tests__/setup.ts',
+        ],
         globalSetup: [
           // './src/__tests__/global-setup.ts',
         ],


### PR DESCRIPTION
# OSIDB-3417: Catch network requests on tests

## Checklist:

- [x] Commits consolidated
- [ ] ~Changelog updated~
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Some tests were not properly mocked and tried to reach the network.
Configured a global `msw` network server to catch al the requests and force test failure to assist in writing better tests.

From now on, instead of importing `setupServer` from `msw/node` you should import `server` from the setup and add your handlers with `server.use()`

## Changes:

* Created a global `msw` server
* Custom `onUnhandledRequest` callback to force fail the tests instead of just logging an error
* Fixed the tests that were failing after the changes

## Considerations:

> [!NOTE]
> Branch created from #410 
> This needs to be merged after it

Closes OSIDB-3417