### PR TITLE
OSIDB-3420: Type checking on test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:unit": "vitest",
     "test:unit:nowatch": "vitest run",
     "test:e2e": "behave features",
-    "type-check": "vue-tsc --noEmit -p tsconfig.app.json --composite false",
+    "type-check": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
     "vibe-check": "npx vite-bundle-visualizer",
     "generate-openapi-client": "openapi-generator-cli generate -i openapi.yml --output src/generated-client -g typescript-axios",
     "mock-osidb-server": "prism mock osidb-3.0.0.oas3.json",

--- a/src/App.vue
+++ b/src/App.vue
@@ -38,7 +38,7 @@ const updateRelativeOsimBuildDate = () => {
   relativeOsimBuildDate.value =
     DateTime.fromISO(osimRuntime.value.osimVersion.timestamp).toRelative() || '';
 };
-let buildDateIntervalId: number = -1;
+let buildDateIntervalId: ReturnType<typeof setInterval>;
 onMounted(() => {
   const ms15Minutes = 15 * 60 * 60 * 1000;
   buildDateIntervalId = setInterval(updateRelativeOsimBuildDate, ms15Minutes);

--- a/src/components/__tests__/IssueQueue.spec.ts
+++ b/src/components/__tests__/IssueQueue.spec.ts
@@ -81,11 +81,17 @@ describe('issueQueue', () => {
 
     });
 
-    const fetchEvents = wrapper.emitted('flaws:fetch');
-    expect(fetchEvents[0][0]._value).toEqual({
-      order: '-created_dt',
-    });
+    const fetchEvents = wrapper.emitted();
     const issues = wrapper.findAllComponents(IssueQueueItem);
+
+    expect(fetchEvents).toHaveProperty('flaws:fetch');
+    expect(fetchEvents['flaws:fetch']).toEqual([
+      [
+        expect.objectContaining({
+          _value: { order: '-created_dt' },
+        }),
+      ],
+    ]);
     expect(issues.length).toBe(1);
   });
 
@@ -104,13 +110,15 @@ describe('issueQueue', () => {
     await myIssuesCheckboxEl.setValue(true);
     await wrapper.vm.$nextTick();
 
-    const fetchEvents = wrapper.emitted('flaws:fetch');
-    expect(fetchEvents[1][0]._value).toEqual({
-      order: '-created_dt',
-      owner: 'skynet',
-    });
-
+    const fetchEvents = wrapper.emitted();
     const issues = wrapper.findAllComponents(IssueQueueItem);
+
+    expect(fetchEvents).toHaveProperty('flaws:fetch');
+    expect(fetchEvents['flaws:fetch'][0]).toEqual([
+      expect.objectContaining({
+        _value: { order: '-created_dt', owner: 'skynet' },
+      }),
+    ]);
     expect(issues.length).toBe(1);
   });
 
@@ -129,13 +137,14 @@ describe('issueQueue', () => {
     await openIssuesCheckboxEl.setValue(true);
     await wrapper.vm.$nextTick();
 
-    const fetchEvents = wrapper.emitted('flaws:fetch');
-    expect(fetchEvents[1][0]._value).toEqual({
-      order: '-created_dt',
-      workflow_state: 'NEW,TRIAGE,PRE_SECONDARY_ASSESSMENT,SECONDARY_ASSESSMENT',
-
-    });
+    const fetchEvents = wrapper.emitted();
     const issues = wrapper.findAllComponents(IssueQueueItem);
+    expect(fetchEvents).toHaveProperty('flaws:fetch');
+    expect(fetchEvents['flaws:fetch'][0]).toEqual([
+      expect.objectContaining({
+        _value: { order: '-created_dt', workflow_state: 'NEW,TRIAGE,PRE_SECONDARY_ASSESSMENT,SECONDARY_ASSESSMENT' },
+      }),
+    ]);
     expect(issues.length).toBe(0);
   });
 
@@ -148,25 +157,61 @@ describe('issueQueue', () => {
         total: 10,
       },
     });
