### PR TITLE
🐛 LabelCollapsible readonly error

### DIFF
--- a/src/components/CvssExplainForm.vue
+++ b/src/components/CvssExplainForm.vue
@@ -20,7 +20,7 @@ const isExpanded = ref(false);
     :isExpanded="isExpanded"
     label="Explain non-obvious CVSSv3 score metrics"
     class="ms-2 cvss-score-mismatch"
-    @setExpanded="isExpanded = !isExpanded"
+    @toggleExpanded="isExpanded = !isExpanded"
   >
     <textarea
       v-model="modelValue.cvss_scores[rhCvss].comment"

--- a/src/components/CvssExplainForm.vue
+++ b/src/components/CvssExplainForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 
 import LabelCollapsible from '@/components/widgets/LabelCollapsible.vue';
 
@@ -10,13 +10,17 @@ const modelValue = defineModel<ZodFlawType>({ required: true });
 const rhCvss = computed(() => modelValue.value?.cvss_scores
   .findIndex(cvss => cvss.issuer === 'RH'
   && cvss.cvss_version === 'V3'));
+
+const isExpanded = ref(false);
 </script>
 
 <template>
   <LabelCollapsible
     v-if="rhCvss > -1"
+    :isExpanded="isExpanded"
     label="Explain non-obvious CVSSv3 score metrics"
     class="ms-2 cvss-score-mismatch"
+    @setExpanded="isExpanded = !isExpanded"
   >
     <textarea
       v-model="modelValue.cvss_scores[rhCvss].comment"

--- a/src/components/FlawAffects.vue
+++ b/src/components/FlawAffects.vue
@@ -543,7 +543,7 @@ function fileTrackersForAffects(affects: ZodAffectType[]) {
       <LabelCollapsible
         :isExpanded="modulesExpanded"
         :isExpandable="hasAffects"
-        @setExpanded="toggleModulesCollapse"
+        @toggleExpanded="toggleModulesCollapse"
       >
         <template #label>
           <label class="form-label m-2">

--- a/src/components/FlawAlert.vue
+++ b/src/components/FlawAlert.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 
 import LabelCollapsible from '@/components/widgets/LabelCollapsible.vue';
 
@@ -30,6 +30,8 @@ function scrollToComponent(parent_uuid: string) {
     }
   });
 }
+
+const isExpanded = ref(false);
 </script>
 
 <template>
