### PR TITLE
🐛 Fix flaw history validation issue

### DIFF
--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -123,7 +123,7 @@ export const ZodHistoryItemSchema = z.object({
   pgh_slug: z.string().nullish(),
   pgh_label: z.string(),
   pgh_context: z.object({ url: z.string(), user: z.number() }).nullable(),
-  pgh_diff: z.record(z.array(z.string())).nullable(),
+  pgh_diff: z.record(z.array(z.any())).nullable(),
 });
 
 export type ZodFlawType = z.infer<typeof ZodFlawSchema>;


### PR DESCRIPTION
# Fix flaw history validation issue

## Checklist:

- [x] Commits consolidated
- [-] Changelog updated
- [-] Test cases added/updated
- [-] Jira ticket updated

## Summary:

Fixes validation errors when saving a flaw cause of the use of strict string on the history type on the zod flaw model.

## Changes:

- Use `any` type on the diff attribute for the history flaw zod model
