### PR TITLE
🐛 OSIDB-3443: Fix wrong column mapping on trackers table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Add query filter support on advance search (`OSIDB-3088`)
 * Support saving query filter on default user search (`OSIDB-3387`)
 
+### Fixed
+* Fix swapped values on trackers `Modules` and `Stream` values (`OSIDB-3443`)
+
 ## [2024.9.1]
 ### Fixed
 * Fix wrong tracker links (`OSIDB-3443`)

--- a/src/components/FlawAffects.vue
+++ b/src/components/FlawAffects.vue
@@ -1030,7 +1030,7 @@ function fileTrackersForAffects(affects: ZodAffectType[]) {
                   class="form-control"
                   @keydown="handleEdit($event, affect)"
                 />
-                <span v-else>
+                <span v-else :title="affect.ps_module">
                   {{ affect.ps_module }}
                 </span>
               </td>

--- a/src/components/FlawTrackers.vue
+++ b/src/components/FlawTrackers.vue
@@ -314,8 +314,8 @@ function increaseItemsPerPage() {
                   None
                 </span>
               </td>
-              <td>{{ tracker.ps_update_stream }}</td>
               <td>{{ tracker.ps_module }}</td>
+              <td>{{ tracker.ps_update_stream }}</td>
               <td>{{ tracker.status?.toUpperCase() || 'EMPTY' }}</td>
               <td>{{ tracker.resolution?.toUpperCase() }}</td>
               <td>{{ formatDate(tracker.created_dt ?? '', true) }}</td>

--- a/src/components/__tests__/FlawTrackers.spec.ts
+++ b/src/components/__tests__/FlawTrackers.spec.ts
@@ -100,7 +100,7 @@ describe('flawTrackers', () => {
 
     let trackersTableRows = subject.findAll('.affects-trackers .osim-tracker-card table tbody tr');
     let firstTracker = trackersTableRows[0];
-    expect(firstTracker.find('td:nth-of-type(2)').text()).toBe('xxxx-0-006');
+    expect(firstTracker.find('td:nth-of-type(3)').text()).toBe('xxxx-0-006');
 
     const componentHeader = subject.find('.affects-trackers table thead tr th:nth-of-type(6)');
     expect(componentHeader.exists()).toBe(true);

--- a/src/components/__tests__/FlawTrackers.spec.ts
+++ b/src/components/__tests__/FlawTrackers.spec.ts
@@ -109,7 +109,27 @@ describe('flawTrackers', () => {
 
     trackersTableRows = subject.findAll('.affects-trackers .osim-tracker-card table tbody tr');
     firstTracker = trackersTableRows[0];
-    expect(firstTracker.find('td:nth-of-type(2)').text()).toBe('xxxx-0-001');
+    expect(firstTracker.find('td:nth-of-type(3)').text()).toBe('xxxx-0-001');
+  });
+
+  osimFullFlawTest('Trackers display functional external links', async ({ flaw }) => {
+    subject = mount(FlawTrackers, {
+      props: {
+        flawId: flaw.uuid,
+        displayedTrackers: flaw.affects
+          .flatMap(affect => affect.trackers
+            .map(tracker => ({ ...tracker, ps_module: affect.ps_module })),
+          ),
+        affectsNotBeingDeleted: [],
+        allTrackersCount: 0,
+      },
+    });
+
+    const trackersTableRows = subject.findAll('.affects-trackers .osim-tracker-card table tbody tr');
+    const firstTracker = trackersTableRows[0];
+
+    const trackerLink = firstTracker.find('td:nth-child(1) > a');
+    expect(trackerLink.attributes('href')).toBe('http://jira-service:8002/browse/XXXX-0006');
   });
 
   osimFullFlawTest('Displays embedded trackers manager', async ({ flaw }) => {

--- a/src/components/__tests__/__snapshots__/FlawAffects.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawAffects.spec.ts.snap
@@ -85,7 +85,7 @@ exports[`flawAffects > Correctly renders the component when there are affects to
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-1">openshift-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-1-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -106,7 +106,7 @@ exports[`flawAffects > Correctly renders the component when there are affects to
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-2</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-2">openshift-2</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-2-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -127,7 +127,7 @@ exports[`flawAffects > Correctly renders the component when there are affects to
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-3</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-3">openshift-3</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-3-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -148,7 +148,7 @@ exports[`flawAffects > Correctly renders the component when there are affects to
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-4</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-4">openshift-4</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-4-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -169,7 +169,7 @@ exports[`flawAffects > Correctly renders the component when there are affects to
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-5</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-5">openshift-5</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-5-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -190,7 +190,7 @@ exports[`flawAffects > Correctly renders the component when there are affects to
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-6</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-6">openshift-6</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-6-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">WONTFIX</span></td>
@@ -246,8 +246,8 @@ exports[`flawAffects > Correctly renders the component when there are affects to
           <tbody data-v-7006d35c="">
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0006" target="_blank">XXXX-0006 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-006</td>
               <td data-v-7006d35c="">openshift-5</td>
+              <td data-v-7006d35c="">xxxx-0-006</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-07-01 13:05 UTC</td>
@@ -255,8 +255,8 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0005" target="_blank">XXXX-0005 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-005</td>
               <td data-v-7006d35c="">openshift-5</td>
+              <td data-v-7006d35c="">xxxx-0-005</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-08-01 13:05 UTC</td>
@@ -264,8 +264,8 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0004" target="_blank">XXXX-0004 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-004</td>
               <td data-v-7006d35c="">openshift-1</td>
+              <td data-v-7006d35c="">xxxx-0-004</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-09-01 13:05 UTC</td>
@@ -273,8 +273,8 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0003" target="_blank">XXXX-0003 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-003</td>
               <td data-v-7006d35c="">openshift-1</td>
+              <td data-v-7006d35c="">xxxx-0-003</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-10-01 13:05 UTC</td>
@@ -282,8 +282,8 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0002" target="_blank">XXXX-0002 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-002</td>
               <td data-v-7006d35c="">openshift-1</td>
+              <td data-v-7006d35c="">xxxx-0-002</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-11-01 13:05 UTC</td>
@@ -291,8 +291,8 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0001" target="_blank">XXXX-0001 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-001</td>
               <td data-v-7006d35c="">openshift-1</td>
+              <td data-v-7006d35c="">xxxx-0-001</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-12-01 13:05 UTC</td>
@@ -519,7 +519,7 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">-test</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="-test">-test</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-1-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -540,7 +540,7 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-2</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-2">openshift-2</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-2-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -561,7 +561,7 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-3</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-3">openshift-3</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-3-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -582,7 +582,7 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-4</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-4">openshift-4</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-4-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -603,7 +603,7 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-5</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-5">openshift-5</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-5-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -624,7 +624,7 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-6</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-6">openshift-6</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-6-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">WONTFIX</span></td>
@@ -680,8 +680,8 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
           <tbody data-v-7006d35c="">
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0006" target="_blank">XXXX-0006 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-006</td>
               <td data-v-7006d35c="">openshift-5</td>
+              <td data-v-7006d35c="">xxxx-0-006</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-07-01 13:05 UTC</td>
@@ -689,8 +689,8 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0005" target="_blank">XXXX-0005 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-005</td>
               <td data-v-7006d35c="">openshift-5</td>
+              <td data-v-7006d35c="">xxxx-0-005</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-08-01 13:05 UTC</td>
@@ -698,8 +698,8 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0004" target="_blank">XXXX-0004 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-004</td>
               <td data-v-7006d35c="">-test</td>
+              <td data-v-7006d35c="">xxxx-0-004</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-09-01 13:05 UTC</td>
@@ -707,8 +707,8 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0003" target="_blank">XXXX-0003 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-003</td>
               <td data-v-7006d35c="">-test</td>
+              <td data-v-7006d35c="">xxxx-0-003</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-10-01 13:05 UTC</td>
@@ -716,8 +716,8 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0002" target="_blank">XXXX-0002 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-002</td>
               <td data-v-7006d35c="">-test</td>
+              <td data-v-7006d35c="">xxxx-0-002</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-11-01 13:05 UTC</td>
@@ -725,8 +725,8 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0001" target="_blank">XXXX-0001 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-001</td>
               <td data-v-7006d35c="">-test</td>
+              <td data-v-7006d35c="">xxxx-0-001</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-12-01 13:05 UTC</td>
@@ -889,7 +889,7 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">-test</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="-test">-test</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-1-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -910,7 +910,7 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-2</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-2">openshift-2</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-2-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -931,7 +931,7 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-3</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-3">openshift-3</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-3-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -952,7 +952,7 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-4</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-4">openshift-4</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-4-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -973,7 +973,7 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-5</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-5">openshift-5</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-5-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
@@ -994,7 +994,7 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
           <td data-v-0fd8a3c0="">
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-6</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-6">openshift-6</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-6-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">WONTFIX</span></td>
@@ -1050,8 +1050,8 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
           <tbody data-v-7006d35c="">
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0006" target="_blank">XXXX-0006 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-006</td>
               <td data-v-7006d35c="">openshift-5</td>
+              <td data-v-7006d35c="">xxxx-0-006</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-07-01 13:05 UTC</td>
@@ -1059,8 +1059,8 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0005" target="_blank">XXXX-0005 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-005</td>
               <td data-v-7006d35c="">openshift-5</td>
+              <td data-v-7006d35c="">xxxx-0-005</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-08-01 13:05 UTC</td>
@@ -1068,8 +1068,8 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0004" target="_blank">XXXX-0004 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-004</td>
               <td data-v-7006d35c="">-test</td>
+              <td data-v-7006d35c="">xxxx-0-004</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-09-01 13:05 UTC</td>
@@ -1077,8 +1077,8 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0003" target="_blank">XXXX-0003 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-003</td>
               <td data-v-7006d35c="">-test</td>
+              <td data-v-7006d35c="">xxxx-0-003</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-10-01 13:05 UTC</td>
@@ -1086,8 +1086,8 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0002" target="_blank">XXXX-0002 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-002</td>
               <td data-v-7006d35c="">-test</td>
+              <td data-v-7006d35c="">xxxx-0-002</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-11-01 13:05 UTC</td>
@@ -1095,8 +1095,8 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0001" target="_blank">XXXX-0001 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">xxxx-0-001</td>
               <td data-v-7006d35c="">-test</td>
+              <td data-v-7006d35c="">xxxx-0-001</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-12-01 13:05 UTC</td>

--- a/src/components/__tests__/__snapshots__/FlawTrackers.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawTrackers.spec.ts.snap
@@ -77,8 +77,8 @@ exports[`flawTrackers > Correctly renders the component when there are trackers 
         <tbody data-v-7006d35c="">
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0006" target="_blank">XXXX-0006 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">xxxx-0-006</td>
             <td data-v-7006d35c="">openshift-5</td>
+            <td data-v-7006d35c="">xxxx-0-006</td>
             <td data-v-7006d35c="">CLOSED</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-07-01 13:05 UTC</td>
@@ -86,8 +86,8 @@ exports[`flawTrackers > Correctly renders the component when there are trackers 
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0005" target="_blank">XXXX-0005 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">xxxx-0-005</td>
             <td data-v-7006d35c="">openshift-5</td>
+            <td data-v-7006d35c="">xxxx-0-005</td>
             <td data-v-7006d35c="">NEW</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-08-01 13:05 UTC</td>
@@ -95,8 +95,8 @@ exports[`flawTrackers > Correctly renders the component when there are trackers 
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0004" target="_blank">XXXX-0004 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">xxxx-0-004</td>
             <td data-v-7006d35c="">openshift-1</td>
+            <td data-v-7006d35c="">xxxx-0-004</td>
             <td data-v-7006d35c="">CLOSED</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-09-01 13:05 UTC</td>
@@ -104,8 +104,8 @@ exports[`flawTrackers > Correctly renders the component when there are trackers 
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0003" target="_blank">XXXX-0003 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">xxxx-0-003</td>
             <td data-v-7006d35c="">openshift-1</td>
+            <td data-v-7006d35c="">xxxx-0-003</td>
             <td data-v-7006d35c="">NEW</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-10-01 13:05 UTC</td>
@@ -113,8 +113,8 @@ exports[`flawTrackers > Correctly renders the component when there are trackers 
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0002" target="_blank">XXXX-0002 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">xxxx-0-002</td>
             <td data-v-7006d35c="">openshift-1</td>
+            <td data-v-7006d35c="">xxxx-0-002</td>
             <td data-v-7006d35c="">CLOSED</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-11-01 13:05 UTC</td>
@@ -122,8 +122,8 @@ exports[`flawTrackers > Correctly renders the component when there are trackers 
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0001" target="_blank">XXXX-0001 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">xxxx-0-001</td>
             <td data-v-7006d35c="">openshift-1</td>
+            <td data-v-7006d35c="">xxxx-0-001</td>
             <td data-v-7006d35c="">NEW</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-12-01 13:05 UTC</td>
@@ -175,8 +175,8 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
         <tbody data-v-7006d35c="">
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0006" target="_blank">XXXX-0006 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">xxxx-0-006</td>
             <td data-v-7006d35c="">openshift-5</td>
+            <td data-v-7006d35c="">xxxx-0-006</td>
             <td data-v-7006d35c="">CLOSED</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-07-01 13:05 UTC</td>
@@ -184,8 +184,8 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0005" target="_blank">XXXX-0005 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">xxxx-0-005</td>
             <td data-v-7006d35c="">openshift-5</td>
+            <td data-v-7006d35c="">xxxx-0-005</td>
             <td data-v-7006d35c="">NEW</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-08-01 13:05 UTC</td>
@@ -193,8 +193,8 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0004" target="_blank">XXXX-0004 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">xxxx-0-004</td>
             <td data-v-7006d35c="">openshift-1</td>
+            <td data-v-7006d35c="">xxxx-0-004</td>
             <td data-v-7006d35c="">CLOSED</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-09-01 13:05 UTC</td>
@@ -202,8 +202,8 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0003" target="_blank">XXXX-0003 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">xxxx-0-003</td>
             <td data-v-7006d35c="">openshift-1</td>
+            <td data-v-7006d35c="">xxxx-0-003</td>
             <td data-v-7006d35c="">NEW</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-10-01 13:05 UTC</td>
@@ -211,8 +211,8 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0002" target="_blank">XXXX-0002 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">xxxx-0-002</td>
             <td data-v-7006d35c="">openshift-1</td>
+            <td data-v-7006d35c="">xxxx-0-002</td>
             <td data-v-7006d35c="">CLOSED</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-11-01 13:05 UTC</td>
@@ -220,8 +220,8 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0001" target="_blank">XXXX-0001 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">xxxx-0-001</td>
             <td data-v-7006d35c="">openshift-1</td>
+            <td data-v-7006d35c="">xxxx-0-001</td>
             <td data-v-7006d35c="">NEW</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-12-01 13:05 UTC</td>


### PR DESCRIPTION
# OSIDB-3443: Swapped trackers Module/Stream column values

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Fixes incorrect mapping on the Modules and Stream columns on the trackers table (column values were swapped).
Also update test cases and introduce new unit test for tracker links and introduces a minor UX improvement.

## Changes:

- Add tooltip on affects modules with it's value
- Fix incorrect tracker module/stream columns values
- Update test cases for the change
- Update snapshots for the change
- Add new unit test for tracker links

## Considerations:

- New affect modules cell tooltip is useful for when the modules are large and truncated, so users can see the full string value without goin to edit mode.

## Demo:

New tooltip:
![image](https://github.com/user-attachments/assets/5276f25f-0cf6-4c99-9f6b-a7f0580d0782)

Trackers column fix:
![image](https://github.com/user-attachments/assets/ffabb993-dddf-4b17-8dfe-0a409098df80)

Closes OSIDB-3443