@@ -39,7 +41,7 @@ function scrollToComponent(parent_uuid: string) {
     :class="{'alert-warning': isWarning, 'alert-danger': isError}"
     role="alert"
   >
-    <LabelCollapsible>
+    <LabelCollapsible :isExpanded="isExpanded" @setExpanded="isExpanded = !isExpanded">
       <template #label>
         <span class="badge mx-2" :class="{'text-bg-warning': isWarning, 'text-bg-danger': isError}">
           <i class="bi" :class="{'bi-exclamation-triangle-fill': isWarning, 'bi-x-circle-fill': isError}" />

--- a/src/components/FlawAlert.vue
+++ b/src/components/FlawAlert.vue
@@ -41,7 +41,7 @@ const isExpanded = ref(false);
     :class="{'alert-warning': isWarning, 'alert-danger': isError}"
     role="alert"
   >
-    <LabelCollapsible :isExpanded="isExpanded" @setExpanded="isExpanded = !isExpanded">
+    <LabelCollapsible :isExpanded="isExpanded" @toggleExpanded="isExpanded = !isExpanded">
       <template #label>
         <span class="badge mx-2" :class="{'text-bg-warning': isWarning, 'text-bg-danger': isError}">
           <i class="bi" :class="{'bi-exclamation-triangle-fill': isWarning, 'bi-x-circle-fill': isError}" />

--- a/src/components/FlawAlertsList.vue
+++ b/src/components/FlawAlertsList.vue
@@ -41,7 +41,7 @@ const alertsExpanded = ref(false);
     v-if="Object.values(alertsCount).reduce((acc, alertTypeCount) => acc + alertTypeCount, 0) !== 0"
     class="my-2"
     :isExpanded="alertsExpanded"
-    @setExpanded="alertsExpanded = !alertsExpanded"
+    @toggleExpanded="alertsExpanded = !alertsExpanded"
   >
     <template #label>
       <label class="mx-2 mb-0 form-label">

--- a/src/components/FlawAlertsSection.vue
+++ b/src/components/FlawAlertsSection.vue
@@ -27,7 +27,7 @@ const emitExpandFocusedComponent = (parent_uuid: string) => {
   <LabelCollapsible
     v-if="Object.values(alertSet).reduce((acc, alertType) => acc + alertType.length, 0) !== 0"
     :isExpanded="isExpanded"
-    @setExpanded="isExpanded = !isExpanded"
+    @toggleExpanded="isExpanded = !isExpanded"
   >
     <template #label>
       <span>

--- a/src/components/widgets/EditableList.vue
+++ b/src/components/widgets/EditableList.vue
@@ -91,7 +91,7 @@ defineExpose({ isExpanded });
       :label="`${entityNamePlural}: ${items.length}`"
       :isExpandable="items.length > 0"
       :isExpanded="isExpanded"
-      @setExpanded="isExpanded = !isExpanded"
+      @toggleExpanded="isExpanded = !isExpanded"
     >
       <div
         v-for="(item, itemIndex) in items"

--- a/src/components/widgets/LabelCollapsible.vue
+++ b/src/components/widgets/LabelCollapsible.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const props = withDefaults(
+withDefaults(
   defineProps<{
     isExpandable?: boolean | undefined;
     isExpanded?: boolean | undefined;
@@ -13,7 +13,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  setExpanded: [value: boolean];
+  toggleExpanded: [];
 }>();
 </script>
 
@@ -24,7 +24,7 @@ const emit = defineEmits<{
       type="button"
       class="me-2 osim-collapsible-toggle"
       :class="{ 'pe-none': !isExpandable }"
-      @click="emit('setExpanded', !props.isExpanded)"
+      @click="emit('toggleExpanded')"
     >
       <i v-if="isExpanded" class="bi bi-dash-square-dotted me-1"></i>
       <i v-else class="bi bi-plus-square-dotted me-1"></i>

--- a/src/components/widgets/LabelCollapsible.vue
+++ b/src/components/widgets/LabelCollapsible.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { watchedPropRef } from '@/utils/helpers';
-
 const props = withDefaults(
   defineProps<{
     isExpandable?: boolean | undefined;
@@ -17,19 +15,6 @@ const props = withDefaults(
 const emit = defineEmits<{
   setExpanded: [value: boolean];
 }>();
-
-const isExpanded = watchedPropRef(props, 'isExpanded', false);
-
-const emitToggle = () => { emit('setExpanded', !props.isExpanded); };
-const localToggle = () => { (isExpanded.value = !isExpanded.value); };
-
-function handleClick() {
-  if (props.isExpanded) {
-    return emitToggle();
-  }
-
-  localToggle();
-}
 </script>
 
 <template>
@@ -39,7 +24,7 @@ function handleClick() {
       type="button"
       class="me-2 osim-collapsible-toggle"
       :class="{ 'pe-none': !isExpandable }"
-      @click="handleClick"
+      @click="emit('setExpanded', !props.isExpanded)"
     >
       <i v-if="isExpanded" class="bi bi-dash-square-dotted me-1"></i>
       <i v-else class="bi bi-plus-square-dotted me-1"></i>


### PR DESCRIPTION
# OSIDB-3445 Fix readonly collapsible attribute

## Checklist:

- [x] Commits consolidated
- [-] Changelog updated
- [-] Test cases added/updated
- [x] Jira ticket updated

## Summary:

This pr fixes the problems of collapsible labels not working on local OSIM instances, by refactoring the `LabelCollapsible` component to always handle the collapsed state change events on the parent components.

## Changes:

- Refactor `LabelCollapsible` component to use always emits for state changes
- Update uses of `LabelCollapsible` component

## Demo:

https://github.com/user-attachments/assets/6c243f89-00ac-41b9-8f91-1d3d1ee4c671

## Considerations:

- Considered the previously 'dual' way to handle collapse state changes (on parents or local) was aggregating unnecessary complexity, as in all the cases handle the events on the parent is possible.
- The components where the `LabelCollapsible` is used are:
	- FlawAffects (modules filter)
	- FlawAlerts (Alert, AlertList and AlertSection)
	- EditableList (Acknowledgements and References)
	- CvssExplainForm (conditionally displayed within the flaw form)
- No changelog update as the bug is only affecting local OSIM instances

Closes OSIDB-3445
