### PR TITLE
OSIDB-3400: Show CVSS comment field when there's a comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 * Corrected wrong tooltips on advance search, empty/non-empty buttons (`OSIDB-3502`)
+* Show comment field on CVSSv3 when the score is the same but the comment is not empty (`OSIDB-3400`)
 
 ## [2024.9.2]
 ### Added

--- a/src/composables/__tests__/useFlawCvssScores.spec.ts
+++ b/src/composables/__tests__/useFlawCvssScores.spec.ts
@@ -1,0 +1,47 @@
+import { ref } from 'vue';
+
+import { osimFullFlawTest } from '@/components/__tests__/test-suite-helpers';
+
+import { useFlawCvssScores } from '../useFlawCvssScores';
+import { blankFlaw } from '../useFlawModel';
+
+describe('useFlawCvssScores', () => {
+  osimFullFlawTest('should return an object', ({ flaw }) => {
+    const cvssScore = useFlawCvssScores(ref(flaw));
+
+    expect(cvssScore).toBeInstanceOf(Object);
+    expect(Object.keys(cvssScore)).toHaveLength(7);
+  });
+
+  describe('shouldDisplayEmailNistForm', () => {
+    it('should be false when flaw does not have scores', () => {
+      const { shouldDisplayEmailNistForm } = useFlawCvssScores(ref(blankFlaw()));
+
+      expect(shouldDisplayEmailNistForm.value).toBeFalsy();
+    });
+
+    osimFullFlawTest('should be true when flaw has different scores', ({ flaw }) => {
+      const { shouldDisplayEmailNistForm } = useFlawCvssScores(ref(flaw));
+
+      expect(shouldDisplayEmailNistForm.value).toBeTruthy();
+    });
+
+    osimFullFlawTest('should be false when flaw has the same scores and no comment', ({ flaw }) => {
+      flaw.cvss_scores[0].comment = '';
+      flaw.cvss_scores[1] = { ...flaw.cvss_scores[0], issuer: 'NIST' };
+
+      const { shouldDisplayEmailNistForm } = useFlawCvssScores(ref(flaw));
+
+      expect(shouldDisplayEmailNistForm.value).toBeFalsy();
+    });
+
+    osimFullFlawTest('should be true when scores have comments', ({ flaw }) => {
+      flaw.cvss_scores[1] = { ...flaw.cvss_scores[0], issuer: 'NIST' };
+      flaw.cvss_scores[0].comment = 'This is a comment';
+
+      const { shouldDisplayEmailNistForm } = useFlawCvssScores(ref(flaw));
+
+      expect(shouldDisplayEmailNistForm.value).toBeTruthy();
+    });
+  });
+});

--- a/src/composables/useFlawCvssScores.ts
+++ b/src/composables/useFlawCvssScores.ts
@@ -58,6 +58,9 @@ export function useFlawCvssScores(flaw: Ref<ZodFlawType>) {
     if (rhCvss3String.value === '' || nvdCvss3String.value === '-') {
       return false;
     }
+    if (flawRhCvss3.value.comment) {
+      return true;
+    }
     return `${rhCvss3String.value}` !== `${nvdCvss3String.value}`;
   });
 


### PR DESCRIPTION
# OSIDB-3400: Show CVSS comment field whe there's a comment

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

The CVSS comment field explaining the difference between RH and NIST was only shown when both issuer had different scores.  The users complaint that after updating the scores to match, the field was hiding, making it impossible to remove the now unneeded explanation.

## Changes:

Added a condition to the `shouldDisplayEmailNistForm` variable that checks if the comment field is filled and shows it even when both issuer have the same score

## Considerations:

Fixes OSIDB-3400
