### PR TITLE
OSIDB-3419: Fail tests on console warn/error

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -41,6 +41,9 @@ const onUnhandledRequest = vi.fn().mockImplementation((req: Request) => {
 });
 export const server = setupServer();
 
+vi.spyOn(console, 'warn').mockImplementation((msg) => { assert.fail(msg); });
+vi.spyOn(console, 'error').mockImplementation((msg) => { assert.fail(msg); });
+
 beforeAll(() => {
   server.listen({
     onUnhandledRequest,


### PR DESCRIPTION
# OSIDB-3419: Fail tests on console warn/error

## Checklist:

- [x] Commits consolidated
- ~Changelog updated~
- ~Test cases added/updated~
- [x] Jira ticket updated

## Summary:

Force test failure when console warn/error is called

Example:
|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/2e9a80ed-bc84-40d8-b98b-1b006d8f1ccb)|![image](https://github.com/user-attachments/assets/0c56d21b-0a77-4ed1-bf28-3ff6ceb4cd05)\

If the tests needs to call console warn/error, you can override the spy:
```ts
vi.spyOn(console, 'error').mockImplementation(()=>{}); // Remove the `assert.fail`
console.error('something else') // <- This will not fail the test and also not print anything to the console
```

## Considerations:

Closes OSIDB-3419