### PR TITLE
🐛 Fix trackers refreshing after file

### DIFF
--- a/src/components/FlawAffects.vue
+++ b/src/components/FlawAffects.vue
@@ -1209,6 +1209,7 @@ function fileTrackersForAffects(affects: ZodAffectType[]) {
       :displayedTrackers="displayedTrackers"
       :affectsNotBeingDeleted="affects"
       :allTrackersCount="allTrackers.length"
+      @affects:refresh="emit('affects:refresh')"
     />
   </div>
   <Modal :show="isModalOpen" style="max-width: 75%;" @close="closeModal">

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -23,6 +23,7 @@ import { useFlawModel } from '@/composables/useFlawModel';
 import { type ZodFlawType, descriptionRequiredStates, flawSources } from '@/types/zodFlaw';
 import { useDraftFlawStore } from '@/stores/DraftFlawStore';
 import { deepCopyFromRaw } from '@/utils/helpers';
+import type { ZodAffectType } from '@/types/zodAffect';
 
 import CvssExplainForm from './CvssExplainForm.vue';
 import IssueFieldAcknowledgments from './IssueFieldAcknowledgments.vue';
@@ -440,9 +441,9 @@ const createdDate = computed(() => {
             :error="errors.affects"
             :flawId="flaw.uuid"
             :embargoed="flaw.embargoed"
-            @affect:recover="(affect) => recoverAffect(affectsToDelete.indexOf(affect))"
-            @affect:remove="(affect) => removeAffect(flaw.affects.indexOf(affect))"
-            @affects:refresh="refreshAffects"
+            @affect:recover="(affect: ZodAffectType) => recoverAffect(affectsToDelete.indexOf(affect))"
+            @affect:remove="(affect: ZodAffectType) => removeAffect(flaw.affects.indexOf(affect))"
+            @affects:refresh="refreshAffects()"
             @affect:add="addAffect"
           />
         </div>

--- a/src/components/TrackerManager.vue
+++ b/src/components/TrackerManager.vue
@@ -52,7 +52,7 @@ const selectedAffectStreams = computed(() => {
 });
 
 function handleFileTrackers() {
-  fileTrackers().finally(() => {
+  fileTrackers().then(() => {
     emit('affects-trackers:refresh');
   });
 }


### PR DESCRIPTION
# OSIDB-3427 After filed tracker, the tracker section not automatically refreshed

## Checklist:

- [x] Commits consolidated
- [-] Changelog updated
- [-] Test cases added/updated
- [x] Jira ticket updated

## Summary:
Fixes a bug on the affect section redesign, where trackers were not being refreshed after file tracker operations, forcing the users to manually refresh the page to see the changes.

## Changes:

- Add couple of missing types on `FlawForm`
- Fix emitters for affects refresh

## Demo:
https://github.com/user-attachments/assets/6a49c952-e95c-4f1d-b1e7-31c133436fd1

## Considerations:

- Affects refresh indirectly refresh trackers aswell
- In the demo the refreshed tracker appears without `Bug ID` cause it was being used local OSIDB instance where those trackers didn't have `external_system_id`

Closes OSIDB-3427