-    const idColumn = wrapper.findAll('th').at(0);
-    await idColumn.trigger('click');
-    const fetchEvents = wrapper.emitted('flaws:fetch');
-    expect(fetchEvents[1][0]._value).toEqual({
-      order: '-cve_id,-uuid',
+
+    await wrapper.findAll('th').at(0)!.trigger('click');
+    const fetchEvents = wrapper.emitted();
+
+    expect(fetchEvents).toHaveProperty('flaws:fetch');
+    expect(fetchEvents['flaws:fetch'][0]).toEqual([
+      expect.objectContaining({
+        _value: { order: '-cve_id,-uuid' },
+      }),
+    ]);
+  });
+
+  it('changes sort order on click', async () => {
+    const wrapper = mountWithConfig(IssueQueue, {
+      props: {
+        issues: [],
+        isLoading: false,
+        isFinalPageFetched: false,
+        total: 10,
+      },
     });
-    // change sort order
-    await idColumn.trigger('click');
-    expect(fetchEvents[1][0]._value).toEqual({
-      order: 'cve_id,uuid',
+
+    await wrapper.findAll('th').at(0)!.trigger('click');
+    await wrapper.findAll('th').at(0)!.trigger('click');
+    const fetchEvents = wrapper.emitted();
+
+    expect(fetchEvents).toHaveProperty('flaws:fetch');
+    expect(fetchEvents['flaws:fetch'][0]).toEqual([
+      expect.objectContaining({
+        _value: { order: 'cve_id,uuid' },
+      }),
+    ]);
+  });
+
+  it('removes sort order on third click', async () => {
+    const wrapper = mountWithConfig(IssueQueue, {
+      props: {
+        issues: [],
+        isLoading: false,
+        isFinalPageFetched: false,
+        total: 10,
+      },
     });
-    // remove order
-    await idColumn.trigger('click');
-    expect(fetchEvents[1][0]._value).toEqual({});
-    const impactColumn = wrapper.findAll('th').at(1);
-    await impactColumn.trigger('click');
-    expect(fetchEvents[1][0]._value).toEqual({
-      order: '-impact',
-    });
+
+    await wrapper.findAll('th').at(0)!.trigger('click');
+    await wrapper.findAll('th').at(0)!.trigger('click');
+    await wrapper.findAll('th').at(0)!.trigger('click');
+    const fetchEvents = wrapper.emitted();
+
+    expect(fetchEvents).toHaveProperty('flaws:fetch');
+    expect(fetchEvents['flaws:fetch'][0]).toEqual([
+      expect.objectContaining({
+        _value: {},
+      }),
+    ]);
   });
 
   it('shouldn\'t render total count when no issues', async () => {

--- a/src/components/__tests__/Navbar.spec.ts
+++ b/src/components/__tests__/Navbar.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 
 import router from '@/router';
-import { useToastStore } from '@/stores/ToastStore';
+import { useToastStore, type ToastAdded } from '@/stores/ToastStore';
 import { useSettingsStore } from '@/stores/SettingsStore';
 
 import Navbar from '../Navbar.vue';
@@ -193,7 +193,7 @@ describe('navbar', () => {
       stubActions: false,
     });
     const toastStore = useToastStore(pinia);
-    const newToasts = Array.from({ length: 1000 });
+    const newToasts: ToastAdded[] = Array.from({ length: 1000 });
     toastStore.$state = {
       toasts: newToasts,
     };

--- a/src/components/widgets/Toast.vue
+++ b/src/components/widgets/Toast.vue
@@ -56,7 +56,7 @@ const percentFreshTimeRemaining = ref<number>(100);
 const freshAndBecomingStaleStart = ref(true);
 
 // Use NaN to check if the id has been assigned before clearInterval
-let freshCountdownId: number = Number.NaN;
+let freshCountdownId: ReturnType<typeof setInterval>;
 onMounted(() => {
   freshCountdownId = setInterval(() => {
     if (settings.showNotifications) {
@@ -88,9 +88,9 @@ onBeforeUnmount(() => {
 });
 
 if (props.timeoutMs) {
-  const countdownId: number = Number.NaN;
+  let countdownId: ReturnType<typeof setInterval>;
   onMounted(() => {
-    const countdownId: number = setInterval(() => {
+    countdownId = setInterval(() => {
       if (active.value || props.timeoutMs == null) {
         percentTimeRemaining.value = 100;
         return;
@@ -127,7 +127,7 @@ const updateTimestampSecond = (updatesRemaining: number = 60) => {
   }
 };
 
-let relativeTimeInterval: number;
+let relativeTimeInterval: ReturnType<typeof setInterval>;
 const updateTimestampMinute = (updatesRemaining: number = 60) => {
   updateTimestamp();
   if (updatesRemaining > 0) {

--- a/src/composables/__tests__/useFlaws.spec.ts
+++ b/src/composables/__tests__/useFlaws.spec.ts
@@ -15,7 +15,7 @@ describe('useFlawsFetching', () => {
   });
 
   it('loads flaws', async () => {
-    vi.mocked(getFlaws).mockResolvedValue({
+    vi.mocked(getFlaws, { partial: true }).mockResolvedValue({
       data: { results: mockIusses.slice(0, 20), total: 30, next: null },
     });
 
@@ -35,7 +35,7 @@ describe('useFlawsFetching', () => {
   });
 
   it('loading more flaws', async () => {
-    vi.mocked(getFlaws).mockResolvedValueOnce({
+    vi.mocked(getFlaws, { partial: true }).mockResolvedValueOnce({
       data:
       {
         results: mockIusses.slice(0, 20),
@@ -66,7 +66,7 @@ describe('useFlawsFetching', () => {
   });
 
   it('should not loading more flaws', async () => {
-    vi.mocked(getFlaws).mockResolvedValueOnce({
+    vi.mocked(getFlaws, { partial: true }).mockResolvedValueOnce({
       data: {
         results: mockIusses.slice(0, 10),
         count: 10,

--- a/src/stores/ToastStore.ts
+++ b/src/stores/ToastStore.ts
@@ -13,7 +13,7 @@ export interface ToastNew {
   title?: string;
 }
 
-interface ToastAdded extends ToastNew {
+export interface ToastAdded extends ToastNew {
   id: number;
   isFresh: boolean;
   timestamp: DateTime;

--- a/src/stores/__tests__/SearchStore.spec.ts
+++ b/src/stores/__tests__/SearchStore.spec.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { createPinia, setActivePinia } from 'pinia';
-import { useLocalStorage } from '@vueuse/core';
 
 import { useSearchStore } from '../SearchStore';
 
@@ -38,25 +37,13 @@ describe('settingsStore', () => {
   });
 
   it('saveFilter', () => {
-    (useLocalStorage as Mock).mockReturnValue({
-      SearchStore: {
-        value: {
-          searchFilters: { test: 'test' },
-        },
-      },
-    });
-    searchStore.saveFilter({ component: 'test' });
+    searchStore.saveFilter({ component: 'test' }, 'test');
+
     expect(searchStore.searchFilters).toEqual({ component: 'test' });
+    expect(searchStore.queryFilter).toBe('test');
   });
 
   it('resetFilter', () => {
-    (useLocalStorage as Mock).mockReturnValue({
-      SearchStore: {
-        value: {
-          searchFilters: { test: 'test' },
-        },
-      },
-    });
     searchStore.resetFilter();
     expect(searchStore.searchFilters).toEqual({});
   });


### PR DESCRIPTION
# OSIDB-3420: Type checking on test files

## Checklist:

- [x] Commits consolidated
- ~Changelog updated~
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Changed the `type-check` command to include test files and fixed all the type errors.

## Changes:

I tried all I could to override the types of the `node:timers` with the `dom` api to return a `number` instead of `NodeJS.Timeout` but nothing worked so at the end I updated the types

## Considerations:

Closes OSIDB-3420