### PR TITLE
OSIDB-3453: Add new tooltips for truncated fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Support saving query filter on default user search (`OSIDB-3387`)
 * Allow emptiness advanced search on supported fields (`OSIDB-3389`)
 * Add additional sortable fields for advance search results (`OSIDB-3388`)
+* Added tootlips with full string value on affect/tracker fields that can be truncated (`OSIDB-3453`)
 
 ### Fixed
 * Fix swapped values on trackers `Modules` and `Stream` values (`OSIDB-3443`)

--- a/src/components/FlawAffects.vue
+++ b/src/components/FlawAffects.vue
@@ -174,6 +174,13 @@ function handleModuleSelection(moduleName: string) {
   }
 }
 
+function moduleBtnTooltip(moduleName: string) {
+  return moduleName
+    + (moduleTrackersCount(moduleName) === 0
+      ? '\nThis module has no trackers associated'
+      : '');
+}
+
 // Affect Field Specific Filters
 const affectednessFilter = ref<string[]>([]);
 const resolutionFilter = ref<string[]>([]);
@@ -571,10 +578,7 @@ function fileTrackersForAffects(affects: ZodAffectType[]) {
               'border-gray': !isModuleSelected(moduleName),
               'fw-bold': moduleTrackersCount(moduleName) === 0,
             }"
-            :title="moduleName
-              + (moduleTrackersCount(moduleName) === 0
-                ? '\nThis module has no trackers associated'
-                : '')"
+            :title="moduleBtnTooltip(moduleName)"
             @click="handleModuleSelection(moduleName)"
           >
             <i

--- a/src/components/FlawAffects.vue
+++ b/src/components/FlawAffects.vue
@@ -571,7 +571,10 @@ function fileTrackersForAffects(affects: ZodAffectType[]) {
               'border-gray': !isModuleSelected(moduleName),
               'fw-bold': moduleTrackersCount(moduleName) === 0,
             }"
-            :title="moduleTrackersCount(moduleName) === 0 ? 'This module has no trackers associated' : ''"
+            :title="moduleName
+              + (moduleTrackersCount(moduleName) === 0
+                ? '\nThis module has no trackers associated'
+                : '')"
             @click="handleModuleSelection(moduleName)"
           >
             <i
