### PR TITLE
🐛 OSIDB-3533: Reset affects delegated resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Corrected wrong tooltips on advance search, empty/non-empty buttons (`OSIDB-3502`)
 * Show comment field on CVSSv3 when the score is the same but the comment is not empty (`OSIDB-3400`)
 * Use UTC time for created date on flaw list (`OSIDB-3478`)
+* Automatically reset affect's delegated resolution when affectedness is set to not affected (`OSIDB-3533`)
 
 ## [2024.9.2]
 ### Added

--- a/src/components/FlawAffects.vue
+++ b/src/components/FlawAffects.vue
@@ -279,6 +279,15 @@ const handleEdit = (event: KeyboardEvent, affect: ZodAffectType) => {
   }
 };
 
+function affectednessChange(event: Event, affect: ZodAffectType) {
+  const selectElement = event.target as HTMLSelectElement;
+  const selectedValue = selectElement.value;
+  if (selectedValue === 'NOTAFFECTED') {
+    affect.delegated_resolution = '';
+    affect.resolution = '';
+  }
+}
+
 // Modified affects
 const omitAffectAttribute = (obj: ZodAffectType, key: keyof ZodAffectType) => {
   const { [key]: _, ...rest } = obj;
@@ -1058,6 +1067,7 @@ function fileTrackersForAffects(affects: ZodAffectType[]) {
                   v-model="affect.affectedness"
                   class="form-select"
                   @keydown="handleEdit($event, affect)"
+                  @change="affectednessChange($event, affect)"
                 >
                   <option
                     v-for="option in affectAffectedness"


### PR DESCRIPTION
# OSIDB-3533: Reset affects delegated resolution

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [x] Jira ticket updated

## Summary:

When an affect with delegated resolution was changed to have non affected affectedness, the resolution was kept as delegated, making it not valid and ending up with an error response form OSIDB when trying to save the flaw.

## Changes:

- Automatically resets resolution to an empty value when an affect's affectedness is set to non affected

Closes OSIDB-3533
