### PR TITLE
🐛 OSIDB-3474: Dont populate trackers table on new affects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 * Allow emptiness advanced search on supported fields (`OSIDB-3389`)
 * Add additional sortable fields for advance search results (`OSIDB-3388`)
 * Added tootlips with full string value on affect/tracker fields that can be truncated (`OSIDB-3453`)
+* Disable file tracking button for non saved new affects (`OSIDB-3474`)
 
 ### Fixed
 * Fix swapped values on trackers `Modules` and `Stream` values (`OSIDB-3443`)
+* Adding new trackers temporary populate trackers table (`OSIDB-3474`)
 
 ## [2024.9.1]
 ### Fixed

--- a/src/components/FlawAffects.vue
+++ b/src/components/FlawAffects.vue
@@ -1129,7 +1129,7 @@ function fileTrackersForAffects(affects: ZodAffectType[]) {
                   <span class="me-2 my-auto">{{ affect.trackers.length }}</span>
                   <button
                     type="button"
-                    :disabled="isBeingEdited(affect) || isRemoved(affect)"
+                    :disabled="isBeingEdited(affect) || isRemoved(affect) || isNewAffect(affect)"
                     class="btn btn-sm px-1 py-0 d-flex rounded-circle"
                     @click.prevent.stop="fileTrackersForAffects([affect])"
                   >

--- a/src/components/FlawAffects.vue
+++ b/src/components/FlawAffects.vue
@@ -528,7 +528,7 @@ const affectsManaging = ref<ZodAffectType[]>();
 
 const displayedTrackers = computed(() => {
   return sortedAffects.value
-    .filter(affect => !affectsToDelete.value.includes(affect))
+    .filter(affect => !isRemoved(affect) && !isNewAffect(affect))
     .flatMap(affect =>
       affect.trackers.map(tracker => ({
         ...tracker,


### PR DESCRIPTION
# OSIDB-3474: Dont populate trackers table on new affects
## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Fixes an unintentional behavior of populating trackers table when adding new draft affects, which was being removed after saving it. 

## Changes:

- Does not consider trackers of new affects for the trackers table component
- Disable filing tracker button for non saved new affects

## Considerations:

- In any case of filing tracker for non saved affect will throw error triggered by OSIDB response, the change of disabling the button just avoids confusing users

Closes OSIDB-3474