@@ -1041,7 +1044,7 @@ function fileTrackersForAffects(affects: ZodAffectType[]) {
                   class="form-control"
                   @keydown="handleEdit($event, affect)"
                 />
-                <span v-else>
+                <span v-else :title="affect.ps_component">
                   {{ affect.ps_component }}
                 </span>
               </td>

--- a/src/components/FlawTrackers.vue
+++ b/src/components/FlawTrackers.vue
@@ -314,8 +314,8 @@ function increaseItemsPerPage() {
                   None
                 </span>
               </td>
-              <td>{{ tracker.ps_module }}</td>
-              <td>{{ tracker.ps_update_stream }}</td>
+              <td :title="tracker.ps_module">{{ tracker.ps_module }}</td>
+              <td :title="tracker.ps_update_stream ?? ''">{{ tracker.ps_update_stream }}</td>
               <td>{{ tracker.status?.toUpperCase() || 'EMPTY' }}</td>
               <td>{{ tracker.resolution?.toUpperCase() }}</td>
               <td>{{ formatDate(tracker.created_dt ?? '', true) }}</td>

--- a/src/components/__tests__/FlawAffects.spec.ts
+++ b/src/components/__tests__/FlawAffects.spec.ts
@@ -42,6 +42,18 @@ describe('flawAffects', () => {
     expect(subject.html()).toMatchSnapshot();
   });
 
+  osimFullFlawTest('Filter button for module with trackers have correct tootltip', async ({ flaw }) => {
+    const subject = mountFlawAffects(flaw);
+    const moduleFilterBtn = subject.findAll('.module-btn')[0];
+    expect(moduleFilterBtn.attributes('title')).toBe('openshift-1');
+  });
+
+  osimFullFlawTest('Filter button for module without trackers have correct tootltip', async ({ flaw }) => {
+    const subject = mountFlawAffects(flaw);
+    const moduleFilterBtn = subject.findAll('.module-btn')[1];
+    expect(moduleFilterBtn.attributes('title')).toBe('openshift-2\nThis module has no trackers associated');
+  });
+
   osimFullFlawTest('Filter tables when affected modules are selected', async ({ flaw }) => {
     const subject = mountFlawAffects(flaw);
 
@@ -347,6 +359,20 @@ describe('flawAffects', () => {
 
     impactFilterBtn = subject.find('#impact-filter');
     expect(impactFilterBtn.find('i.bi-funnel-fill').exists()).toBe(true);
+  });
+
+  osimFullFlawTest('Affect modules table cell have correct tootltip', async ({ flaw }) => {
+    const subject = mountFlawAffects(flaw);
+    const affectRow = subject.findAll('.affects-management table tbody tr')[1];
+    const affectModuleDisplay = affectRow.find('td:nth-of-type(3) > span');
+    expect(affectModuleDisplay.attributes('title')).toBe('openshift-2');
+  });
+
+  osimFullFlawTest('Affect components table cell have correct tootltip', async ({ flaw }) => {
+    const subject = mountFlawAffects(flaw);
+    const affectRow = subject.findAll('.affects-management table tbody tr')[1];
+    const affectComponentDisplay = affectRow.find('td:nth-of-type(4) > span');
+    expect(affectComponentDisplay.attributes('title')).toBe('openshift-2-1');
   });
 
   osimFullFlawTest('Displays tracker manager for individual affect', async ({ flaw }) => {

--- a/src/components/__tests__/FlawTrackers.spec.ts
+++ b/src/components/__tests__/FlawTrackers.spec.ts
@@ -141,7 +141,7 @@ describe('flawTrackers', () => {
     expect(trackerModuleCell.attributes('title')).toBe('openshift-5');
   });
 
-  osimFullFlawTest('Tracker ps_stream table cell have correct tootltip', async ({ flaw }) => {
+  osimFullFlawTest('Tracker ps_stream table cell have correct tooltip', async ({ flaw }) => {
     const subject = mountFlawTrackers({
       flawId: flaw.uuid,
       displayedTrackers: flaw.affects

--- a/src/components/__tests__/FlawTrackers.spec.ts
+++ b/src/components/__tests__/FlawTrackers.spec.ts
@@ -126,7 +126,7 @@ describe('flawTrackers', () => {
     expect(trackerLink.attributes('href')).toBe('http://jira-service:8002/browse/XXXX-0006');
   });
 
-  osimFullFlawTest('Tracker modules table cell have correct tootltip', async ({ flaw }) => {
+  osimFullFlawTest('Tracker modules table cell have correct tooltip', async ({ flaw }) => {
     const subject = mountFlawTrackers({
       flawId: flaw.uuid,
       displayedTrackers: flaw.affects

--- a/src/components/__tests__/FlawTrackers.spec.ts
+++ b/src/components/__tests__/FlawTrackers.spec.ts
@@ -126,6 +126,36 @@ describe('flawTrackers', () => {
     expect(trackerLink.attributes('href')).toBe('http://jira-service:8002/browse/XXXX-0006');
   });
 
+  osimFullFlawTest('Tracker modules table cell have correct tootltip', async ({ flaw }) => {
+    const subject = mountFlawTrackers({
+      flawId: flaw.uuid,
+      displayedTrackers: flaw.affects
+        .flatMap(affect => affect.trackers
+          .map(tracker => ({ ...tracker, ps_module: affect.ps_module })),
+        ),
+      affectsNotBeingDeleted: [],
+      allTrackersCount: 0,
+    });
+    const trackerRow = subject.findAll('.affects-trackers .osim-tracker-card table tbody tr')[1];
+    const trackerModuleCell = trackerRow.find('td:nth-of-type(2)');
+    expect(trackerModuleCell.attributes('title')).toBe('openshift-5');
+  });
+
+  osimFullFlawTest('Tracker ps_stream table cell have correct tootltip', async ({ flaw }) => {
+    const subject = mountFlawTrackers({
+      flawId: flaw.uuid,
+      displayedTrackers: flaw.affects
+        .flatMap(affect => affect.trackers
+          .map(tracker => ({ ...tracker, ps_module: affect.ps_module })),
+        ),
+      affectsNotBeingDeleted: [],
+      allTrackersCount: 0,
+    });
+    const trackerRow = subject.findAll('.affects-trackers .osim-tracker-card table tbody tr')[0];
+    const trackerModuleCell = trackerRow.find('td:nth-of-type(3)');
+    expect(trackerModuleCell.attributes('title')).toBe('xxxx-0-006');
+  });
+
   osimFullFlawTest('Displays embedded trackers manager', async ({ flaw }) => {
     const subject = mountFlawTrackers({
       flawId: flaw.uuid,

--- a/src/components/__tests__/__snapshots__/FlawAffects.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawAffects.spec.ts.snap
@@ -6,11 +6,15 @@ exports[`flawAffects > Correctly renders the component when there are affects to
   <div data-v-0fd8a3c0="" class="affect-modules-selection mb-4">
     <div data-v-357e30d7="" data-v-0fd8a3c0="" class="osim-collapsible-label"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-dash-square-dotted me-1"></i><label data-v-0fd8a3c0="" class="form-label m-2"> Affected Modules </label></button>
       <div data-v-357e30d7="" class="ps-3 border-start">
-        <div data-v-357e30d7="" class=""><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="">
+        <div data-v-357e30d7="" class=""><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="openshift-1">
             <!--v-if--><span data-v-0fd8a3c0="">openshift-1</span>
-          </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-2</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-3</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-4</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="">
+          </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-2
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-2</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-3
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-3</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-4
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-4</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="openshift-5">
             <!--v-if--><span data-v-0fd8a3c0="">openshift-5</span>
-          </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-6</span></button></div>
+          </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-6
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-6</span></button></div>
       </div>
     </div>
     <!--v-if-->
@@ -86,7 +90,7 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-1">openshift-1</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-1-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-1-1">openshift-1-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -107,7 +111,7 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-2">openshift-2</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-2-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-2-1">openshift-2-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -128,7 +132,7 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-3">openshift-3</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-3-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-3-1">openshift-3-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -149,7 +153,7 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-4">openshift-4</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-4-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-4-1">openshift-4-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -170,7 +174,7 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-5">openshift-5</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-5-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-5-1">openshift-5-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -191,7 +195,7 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-6">openshift-6</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-6-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-6-1">openshift-6-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">WONTFIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">CRITICAL</span></td>
@@ -246,8 +250,8 @@ exports[`flawAffects > Correctly renders the component when there are affects to
           <tbody data-v-7006d35c="">
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0006" target="_blank">XXXX-0006 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">openshift-5</td>
-              <td data-v-7006d35c="">xxxx-0-006</td>
+              <td data-v-7006d35c="" title="openshift-5">openshift-5</td>
+              <td data-v-7006d35c="" title="xxxx-0-006">xxxx-0-006</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-07-01 13:05 UTC</td>
@@ -255,8 +259,8 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0005" target="_blank">XXXX-0005 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">openshift-5</td>
-              <td data-v-7006d35c="">xxxx-0-005</td>
+              <td data-v-7006d35c="" title="openshift-5">openshift-5</td>
+              <td data-v-7006d35c="" title="xxxx-0-005">xxxx-0-005</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-08-01 13:05 UTC</td>
@@ -264,8 +268,8 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0004" target="_blank">XXXX-0004 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">openshift-1</td>
-              <td data-v-7006d35c="">xxxx-0-004</td>
+              <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+              <td data-v-7006d35c="" title="xxxx-0-004">xxxx-0-004</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-09-01 13:05 UTC</td>
@@ -273,8 +277,8 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0003" target="_blank">XXXX-0003 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">openshift-1</td>
-              <td data-v-7006d35c="">xxxx-0-003</td>
+              <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+              <td data-v-7006d35c="" title="xxxx-0-003">xxxx-0-003</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-10-01 13:05 UTC</td>
@@ -282,8 +286,8 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0002" target="_blank">XXXX-0002 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">openshift-1</td>
-              <td data-v-7006d35c="">xxxx-0-002</td>
+              <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+              <td data-v-7006d35c="" title="xxxx-0-002">xxxx-0-002</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-11-01 13:05 UTC</td>
@@ -291,8 +295,8 @@ exports[`flawAffects > Correctly renders the component when there are affects to
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0001" target="_blank">XXXX-0001 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">openshift-1</td>
-              <td data-v-7006d35c="">xxxx-0-001</td>
+              <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+              <td data-v-7006d35c="" title="xxxx-0-001">xxxx-0-001</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-12-01 13:05 UTC</td>
@@ -443,11 +447,15 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
   <div data-v-0fd8a3c0="" class="affect-modules-selection mb-4">
     <div data-v-357e30d7="" data-v-0fd8a3c0="" class="osim-collapsible-label"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-dash-square-dotted me-1"></i><label data-v-0fd8a3c0="" class="form-label m-2"> Affected Modules </label></button>
       <div data-v-357e30d7="" class="ps-3 border-start">
-        <div data-v-357e30d7="" class=""><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="">
+        <div data-v-357e30d7="" class=""><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="-test">
             <!--v-if--><span data-v-0fd8a3c0="">-test</span>
-          </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-2</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-3</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-4</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="">
+          </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-2
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-2</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-3
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-3</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-4
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-4</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="openshift-5">
             <!--v-if--><span data-v-0fd8a3c0="">openshift-5</span>
-          </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-6</span></button></div>
+          </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-6
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-6</span></button></div>
       </div>
     </div>
     <!--v-if-->
@@ -520,7 +528,7 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="-test">-test</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-1-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-1-1">openshift-1-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -541,7 +549,7 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-2">openshift-2</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-2-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-2-1">openshift-2-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -562,7 +570,7 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-3">openshift-3</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-3-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-3-1">openshift-3-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -583,7 +591,7 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-4">openshift-4</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-4-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-4-1">openshift-4-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -604,7 +612,7 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-5">openshift-5</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-5-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-5-1">openshift-5-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -625,7 +633,7 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-6">openshift-6</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-6-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-6-1">openshift-6-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">WONTFIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">CRITICAL</span></td>
@@ -680,8 +688,8 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
           <tbody data-v-7006d35c="">
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0006" target="_blank">XXXX-0006 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">openshift-5</td>
-              <td data-v-7006d35c="">xxxx-0-006</td>
+              <td data-v-7006d35c="" title="openshift-5">openshift-5</td>
+              <td data-v-7006d35c="" title="xxxx-0-006">xxxx-0-006</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-07-01 13:05 UTC</td>
@@ -689,8 +697,8 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0005" target="_blank">XXXX-0005 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">openshift-5</td>
-              <td data-v-7006d35c="">xxxx-0-005</td>
+              <td data-v-7006d35c="" title="openshift-5">openshift-5</td>
+              <td data-v-7006d35c="" title="xxxx-0-005">xxxx-0-005</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-08-01 13:05 UTC</td>
@@ -698,8 +706,8 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0004" target="_blank">XXXX-0004 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">-test</td>
-              <td data-v-7006d35c="">xxxx-0-004</td>
+              <td data-v-7006d35c="" title="-test">-test</td>
+              <td data-v-7006d35c="" title="xxxx-0-004">xxxx-0-004</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-09-01 13:05 UTC</td>
@@ -707,8 +715,8 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0003" target="_blank">XXXX-0003 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">-test</td>
-              <td data-v-7006d35c="">xxxx-0-003</td>
+              <td data-v-7006d35c="" title="-test">-test</td>
+              <td data-v-7006d35c="" title="xxxx-0-003">xxxx-0-003</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-10-01 13:05 UTC</td>
@@ -716,8 +724,8 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0002" target="_blank">XXXX-0002 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">-test</td>
-              <td data-v-7006d35c="">xxxx-0-002</td>
+              <td data-v-7006d35c="" title="-test">-test</td>
+              <td data-v-7006d35c="" title="xxxx-0-002">xxxx-0-002</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-11-01 13:05 UTC</td>
@@ -725,8 +733,8 @@ exports[`flawAffects > Displays tracker manager for a selection of affects 1`] =
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0001" target="_blank">XXXX-0001 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">-test</td>
-              <td data-v-7006d35c="">xxxx-0-001</td>
+              <td data-v-7006d35c="" title="-test">-test</td>
+              <td data-v-7006d35c="" title="xxxx-0-001">xxxx-0-001</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-12-01 13:05 UTC</td>
@@ -810,11 +818,15 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
   <div data-v-0fd8a3c0="" class="affect-modules-selection mb-4">
     <div data-v-357e30d7="" data-v-0fd8a3c0="" class="osim-collapsible-label"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-dash-square-dotted me-1"></i><label data-v-0fd8a3c0="" class="form-label m-2"> Affected Modules </label></button>
       <div data-v-357e30d7="" class="ps-3 border-start">
-        <div data-v-357e30d7="" class=""><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="">
+        <div data-v-357e30d7="" class=""><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="-test">
             <!--v-if--><span data-v-0fd8a3c0="">-test</span>
-          </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-2</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-3</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-4</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="">
+          </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-2
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-2</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-3
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-3</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-4
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-4</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="openshift-5">
             <!--v-if--><span data-v-0fd8a3c0="">openshift-5</span>
-          </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-6</span></button></div>
+          </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-6
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-6</span></button></div>
       </div>
     </div>
     <!--v-if-->
@@ -890,7 +902,7 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="-test">-test</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-1-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-1-1">openshift-1-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -911,7 +923,7 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-2">openshift-2</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-2-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-2-1">openshift-2-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -932,7 +944,7 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-3">openshift-3</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-3-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-3-1">openshift-3-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -953,7 +965,7 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-4">openshift-4</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-4-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-4-1">openshift-4-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -974,7 +986,7 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-5">openshift-5</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-5-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-5-1">openshift-5-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -995,7 +1007,7 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
           </td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-6">openshift-6</span></td>
-          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-6-1</span></td>
+          <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-6-1">openshift-6-1</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">WONTFIX</span></td>
           <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">CRITICAL</span></td>
@@ -1050,8 +1062,8 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
           <tbody data-v-7006d35c="">
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0006" target="_blank">XXXX-0006 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">openshift-5</td>
-              <td data-v-7006d35c="">xxxx-0-006</td>
+              <td data-v-7006d35c="" title="openshift-5">openshift-5</td>
+              <td data-v-7006d35c="" title="xxxx-0-006">xxxx-0-006</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-07-01 13:05 UTC</td>
@@ -1059,8 +1071,8 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0005" target="_blank">XXXX-0005 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">openshift-5</td>
-              <td data-v-7006d35c="">xxxx-0-005</td>
+              <td data-v-7006d35c="" title="openshift-5">openshift-5</td>
+              <td data-v-7006d35c="" title="xxxx-0-005">xxxx-0-005</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-08-01 13:05 UTC</td>
@@ -1068,8 +1080,8 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0004" target="_blank">XXXX-0004 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">-test</td>
-              <td data-v-7006d35c="">xxxx-0-004</td>
+              <td data-v-7006d35c="" title="-test">-test</td>
+              <td data-v-7006d35c="" title="xxxx-0-004">xxxx-0-004</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-09-01 13:05 UTC</td>
@@ -1077,8 +1089,8 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0003" target="_blank">XXXX-0003 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">-test</td>
-              <td data-v-7006d35c="">xxxx-0-003</td>
+              <td data-v-7006d35c="" title="-test">-test</td>
+              <td data-v-7006d35c="" title="xxxx-0-003">xxxx-0-003</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-10-01 13:05 UTC</td>
@@ -1086,8 +1098,8 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0002" target="_blank">XXXX-0002 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">-test</td>
-              <td data-v-7006d35c="">xxxx-0-002</td>
+              <td data-v-7006d35c="" title="-test">-test</td>
+              <td data-v-7006d35c="" title="xxxx-0-002">xxxx-0-002</td>
               <td data-v-7006d35c="">CLOSED</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-11-01 13:05 UTC</td>
@@ -1095,8 +1107,8 @@ exports[`flawAffects > Displays tracker manager for individual affect 1`] = `
             </tr>
             <tr data-v-7006d35c="">
               <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0001" target="_blank">XXXX-0001 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-              <td data-v-7006d35c="">-test</td>
-              <td data-v-7006d35c="">xxxx-0-001</td>
+              <td data-v-7006d35c="" title="-test">-test</td>
+              <td data-v-7006d35c="" title="xxxx-0-001">xxxx-0-001</td>
               <td data-v-7006d35c="">NEW</td>
               <td data-v-7006d35c=""></td>
               <td data-v-7006d35c="">2024-12-01 13:05 UTC</td>

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -498,11 +498,15 @@ exports[`flawForm > mounts and renders 1`] = `
       <div data-v-0fd8a3c0="" class="affect-modules-selection mb-4">
         <div data-v-357e30d7="" data-v-0fd8a3c0="" class="osim-collapsible-label"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-dash-square-dotted me-1"></i><label data-v-0fd8a3c0="" class="form-label m-2"> Affected Modules </label></button>
           <div data-v-357e30d7="" class="ps-3 border-start">
-            <div data-v-357e30d7="" class=""><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="">
+            <div data-v-357e30d7="" class=""><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="openshift-1">
                 <!--v-if--><span data-v-0fd8a3c0="">openshift-1</span>
-              </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-2</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-3</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-4</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="">
+              </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-2
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-2</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-3
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-3</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-4
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-4</span></button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray" title="openshift-5">
                 <!--v-if--><span data-v-0fd8a3c0="">openshift-5</span>
-              </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-6</span></button></div>
+              </button><button data-v-0fd8a3c0="" type="button" tabindex="-1" class="module-btn btn btn-sm border-gray fw-bold" title="openshift-6
+This module has no trackers associated"><i data-v-0fd8a3c0="" class="bi bi-exclamation-lg"></i><span data-v-0fd8a3c0="">openshift-6</span></button></div>
           </div>
         </div>
         <!--v-if-->
@@ -578,7 +582,7 @@ exports[`flawForm > mounts and renders 1`] = `
                 <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
               </td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-1">openshift-1</span></td>
-              <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-1-1</span></td>
+              <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-1-1">openshift-1-1</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -599,7 +603,7 @@ exports[`flawForm > mounts and renders 1`] = `
                 <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
               </td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-2">openshift-2</span></td>
-              <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-2-1</span></td>
+              <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-2-1">openshift-2-1</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -620,7 +624,7 @@ exports[`flawForm > mounts and renders 1`] = `
                 <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
               </td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-3">openshift-3</span></td>
-              <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-3-1</span></td>
+              <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-3-1">openshift-3-1</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -641,7 +645,7 @@ exports[`flawForm > mounts and renders 1`] = `
                 <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
               </td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-4">openshift-4</span></td>
-              <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-4-1</span></td>
+              <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-4-1">openshift-4-1</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -662,7 +666,7 @@ exports[`flawForm > mounts and renders 1`] = `
                 <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
               </td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-5">openshift-5</span></td>
-              <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-5-1</span></td>
+              <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-5-1">openshift-5-1</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">AFFECTED</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">FIX</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">LOW</span></td>
@@ -683,7 +687,7 @@ exports[`flawForm > mounts and renders 1`] = `
                 <div data-v-0fd8a3c0="" class="ps-3"><i data-v-0fd8a3c0="" class="bi bi-database-check" title="This affect is saved"></i></div>
               </td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-6">openshift-6</span></td>
-              <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">openshift-6-1</span></td>
+              <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="" title="openshift-6-1">openshift-6-1</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0=""></span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">WONTFIX</span></td>
               <td data-v-0fd8a3c0=""><span data-v-0fd8a3c0="">CRITICAL</span></td>
@@ -738,8 +742,8 @@ exports[`flawForm > mounts and renders 1`] = `
               <tbody data-v-7006d35c="">
                 <tr data-v-7006d35c="">
                   <td data-v-7006d35c=""><a data-v-7006d35c="" target="_blank">XXXX-0006 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-                  <td data-v-7006d35c="">openshift-5</td>
-                  <td data-v-7006d35c="">xxxx-0-006</td>
+                  <td data-v-7006d35c="" title="openshift-5">openshift-5</td>
+                  <td data-v-7006d35c="" title="xxxx-0-006">xxxx-0-006</td>
                   <td data-v-7006d35c="">CLOSED</td>
                   <td data-v-7006d35c=""></td>
                   <td data-v-7006d35c="">2024-07-01 13:05 UTC</td>
@@ -747,8 +751,8 @@ exports[`flawForm > mounts and renders 1`] = `
                 </tr>
                 <tr data-v-7006d35c="">
                   <td data-v-7006d35c=""><a data-v-7006d35c="" target="_blank">XXXX-0005 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-                  <td data-v-7006d35c="">openshift-5</td>
-                  <td data-v-7006d35c="">xxxx-0-005</td>
+                  <td data-v-7006d35c="" title="openshift-5">openshift-5</td>
+                  <td data-v-7006d35c="" title="xxxx-0-005">xxxx-0-005</td>
                   <td data-v-7006d35c="">NEW</td>
                   <td data-v-7006d35c=""></td>
                   <td data-v-7006d35c="">2024-08-01 13:05 UTC</td>
@@ -756,8 +760,8 @@ exports[`flawForm > mounts and renders 1`] = `
                 </tr>
                 <tr data-v-7006d35c="">
                   <td data-v-7006d35c=""><a data-v-7006d35c="" target="_blank">XXXX-0004 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-                  <td data-v-7006d35c="">openshift-1</td>
-                  <td data-v-7006d35c="">xxxx-0-004</td>
+                  <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+                  <td data-v-7006d35c="" title="xxxx-0-004">xxxx-0-004</td>
                   <td data-v-7006d35c="">CLOSED</td>
                   <td data-v-7006d35c=""></td>
                   <td data-v-7006d35c="">2024-09-01 13:05 UTC</td>
@@ -765,8 +769,8 @@ exports[`flawForm > mounts and renders 1`] = `
                 </tr>
                 <tr data-v-7006d35c="">
                   <td data-v-7006d35c=""><a data-v-7006d35c="" target="_blank">XXXX-0003 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-                  <td data-v-7006d35c="">openshift-1</td>
-                  <td data-v-7006d35c="">xxxx-0-003</td>
+                  <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+                  <td data-v-7006d35c="" title="xxxx-0-003">xxxx-0-003</td>
                   <td data-v-7006d35c="">NEW</td>
                   <td data-v-7006d35c=""></td>
                   <td data-v-7006d35c="">2024-10-01 13:05 UTC</td>
@@ -774,8 +778,8 @@ exports[`flawForm > mounts and renders 1`] = `
                 </tr>
                 <tr data-v-7006d35c="">
                   <td data-v-7006d35c=""><a data-v-7006d35c="" target="_blank">XXXX-0002 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-                  <td data-v-7006d35c="">openshift-1</td>
-                  <td data-v-7006d35c="">xxxx-0-002</td>
+                  <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+                  <td data-v-7006d35c="" title="xxxx-0-002">xxxx-0-002</td>
                   <td data-v-7006d35c="">CLOSED</td>
                   <td data-v-7006d35c=""></td>
                   <td data-v-7006d35c="">2024-11-01 13:05 UTC</td>
@@ -783,8 +787,8 @@ exports[`flawForm > mounts and renders 1`] = `
                 </tr>
                 <tr data-v-7006d35c="">
                   <td data-v-7006d35c=""><a data-v-7006d35c="" target="_blank">XXXX-0001 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-                  <td data-v-7006d35c="">openshift-1</td>
-                  <td data-v-7006d35c="">xxxx-0-001</td>
+                  <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+                  <td data-v-7006d35c="" title="xxxx-0-001">xxxx-0-001</td>
                   <td data-v-7006d35c="">NEW</td>
                   <td data-v-7006d35c=""></td>
                   <td data-v-7006d35c="">2024-12-01 13:05 UTC</td>

--- a/src/components/__tests__/__snapshots__/FlawTrackers.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawTrackers.spec.ts.snap
@@ -77,8 +77,8 @@ exports[`flawTrackers > Correctly renders the component when there are trackers 
         <tbody data-v-7006d35c="">
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0006" target="_blank">XXXX-0006 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">openshift-5</td>
-            <td data-v-7006d35c="">xxxx-0-006</td>
+            <td data-v-7006d35c="" title="openshift-5">openshift-5</td>
+            <td data-v-7006d35c="" title="xxxx-0-006">xxxx-0-006</td>
             <td data-v-7006d35c="">CLOSED</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-07-01 13:05 UTC</td>
@@ -86,8 +86,8 @@ exports[`flawTrackers > Correctly renders the component when there are trackers 
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0005" target="_blank">XXXX-0005 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">openshift-5</td>
-            <td data-v-7006d35c="">xxxx-0-005</td>
+            <td data-v-7006d35c="" title="openshift-5">openshift-5</td>
+            <td data-v-7006d35c="" title="xxxx-0-005">xxxx-0-005</td>
             <td data-v-7006d35c="">NEW</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-08-01 13:05 UTC</td>
@@ -95,8 +95,8 @@ exports[`flawTrackers > Correctly renders the component when there are trackers 
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0004" target="_blank">XXXX-0004 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">openshift-1</td>
-            <td data-v-7006d35c="">xxxx-0-004</td>
+            <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+            <td data-v-7006d35c="" title="xxxx-0-004">xxxx-0-004</td>
             <td data-v-7006d35c="">CLOSED</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-09-01 13:05 UTC</td>
@@ -104,8 +104,8 @@ exports[`flawTrackers > Correctly renders the component when there are trackers 
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0003" target="_blank">XXXX-0003 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">openshift-1</td>
-            <td data-v-7006d35c="">xxxx-0-003</td>
+            <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+            <td data-v-7006d35c="" title="xxxx-0-003">xxxx-0-003</td>
             <td data-v-7006d35c="">NEW</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-10-01 13:05 UTC</td>
@@ -113,8 +113,8 @@ exports[`flawTrackers > Correctly renders the component when there are trackers 
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0002" target="_blank">XXXX-0002 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">openshift-1</td>
-            <td data-v-7006d35c="">xxxx-0-002</td>
+            <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+            <td data-v-7006d35c="" title="xxxx-0-002">xxxx-0-002</td>
             <td data-v-7006d35c="">CLOSED</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-11-01 13:05 UTC</td>
@@ -122,8 +122,8 @@ exports[`flawTrackers > Correctly renders the component when there are trackers 
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0001" target="_blank">XXXX-0001 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">openshift-1</td>
-            <td data-v-7006d35c="">xxxx-0-001</td>
+            <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+            <td data-v-7006d35c="" title="xxxx-0-001">xxxx-0-001</td>
             <td data-v-7006d35c="">NEW</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-12-01 13:05 UTC</td>
@@ -175,8 +175,8 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
         <tbody data-v-7006d35c="">
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0006" target="_blank">XXXX-0006 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">openshift-5</td>
-            <td data-v-7006d35c="">xxxx-0-006</td>
+            <td data-v-7006d35c="" title="openshift-5">openshift-5</td>
+            <td data-v-7006d35c="" title="xxxx-0-006">xxxx-0-006</td>
             <td data-v-7006d35c="">CLOSED</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-07-01 13:05 UTC</td>
@@ -184,8 +184,8 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0005" target="_blank">XXXX-0005 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">openshift-5</td>
-            <td data-v-7006d35c="">xxxx-0-005</td>
+            <td data-v-7006d35c="" title="openshift-5">openshift-5</td>
+            <td data-v-7006d35c="" title="xxxx-0-005">xxxx-0-005</td>
             <td data-v-7006d35c="">NEW</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-08-01 13:05 UTC</td>
@@ -193,8 +193,8 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0004" target="_blank">XXXX-0004 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">openshift-1</td>
-            <td data-v-7006d35c="">xxxx-0-004</td>
+            <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+            <td data-v-7006d35c="" title="xxxx-0-004">xxxx-0-004</td>
             <td data-v-7006d35c="">CLOSED</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-09-01 13:05 UTC</td>
@@ -202,8 +202,8 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0003" target="_blank">XXXX-0003 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">openshift-1</td>
-            <td data-v-7006d35c="">xxxx-0-003</td>
+            <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+            <td data-v-7006d35c="" title="xxxx-0-003">xxxx-0-003</td>
             <td data-v-7006d35c="">NEW</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-10-01 13:05 UTC</td>
@@ -211,8 +211,8 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0002" target="_blank">XXXX-0002 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">openshift-1</td>
-            <td data-v-7006d35c="">xxxx-0-002</td>
+            <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+            <td data-v-7006d35c="" title="xxxx-0-002">xxxx-0-002</td>
             <td data-v-7006d35c="">CLOSED</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-11-01 13:05 UTC</td>
@@ -220,8 +220,8 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
           </tr>
           <tr data-v-7006d35c="">
             <td data-v-7006d35c=""><a data-v-7006d35c="" href="http://jira-service:8002/browse/XXXX-0001" target="_blank">XXXX-0001 <i data-v-7006d35c="" class="bi-box-arrow-up-right"></i></a></td>
-            <td data-v-7006d35c="">openshift-1</td>
-            <td data-v-7006d35c="">xxxx-0-001</td>
+            <td data-v-7006d35c="" title="openshift-1">openshift-1</td>
+            <td data-v-7006d35c="" title="xxxx-0-001">xxxx-0-001</td>
             <td data-v-7006d35c="">NEW</td>
             <td data-v-7006d35c=""></td>
             <td data-v-7006d35c="">2024-12-01 13:05 UTC</td>


### PR DESCRIPTION
# OSIDB-3453: Add new tooltips for truncated fields

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Adds new tooltips in the affect section redesign to display full string value on fields that can be truncated if too long.

## Changes:

- Adds new tooltips
- Update snapshots
- Adds tooltip tests

## Demo:
https://github.com/user-attachments/assets/e38728bf-0158-4c90-a43d-f26c715f27b9

Closes OSIDB-3453
