### PR TITLE
OSIDB-3478: Use UTC on flaw list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 * Corrected wrong tooltips on advance search, empty/non-empty buttons (`OSIDB-3502`)
 * Show comment field on CVSSv3 when the score is the same but the comment is not empty (`OSIDB-3400`)
+* Use UTC time for created date on flaw list (`OSIDB-3478`)
 
 ## [2024.9.2]
 ### Added

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -118,7 +118,7 @@ function relevantFields(issue: any) {
     unembargo_dt: issue.unembargo_dt,
     embargoed: issue.embargoed,
     owner: issue.owner,
-    formattedDate: DateTime.fromISO(issue.created_dt).toFormat('yyyy-MM-dd'),
+    formattedDate: DateTime.fromISO(issue.created_dt).toUTC().toFormat('yyyy-MM-dd'),
   };
 }
 

--- a/src/components/__tests__/IssueQueue.spec.ts
+++ b/src/components/__tests__/IssueQueue.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { Settings } from 'luxon';
 
 import IssueQueueItem from '@/components/IssueQueueItem.vue';
 
@@ -68,6 +69,7 @@ describe('issueQueue', () => {
 
   afterAll(() => {
     vi.clearAllMocks();
+    Settings.defaultZone = 'local';
   });
 
   it('should fetch data from API', async () => {
@@ -295,5 +297,21 @@ describe('issueQueue', () => {
     expect(defaultFilterEL.findAll('span.badge')).toHaveLength(1);
     const filterOptionEL = defaultFilterEL.find('span.badge');
     expect(filterOptionEL.text()).toBe('Affected Component : test');
+  });
+
+  it('should render create_dt in UTC format', async () => {
+    Settings.defaultZone = 'Europe/Madrid';
+    const wrapper = mountWithConfig(IssueQueue, {
+      props: {
+        issues: [{ ...mockData[0], created_dt: '2021-07-29T22:50:50Z' }],
+        isLoading: false,
+        isFinalPageFetched: false,
+        total: 10,
+      },
+    });
+
+    const dateEl = wrapper.findAll('td')[2];
+    expect(dateEl.exists()).toBeTruthy();
+    expect(dateEl.text()).toBe('2021-07-29');
   });
 });


### PR DESCRIPTION
# OSIDB-3478: Use UTC on flaw list

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:
Flaw creation date was using local timezone instead of UTC.
Because we only show dates (and no time) it wasn't obvious, but depending on the user timezone the date could change (i.e. `29-08-2024 22:05 UTC` = `30-08-2024 00:05 GMT+2`)

## Changes:
Added `toUtc` to `formattedDate` field

## Considerations:

Closes OSIDB-3478