### PR TITLE
🐛 OSIDB-3592: Bugzilla link overlap on flaw state promotion button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OSIM Changelog
 
+## [Unreleased]
+### Fixed
+* Corrected BZ link overlapping flaw promotion button (`OSIDB-3529`)
+
 ## [2024.10.0]
 ### Added
 * Extend incident types to include 'Minor' and 'Zero Day' (`OSIDB-3442`)

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -212,7 +212,7 @@ const createdDate = computed(() => {
         class="row px-4 my-3"
         :class="{'osim-flaw-form-embargoed border border-2 border-primary': flaw.embargoed}"
       >
-        <div class="row osim-flaw-form-section">
+        <div class="row osim-flaw-form-section pt-0">
           <div class="osim-flaw-form-header">
             <div v-if="flaw.meta_attr?.bz_id" class="osim-flaw-header-link">
               <a
@@ -617,7 +617,7 @@ div.osim-content {
 .osim-flaw-header-link {
   position: absolute;
   right: 0;
-  top: 2.5rem;
+  top: 1rem;
   width: auto;
 }
 </style>

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -617,7 +617,7 @@ div.osim-content {
 .osim-flaw-header-link {
   position: absolute;
   right: 0;
-  top: 2rem;
+  top: 2.5rem;
   width: auto;
 }
 </style>

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -216,7 +216,6 @@ const createdDate = computed(() => {
           <div v-if="flaw.meta_attr?.bz_id" class="osim-flaw-header-link">
             <a
               :href="bugzillaLink"
-              class="osim-bugzilla-link"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/components/FlawForm.vue
+++ b/src/components/FlawForm.vue
@@ -213,20 +213,22 @@ const createdDate = computed(() => {
         :class="{'osim-flaw-form-embargoed border border-2 border-primary': flaw.embargoed}"
       >
         <div class="row osim-flaw-form-section">
-          <div v-if="flaw.meta_attr?.bz_id" class="osim-flaw-header-link">
-            <a
-              :href="bugzillaLink"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Open in Bugzilla <i class="bi-box-arrow-up-right ms-2" />
-            </a>
+          <div class="osim-flaw-form-header">
+            <div v-if="flaw.meta_attr?.bz_id" class="osim-flaw-header-link">
+              <a
+                :href="bugzillaLink"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open in Bugzilla <i class="bi-box-arrow-up-right ms-2" />
+              </a>
+            </div>
+            <FlawAlertsList
+              :flaw="flaw"
+              class="col-12 osim-alerts-banner"
+              @expandFocusedComponent="expandFocusedComponent"
+            />
           </div>
-          <FlawAlertsList
-            :flaw="flaw"
-            class="col-12 osim-alerts-banner"
-            @expandFocusedComponent="expandFocusedComponent"
-          />
           <div :id="flaw.uuid" class="col-6">
             <LabelEditable
               v-model="flaw.title"
@@ -503,8 +505,9 @@ form.osim-flaw-form :deep(*) {
     padding-block: 1.5rem;
   }
 
-  .osim-alerts-banner {
+  .osim-flaw-form-header {
     min-height: 3rem;
+    margin-block: 0.5rem;
   }
 }
 

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -460,7 +460,7 @@ describe('flawForm', () => {
   osimFullFlawTest('should show a link to bugzilla if ID exists', async ({ flaw }) => {
     const subject = mountWithProps({ flaw, mode: 'edit' });
 
-    const bugzillaLink = subject.find('.osim-bugzilla-link');
+    const bugzillaLink = subject.find('.osim-flaw-header-link > a');
     expect(bugzillaLink.exists()).toBe(true);
   });
 
@@ -468,7 +468,7 @@ describe('flawForm', () => {
     flaw.meta_attr = {};
     const subject = mountWithProps({ flaw, mode: 'edit' });
 
-    const bugzillaLink = subject.find('.osim-bugzilla-link');
+    const bugzillaLink = subject.find('.osim-flaw-header-link > a');
     expect(bugzillaLink.exists()).toBe(false);
   });
 

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -4,69 +4,71 @@ exports[`flawForm > mounts and renders 1`] = `
 "<form data-v-bb5d5f91="" class="osim-flaw-form">
   <div data-v-bb5d5f91="" class="osim-content container-fluid">
     <div data-v-bb5d5f91="" class="row px-4 my-3">
-      <div data-v-bb5d5f91="" class="row osim-flaw-form-section">
-        <div data-v-bb5d5f91="" class="osim-flaw-header-link"><a data-v-bb5d5f91="" href="/show_bug.cgi?id=1984541" class="osim-bugzilla-link" target="_blank" rel="noopener noreferrer"> Open in Bugzilla <i data-v-bb5d5f91="" class="bi-box-arrow-up-right ms-2"></i></a></div>
-        <div data-v-357e30d7="" data-v-bb5d5f91="" class="osim-collapsible-label my-2 col-12 osim-alerts-banner my-2 col-12 osim-alerts-banner"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-plus-square-dotted me-1"></i><label class="mx-2 mb-0 form-label"> Alerts: </label><span><div class="badge text-bg-danger mx-1"><i class="bi bi-x-circle-fill"></i> 1 Errors </div><div class="badge text-bg-warning mx-1"><i class="bi bi-exclamation-triangle-fill"></i> 1 Warnings </div></span></button>
-          <div data-v-357e30d7="" class="ps-3 border-start">
-            <div data-v-357e30d7="" class="visually-hidden">
-              <div data-v-357e30d7="" class="osim-collapsible-label"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-plus-square-dotted me-1"></i><span><label class="mx-2">Flaw:</label><span><!--v-if--><span class="badge text-bg-warning mx-1"><i class="bi bi-exclamation-triangle-fill"></i> 1 Warnings </span></span></span></button>
-                <div data-v-357e30d7="" class="ps-3 border-start">
-                  <div data-v-357e30d7="" class="visually-hidden">
-                    <div>
-                      <!--v-if-->
-                    </div>
-                    <div>
-                      <div><span><div data-v-eef2791a="" class="alert my-1 p-2 alert-warning" role="alert"><div data-v-357e30d7="" data-v-eef2791a="" class="osim-collapsible-label"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-plus-square-dotted me-1"></i><span data-v-eef2791a="" class="badge mx-2 text-bg-warning"><i data-v-eef2791a="" class="bi bi-exclamation-triangle-fill"></i> Warning cvss3_missing</span></button>
-                        <div data-v-357e30d7="" class="ps-3 border-start">
-                          <div data-v-357e30d7="" class="visually-hidden">
-                            <div data-v-eef2791a="" class="ms-1 py-2 container text-left">
-                              <div data-v-eef2791a="" class="osim-flaw-alert-info"><strong data-v-eef2791a="">Description:</strong><span data-v-eef2791a=""> CVSSv3 score is missing.</span></div>
-                              <div data-v-eef2791a="" class="osim-flaw-alert-info"><strong data-v-eef2791a="">How To Resolve:</strong><span data-v-eef2791a=""> No resolution steps are defined.</span></div>
-                              <div data-v-eef2791a="" class="row mt-2">
-                                <div data-v-eef2791a="" class="col"><button data-v-eef2791a="" type="button" class="btn btn-sm btn-secondary"> Scroll To Origin <i data-v-eef2791a="" class="bi bi-arrow-down-circle"></i></button></div>
+      <div data-v-bb5d5f91="" class="row osim-flaw-form-section pt-0">
+        <div data-v-bb5d5f91="" class="osim-flaw-form-header">
+          <div data-v-bb5d5f91="" class="osim-flaw-header-link"><a data-v-bb5d5f91="" href="/show_bug.cgi?id=1984541" target="_blank" rel="noopener noreferrer"> Open in Bugzilla <i data-v-bb5d5f91="" class="bi-box-arrow-up-right ms-2"></i></a></div>
+          <div data-v-357e30d7="" data-v-bb5d5f91="" class="osim-collapsible-label my-2 col-12 osim-alerts-banner my-2 col-12 osim-alerts-banner"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-plus-square-dotted me-1"></i><label class="mx-2 mb-0 form-label"> Alerts: </label><span><div class="badge text-bg-danger mx-1"><i class="bi bi-x-circle-fill"></i> 1 Errors </div><div class="badge text-bg-warning mx-1"><i class="bi bi-exclamation-triangle-fill"></i> 1 Warnings </div></span></button>
+            <div data-v-357e30d7="" class="ps-3 border-start">
+              <div data-v-357e30d7="" class="visually-hidden">
+                <div data-v-357e30d7="" class="osim-collapsible-label"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-plus-square-dotted me-1"></i><span><label class="mx-2">Flaw:</label><span><!--v-if--><span class="badge text-bg-warning mx-1"><i class="bi bi-exclamation-triangle-fill"></i> 1 Warnings </span></span></span></button>
+                  <div data-v-357e30d7="" class="ps-3 border-start">
+                    <div data-v-357e30d7="" class="visually-hidden">
+                      <div>
+                        <!--v-if-->
+                      </div>
+                      <div>
+                        <div><span><div data-v-eef2791a="" class="alert my-1 p-2 alert-warning" role="alert"><div data-v-357e30d7="" data-v-eef2791a="" class="osim-collapsible-label"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-plus-square-dotted me-1"></i><span data-v-eef2791a="" class="badge mx-2 text-bg-warning"><i data-v-eef2791a="" class="bi bi-exclamation-triangle-fill"></i> Warning cvss3_missing</span></button>
+                          <div data-v-357e30d7="" class="ps-3 border-start">
+                            <div data-v-357e30d7="" class="visually-hidden">
+                              <div data-v-eef2791a="" class="ms-1 py-2 container text-left">
+                                <div data-v-eef2791a="" class="osim-flaw-alert-info"><strong data-v-eef2791a="">Description:</strong><span data-v-eef2791a=""> CVSSv3 score is missing.</span></div>
+                                <div data-v-eef2791a="" class="osim-flaw-alert-info"><strong data-v-eef2791a="">How To Resolve:</strong><span data-v-eef2791a=""> No resolution steps are defined.</span></div>
+                                <div data-v-eef2791a="" class="row mt-2">
+                                  <div data-v-eef2791a="" class="col"><button data-v-eef2791a="" type="button" class="btn btn-sm btn-secondary"> Scroll To Origin <i data-v-eef2791a="" class="bi bi-arrow-down-circle"></i></button></div>
+                                </div>
                               </div>
                             </div>
                           </div>
                         </div>
-                      </div>
-                    </div></span>
+                      </div></span>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div data-v-357e30d7="" class="osim-collapsible-label"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-plus-square-dotted me-1"></i><span><label class="mx-2">Flaw Acknowledgments:</label><span><span class="badge text-bg-danger mx-1"><i class="bi bi-x-circle-fill"></i> 1 Errors </span>
-              <!--v-if--></span></span>
-            </button>
-            <div data-v-357e30d7="" class="ps-3 border-start">
-              <div data-v-357e30d7="" class="visually-hidden">
-                <div>
-                  <div><span><div data-v-eef2791a="" class="alert my-1 p-2 alert-danger" role="alert"><div data-v-357e30d7="" data-v-eef2791a="" class="osim-collapsible-label"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-plus-square-dotted me-1"></i><span data-v-eef2791a="" class="badge mx-2 text-bg-danger"><i data-v-eef2791a="" class="bi bi-x-circle-fill"></i> Error _validate_public_source_no_ack</span></button>
-                    <div data-v-357e30d7="" class="ps-3 border-start">
-                      <div data-v-357e30d7="" class="visually-hidden">
-                        <div data-v-eef2791a="" class="ms-1 py-2 container text-left">
-                          <div data-v-eef2791a="" class="osim-flaw-alert-info"><strong data-v-eef2791a="">Description:</strong><span data-v-eef2791a=""> Flaw contains acknowledgments for public source LKML</span></div>
-                          <div data-v-eef2791a="" class="osim-flaw-alert-info"><strong data-v-eef2791a="">How To Resolve:</strong><span data-v-eef2791a=""> No resolution steps are defined.</span></div>
-                          <div data-v-eef2791a="" class="row mt-2">
-                            <div data-v-eef2791a="" class="col"><button data-v-eef2791a="" type="button" class="btn btn-sm btn-secondary"> Scroll To Origin <i data-v-eef2791a="" class="bi bi-arrow-down-circle"></i></button></div>
+            <div data-v-357e30d7="" class="osim-collapsible-label"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-plus-square-dotted me-1"></i><span><label class="mx-2">Flaw Acknowledgments:</label><span><span class="badge text-bg-danger mx-1"><i class="bi bi-x-circle-fill"></i> 1 Errors </span>
+                <!--v-if--></span></span>
+              </button>
+              <div data-v-357e30d7="" class="ps-3 border-start">
+                <div data-v-357e30d7="" class="visually-hidden">
+                  <div>
+                    <div><span><div data-v-eef2791a="" class="alert my-1 p-2 alert-danger" role="alert"><div data-v-357e30d7="" data-v-eef2791a="" class="osim-collapsible-label"><button data-v-357e30d7="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-357e30d7="" class="bi bi-plus-square-dotted me-1"></i><span data-v-eef2791a="" class="badge mx-2 text-bg-danger"><i data-v-eef2791a="" class="bi bi-x-circle-fill"></i> Error _validate_public_source_no_ack</span></button>
+                      <div data-v-357e30d7="" class="ps-3 border-start">
+                        <div data-v-357e30d7="" class="visually-hidden">
+                          <div data-v-eef2791a="" class="ms-1 py-2 container text-left">
+                            <div data-v-eef2791a="" class="osim-flaw-alert-info"><strong data-v-eef2791a="">Description:</strong><span data-v-eef2791a=""> Flaw contains acknowledgments for public source LKML</span></div>
+                            <div data-v-eef2791a="" class="osim-flaw-alert-info"><strong data-v-eef2791a="">How To Resolve:</strong><span data-v-eef2791a=""> No resolution steps are defined.</span></div>
+                            <div data-v-eef2791a="" class="row mt-2">
+                              <div data-v-eef2791a="" class="col"><button data-v-eef2791a="" type="button" class="btn btn-sm btn-secondary"> Scroll To Origin <i data-v-eef2791a="" class="bi bi-arrow-down-circle"></i></button></div>
+                            </div>
                           </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                </div></span>
+                  </div></span>
+                </div>
               </div>
-            </div>
-            <div>
-              <!--v-if-->
+              <div>
+                <!--v-if-->
+              </div>
             </div>
           </div>
         </div>
+        <!--v-if-->
+        <!--v-if-->
+        <!--v-if-->
+        <!--v-if-->
       </div>
-      <!--v-if-->
-      <!--v-if-->
-      <!--v-if-->
-      <!--v-if-->
     </div>
   </div>
   </div>

--- a/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
+++ b/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
@@ -5,9 +5,11 @@ exports[`flawCreateView > should render 1`] = `
   <form data-v-bb5d5f91="" data-v-764cfa6a="" class="osim-flaw-form">
     <div data-v-bb5d5f91="" class="osim-content container-fluid">
       <div data-v-bb5d5f91="" class="row px-4 my-3">
-        <div data-v-bb5d5f91="" class="row osim-flaw-form-section">
-          <!--v-if-->
-          <!--v-if-->
+        <div data-v-bb5d5f91="" class="row osim-flaw-form-section pt-0">
+          <div data-v-bb5d5f91="" class="osim-flaw-form-header">
+            <!--v-if-->
+            <!--v-if-->
+          </div>
           <div data-v-bb5d5f91="" id="" class="col-6"><label data-v-3f715d23="" data-v-bb5d5f91="" class="osim-input ps-3 mb-2 input-group">
               <div data-v-3f715d23="" class="row"><span data-v-3f715d23="" class="form-label col-3">Title</span>
                 <!--v-if-->


### PR DESCRIPTION
# OSIDB-3592: Bugzilla link overlap on flaw state promotion button

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Fix BZ flaw link overlapping promotion button when no alerts are present

## Changes:

- Adds a "flaw header" div to have always a static space for header elements (even some of them are not present)
- Remove an unnecessary class
- Adjust vertical alignment of the BZ link

## Considerations
### Before:
![image](https://github.com/user-attachments/assets/30f7ebd8-f298-44dc-974e-834c0f5ad3f8)

### After:
![image](https://github.com/user-attachments/assets/3ac9ff19-7fc2-43aa-b499-e671b59db449)

### New improved alignment:
![image](https://github.com/user-attachments/assets/6917b830-464e-4b49-ad57-23bbe752fa3c)

* Note: Also now the space between the flaw form and the top bar is always the same independently of the flaw header items displayed.
** In flaw creation that space is also the same.

Closes OSIDB-3592
