### PR TITLE
OSIDB-3449: Advanced search suggestions are not applied when using the mouse

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
     "lint-style": "stylelint '**/*.{vue,css,scss}'"
   },
   "dependencies": {
+    "@mrmarble/djangoql-completion": "^0.8.1",
     "@popperjs/core": "^2.11.8",
     "@rollup/plugin-inject": "^5.0.5",
     "@vueuse/core": "^10.4.1",
     "axios": "^1.4.0",
     "bootstrap": "^5.3.2",
     "bootstrap-icons": "^1.10.5",
-    "djangoql-completion": "^0.5.0",
     "jwt-decode": "^3.1.2",
     "luxon": "^3.4.3",
     "marked": "^12.0.1",

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -2,8 +2,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 
 import { sort } from 'ramda';
-// @ts-expect-error missing types
-import DjangoQL from 'djangoql-completion';
+import DjangoQL from '@mrmarble/djangoql-completion';
 
 import Modal from '@/components/widgets/Modal.vue';
 import QueryFilterGuide from '@/components/QueryFilterGuide.vue';
@@ -97,7 +96,6 @@ onMounted(() => {
     introspections: `${osimRuntime.value.backends.osidb}/osidb/api/v1/introspection`,
     selector: 'textarea#query',
     autoResize: true,
-    syntaxHelp: null,
     onSubmit: function (value: string) {
       query.value = value;
       submitAdvancedSearch();
@@ -279,5 +277,5 @@ onUnmounted(() => {
 
 <style lang="scss">
 @import '@/scss/djangoql';
-@import 'djangoql-completion/dist/completion.css';
+@import '@mrmarble/djangoql-completion/dist/index.css';
 </style>

--- a/src/components/__tests__/IssueSearchAdvanced.spec.ts
+++ b/src/components/__tests__/IssueSearchAdvanced.spec.ts
@@ -3,13 +3,12 @@ import { type ExtractPublicPropTypes } from 'vue';
 import { mount, flushPromises } from '@vue/test-utils';
 import { describe, it, expect, vi } from 'vitest';
 import { useRouter } from 'vue-router';
-// @ts-expect-error missing types
-import DjangoQLCompletion from 'djangoql-completion';
+import DjangoQLCompletion from '@mrmarble/djangoql-completion';
 
 describe('issueSearchAdvanced', () => {
   let IssueSearchAdvanced: typeof import('@/components/IssueSearchAdvanced.vue').default;
 
-  vi.mock('djangoql-completion');
+  vi.mock('@mrmarble/djangoql-completion');
   vi.mock('vue-router', () => ({
     useRoute: vi.fn().mockReturnValue({
       query: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -669,6 +669,14 @@
   resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
   integrity sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==
 
+"@mrmarble/djangoql-completion@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@mrmarble/djangoql-completion/-/djangoql-completion-0.8.1.tgz#ded11ee27c4114747f82b074dd24d1c4316f5552"
+  integrity sha512-SH182m6qYDZrVERIsOvm6XxFxnNSV4xm9afy1ZsAnlWSk80s3zZTaaOQV77BD4VsxLH04JVSaXd9sE6KvzbbWg==
+  dependencies:
+    lex "1.7.9"
+    lodash "4.17.21"
+
 "@mswjs/cookies@^1.1.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-1.1.1.tgz#8b519e2bd8f1577c530beed44a25578eb9a6e72c"
@@ -2221,14 +2229,6 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
-
-djangoql-completion@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/djangoql-completion/-/djangoql-completion-0.5.0.tgz#984fcef2cf25499b44722b3ef36d5e63e210749f"
-  integrity sha512-07P9Ksyb9Urnb/I/DfSIIw41xXdps9mTcIXR7PYbz/vryBUQSEc4tYC3CZ3dHJXQVk665kzseNxXBxqOvpzxSQ==
-  dependencies:
-    lex "1.7.9"
-    lodash "4.17.21"
 
 doctrine@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# OSIDB-3449: Advanced search suggestions are not applied when using the mouse

## Checklist:

- [x] Commits consolidated
- ~Changelog updated~
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Because `djangoql-completion` uses normal DOM events to update the query, Vue wasn't aware of the changes when clicking the search button. Using my fork, I emit an **Input** event when the textarea changes, allowing Vue to detect the event and update the `v-model` accordingly. This fork also adds typescript support.

## Changes:

- replace `djangoql-completion` with `@mrmarble/djangoql-completion`

## Considerations:

Closes OSIDB-3449
