### PR TITLE
OSIDB-3481: Allow users to resize advanced query input

### DIFF
--- a/src/components/DjangoQLInput.vue
+++ b/src/components/DjangoQLInput.vue
@@ -22,7 +22,7 @@ onMounted(() => {
     completionEnabled: true,
     introspections: `${osimRuntime.value.backends.osidb}/osidb/api/v1/introspection`,
     selector: textArea.value,
-    autoResize: true,
+    autoResize: false,
     onSubmit: function (value: string) {
       model.value = value;
       emit('submit', value);

--- a/src/components/__tests__/__snapshots__/DjangoQLInput.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/DjangoQLInput.spec.ts.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`djangoQLInput > should render 1`] = `"<textarea class="form-control" autocomplete="off" style="resize: none; overflow: hidden; height: -3px;"></textarea>"`;
+exports[`djangoQLInput > should render 1`] = `"<textarea class="form-control" autocomplete="off"></textarea>"`;


### PR DESCRIPTION
# OSIDB-3481: Allow users to resize advanced query input

## Checklist:

- [x] Commits consolidated
- ~Changelog updated~
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:
DjangoQL `autoResize` property disabled manually resizing the textArea 


## Considerations:

Closes OSIDB-3481