### PR TITLE
OSIDB-3137: Allow multiple user saved searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 ### Fixed
 * Time format on history dates changed from 12h to 24h (`OSIDB-3645`)
 
+### Added
+* Support multiple user saved searches (`OSIDB-3554`)
+* Allow editing/removing/adding saved user searches (`OSIDB-3555`)
+
+### Changed
+* Extend advance search UI to handle multiple saved searches (`OSIDB-3556`)
+
 ## [2024.11.0]
 ### Added
 * Add multi-flaw tracker filing (`OSIDB-3129`)

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -174,13 +174,13 @@ const nameForOption = (fieldName: string) => {
   return name.charAt(0).toUpperCase() + name.slice(1);
 };
 
-function clearDefaultFilter() {
-  searchStore.resetFilter();
-  addToast({
-    title: 'Default Filter',
-    body: 'User\'s default filter cleared',
-  });
-}
+// function clearDefaultFilter() {
+//   searchStore.resetFilter();
+//   addToast({
+//     title: 'Default Filter',
+//     body: 'User\'s default filter cleared',
+//   });
+// }
 </script>
 
 <template>
@@ -211,10 +211,11 @@ function clearDefaultFilter() {
     </div>
     <div v-if="showFilter" class="d-flex gap-2">
       <details class="osim-default-filter">
-        <summary>Default Filters
+        <!-- <summary>Default Filters
           <button class="btn btn-sm btn-primary lh-0 py-0" @click="clearDefaultFilter()">
             clear
-          </button></summary>
+          </button>
+        </summary> -->
         <div class="my-2">
           <span
             v-for="(value, key) in defaultFilters"

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -7,9 +7,7 @@ import IssueQueueItem from '@/components/IssueQueueItem.vue';
 import LabelCheckbox from '@/components/widgets/LabelCheckbox.vue';
 
 import { useUserStore } from '@/stores/UserStore';
-import { useSearchStore } from '@/stores/SearchStore';
 import { FlawClassificationStateEnum } from '@/generated-client';
-import { useToastStore } from '@/stores/ToastStore';
 
 const props = defineProps<{
   defaultFilters?: Record<string, string>;
@@ -22,8 +20,6 @@ const props = defineProps<{
 const isDefaultFilterSelected = defineModel<boolean>('isDefaultFilterSelected', { default: true });
 const emit = defineEmits(['flaws:fetch', 'flaws:load-more']);
 const userStore = useUserStore();
-const searchStore = useSearchStore();
-const { addToast } = useToastStore();
 
 type FilteredIssue = {
   issue: any;
@@ -173,14 +169,6 @@ const nameForOption = (fieldName: string) => {
   name = name.replace(/_/g, ' ');
   return name.charAt(0).toUpperCase() + name.slice(1);
 };
-
-// function clearDefaultFilter() {
-//   searchStore.resetFilter();
-//   addToast({
-//     title: 'Default Filter',
-//     body: 'User\'s default filter cleared',
-//   });
-// }
 </script>
 
 <template>
@@ -211,11 +199,6 @@ const nameForOption = (fieldName: string) => {
     </div>
     <div v-if="showFilter" class="d-flex gap-2">
       <details class="osim-default-filter">
-        <!-- <summary>Default Filters
-          <button class="btn btn-sm btn-primary lh-0 py-0" @click="clearDefaultFilter()">
-            clear
-          </button>
-        </summary> -->
         <div class="my-2">
           <span
             v-for="(value, key) in defaultFilters"

--- a/src/components/IssueQueue.vue
+++ b/src/components/IssueQueue.vue
@@ -10,14 +10,11 @@ import { useUserStore } from '@/stores/UserStore';
 import { FlawClassificationStateEnum } from '@/generated-client';
 
 const props = defineProps<{
-  defaultFilters?: Record<string, string>;
   isFinalPageFetched: boolean;
   isLoading: boolean;
   issues: any[];
-  showFilter?: boolean;
   total: number;
 }>();
-const isDefaultFilterSelected = defineModel<boolean>('isDefaultFilterSelected', { default: true });
 const emit = defineEmits(['flaws:fetch', 'flaws:load-more']);
 const userStore = useUserStore();
 
@@ -146,29 +143,6 @@ function emitLoadMore() {
 watch(params, () => {
   emit('flaws:fetch', params);
 });
-
-const nameForOption = (fieldName: string) => {
-  const mappings: Record<string, string> = {
-    uuid: 'UUID',
-    cvss_scores__score: 'CVSS Score',
-    cvss_scores__vector: 'CVSS Vector',
-    affects__ps_module: 'Affected Module',
-    affects__ps_component: 'Affected Component',
-    affects__trackers__ps_update_stream: 'Affect Update Stream',
-    acknowledgments__name: 'Acknowledgment Author',
-    affects__trackers__errata__advisory_name: 'Errata Advisory Name',
-    affects__trackers__external_system_id: 'Tracker External System ID',
-    workflow_state: 'Flaw State',
-    cwe_id: 'CWE ID',
-    cve_id: 'CVE ID',
-    source: 'CVE Source',
-  };
-  let name =
-    mappings[fieldName]
-    || fieldName.replace(/__[a-z]/g, label => `: ${label.charAt(2).toUpperCase()}`);
-  name = name.replace(/_/g, ' ');
-  return name.charAt(0).toUpperCase() + name.slice(1);
-};
 </script>
 
 <template>
@@ -176,12 +150,6 @@ const nameForOption = (fieldName: string) => {
     <div class="osim-incident-filter">
       <LabelCheckbox v-model="isMyIssuesSelected" label="My Issues" class="d-inline-block" />
       <LabelCheckbox v-model="isOpenIssuesSelected" label="Open Issues" class="d-inline-block" />
-      <LabelCheckbox
-        v-if="showFilter"
-        v-model="isDefaultFilterSelected"
-        label="Default Filter"
-        class="d-inline-block"
-      />
       <div v-if="isLoading" class="d-inline-block float-end">
         <span
           class="spinner-border spinner-border-sm"
@@ -196,19 +164,6 @@ const nameForOption = (fieldName: string) => {
         class="float-end"
         :class="{'text-secondary': isLoading}"
       > Loaded {{ issues.length }} of {{ total }}</span>
-    </div>
-    <div v-if="showFilter" class="d-flex gap-2">
-      <details class="osim-default-filter">
-        <div class="my-2">
-          <span
-            v-for="(value, key) in defaultFilters"
-            :key="key"
-            class="badge bg-secondary me-1"
-          >
-            {{ nameForOption(key) }} : {{ value }}
-          </span>
-        </div>
-      </details>
     </div>
     <div ref="tableContainerEl" class="osim-incident-list">
       <table class="table align-middle" :class="{ 'osim-table-loading': isLoading }">

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -27,6 +27,7 @@ const emit = defineEmits<{
   'filter:save': [name: string];
   'filter:update': [];
   'savedSearch:select': [index: number];
+  'savedSearch:setDefault': [index: number];
 }>();
 
 const {
@@ -297,6 +298,11 @@ function closeSavingSearchModal() {
           @click="emit('savedSearch:select', index)"
         >
           {{ savedSearch.name }}
+          <i
+            class="bi ms-2"
+            :class="savedSearch.default ? 'bi-star-fill' : 'bi-star'"
+            @click.stop="emit('savedSearch:setDefault', index)"
+          />
         </button>
       </template>
     </div>

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -460,6 +460,14 @@ function closeSavingSearchModal() {
     width: 241.5px;
   }
 }
+
+details {
+  user-select: none;
+
+  summary {
+    width: fit-content;
+  }
+}
 </style>
 
 <style lang="scss">

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -45,6 +45,8 @@ const savingSearchModal = useModal();
 
 const newSearchName = ref('');
 
+const emptySearch = computed(() => facets.value.length <= 1 && !query.value);
+
 const invalidSearcName = computed(() =>
   newSearchName.value === '' || props.savedSearches.some(search => search.name === newSearchName.value),
 );
@@ -351,7 +353,7 @@ function closeSavingSearchModal() {
         class="btn btn-primary me-2"
         aria-label="Save filters as default"
         type="button"
-        :disabled="isLoading"
+        :disabled="isLoading || emptySearch"
         @click="openSavingSearchModal()"
       >
         Save Search

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -263,7 +263,7 @@ function handleToggleOrder() {
     :open="showSavedSearches"
     class="osim-advanced-search-container container-fluid"
   >
-    <summary @click="showSavedSearches = true"> Saved Searches</summary>
+    <summary @click="showSavedSearches === true"> Saved Searches</summary>
     <div class="d-flex mt-2">
       <template v-for="(savedSearch, index) in savedSearches" :key="index">
         <button

--- a/src/components/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced.vue
@@ -131,7 +131,7 @@ function handleToggleOrder() {
             <i class="bi bi-question-circle-fill fs-5" aria-label="hide query filter" />
           </button>
         </div>
-        <DjangoQLInput v-model="query" @submit="submitAdvancedSearch()" />
+        <DjangoQLInput v-model="query" style="height: 38px;" @submit="submitAdvancedSearch()" />
         <button
           :disabled="!query"
           class="btn btn-sm btn-secondary rounded-0 py-0"

--- a/src/components/__tests__/IssueQueue.spec.ts
+++ b/src/components/__tests__/IssueQueue.spec.ts
@@ -9,8 +9,9 @@ import IssueQueue from '../IssueQueue.vue';
 import LabelCheckbox from '../widgets/LabelCheckbox.vue';
 
 vi.mock('@vueuse/core', () => ({
-  useLocalStorage: vi.fn((key: string) => {
+  useLocalStorage: vi.fn((key: string, defaults) => {
     return {
+      SearchStore: { value: defaults },
       UserStore: {
         value: {
           // Set your fake user data here
@@ -260,43 +261,6 @@ describe('issueQueue', () => {
     expect(filterEl.exists()).toBeTruthy();
     const spinner = filterEl.find('div.float-end span.spinner-border');
     expect(spinner.exists()).toBeTruthy();
-  });
-
-  it('shouldn\'t render useDefault filter button', async () => {
-    const wrapper = mountWithConfig(IssueQueue, {
-      props: {
-        issues: mockData,
-        isLoading: false,
-        isFinalPageFetched: false,
-        showFilter: false,
-        total: 10,
-      },
-    });
-    const defaultFilterCheckbox = wrapper.findAllComponents(LabelCheckbox)[2];
-    expect(defaultFilterCheckbox).toBeFalsy();
-    const defaultFilterEL = wrapper.find('details.osim-default-filter');
-    expect(defaultFilterEL.exists()).toBeFalsy();
-  });
-
-  it('should render useDefault filter button', async () => {
-    const wrapper = mountWithConfig(IssueQueue, {
-      props: {
-        issues: mockData,
-        isLoading: false,
-        isFinalPageFetched: false,
-        showFilter: true,
-        defaultFilters: { affects__ps_component: 'test' },
-        total: 10,
-      },
-    });
-    const defaultFilterCheckbox = wrapper.findAllComponents(LabelCheckbox)[2];
-    expect(defaultFilterCheckbox.exists()).toBeTruthy();
-    const defaultFilterEL = wrapper.find('details.osim-default-filter');
-    expect(defaultFilterEL.exists()).toBeTruthy();
-    await defaultFilterEL.trigger('click');
-    expect(defaultFilterEL.findAll('span.badge')).toHaveLength(1);
-    const filterOptionEL = defaultFilterEL.find('span.badge');
-    expect(filterOptionEL.text()).toBe('Affected Component : test');
   });
 
   it('should render create_dt in UTC format', async () => {

--- a/src/components/__tests__/Navbar.spec.ts
+++ b/src/components/__tests__/Navbar.spec.ts
@@ -10,51 +10,6 @@ import Navbar from '../Navbar.vue';
 
 describe('navbar', () => {
   let subject: VueWrapper<InstanceType<typeof Navbar>>;
-  beforeEach(() => {
-    vi.mock('@vueuse/core', () => ({
-      useLocalStorage: vi.fn((key: string, defaults) => {
-        return {
-          UserStore: {
-            value: defaults || {
-              // Set your fake user data here
-              refresh: 'mocked_refresh_token',
-              env: 'mocked_env',
-              whoami: {
-                email: 'test@example.com',
-                username: 'testuser',
-              },
-              jiraUsername: 'skynet',
-            },
-          },
-        }[key];
-      }),
-      useElementBounding: vi.fn(() => ({
-        bottom: 1000,
-        height: 100,
-      })),
-      useStorage: vi.fn((key: string, defaults) => {
-        return {
-          'OSIM::USER-SETTINGS': {
-            value: defaults || {
-              bugzillaApiKey: '',
-              jiraApiKey: '',
-              showNotifications: false,
-            },
-          },
-        }[key];
-      }),
-    }));
-
-    vi.mock('jwt-decode', () => ({
-      default: vi.fn(() => ({
-        sub: '1234567890',
-        name: 'Test User',
-        exp: Math.floor(Date.now() / 1000) + (60 * 60 * 24 * 365),
-      })),
-    }));
-
-    router.push('/');
-  });
 
   afterEach(() => {
     vi.clearAllMocks();

--- a/src/components/__tests__/__snapshots__/IssueSearchAdvanced.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/IssueSearchAdvanced.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`issueSearchAdvanced > should add new facet when last facet is populated
   <summary data-v-21c9158a="" class="mb-1">Advanced Search</summary>
   <form data-v-21c9158a="" class="mb-2">
     <div data-v-21c9158a="" class="input-group my-1">
-      <div data-v-21c9158a="" type="button" class="query-input form-control bg-secondary text-white"><span data-v-21c9158a="" class="my-auto">Query Filter</span><button data-v-21c9158a="" class="btn btn-sm text-white" type="button"><i data-v-21c9158a="" class="bi bi-question-circle-fill fs-5" aria-label="hide query filter"></i></button></div><textarea data-v-21c9158a="" class="form-control"></textarea><button data-v-21c9158a="" disabled="" class="btn btn-sm btn-secondary rounded-0 py-0" title="Clear query" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-secondary py-0" type="button"><i data-v-21c9158a="" class="bi bi-x fs-5" aria-label="hide query filter"></i></button>
+      <div data-v-21c9158a="" type="button" class="query-input form-control bg-secondary text-white"><span data-v-21c9158a="" class="my-auto">Query Filter</span><button data-v-21c9158a="" class="btn btn-sm text-white" type="button"><i data-v-21c9158a="" class="bi bi-question-circle-fill fs-5" aria-label="hide query filter"></i></button></div><textarea data-v-21c9158a="" class="form-control" style="height: 38px;"></textarea><button data-v-21c9158a="" disabled="" class="btn btn-sm btn-secondary rounded-0 py-0" title="Clear query" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-secondary py-0" type="button"><i data-v-21c9158a="" class="bi bi-x fs-5" aria-label="hide query filter"></i></button>
     </div>
     <div data-v-21c9158a="" class="input-group my-1"><select data-v-21c9158a="" class="form-select search-facet-field">
         <!--v-if-->
@@ -63,9 +63,9 @@ exports[`issueSearchAdvanced > should add new facet when last facet is populated
       <!--v-if-->
       <!--v-if--><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button>
     </div>
-    <div data-v-21c9158a="" class="d-flex mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit" aria-label="Advance search button">
+    <div data-v-21c9158a="" class="d-flex mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit" style="width: 23ch;" aria-label="Advance search button">
         <!--v-if--> Search
-      </button><button data-v-21c9158a="" class="btn btn-primary me-2" aria-label="Save filters as default" type="button"> Save as Default </button>
+      </button>
       <!--v-if--><select data-v-21c9158a="" class="sort-by-select form-select search-facet-field" title="When using this sorting with active table column sort, the table column field will be used as secondary sorting key">
         <option data-v-21c9158a="" selected="" disabled="" label="Sort By..."></option>
         <option data-v-21c9158a="" hidden="" label="" value=""></option>
@@ -77,6 +77,22 @@ exports[`issueSearchAdvanced > should add new facet when last facet is populated
       <!--v-if-->
     </div>
   </form>
+</details>
+<details data-v-21c9158a="" open="" class="osim-advanced-search-container container-fluid">
+  <summary data-v-21c9158a=""> Saved Searches</summary>
+  <div data-v-21c9158a="" class="container-fluid mt-2"><button data-v-21c9158a="" title="Query: django query
+Fields: affects__ps_component: test" class="btn me-2 mt-1 border" type="button">name <i data-v-21c9158a="" class="bi ms-2 bi-star"></i></button></div>
+  <!--v-if-->
+  <transition-stub data-v-a347fd2c="" name="modal" appear="false" persisted="false" css="true">
+    <!--v-if-->
+  </transition-stub>
+  <transition-stub data-v-a347fd2c="" name="modal-bg" appear="false" persisted="false" css="true">
+    <!--v-if-->
+  </transition-stub>
+  <div data-v-21c9158a="" class="d-flex mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" aria-label="Save search" type="button"> Save Search </button>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
 </details>
 <transition-stub data-v-a347fd2c="" name="modal" appear="false" persisted="false" css="true">
   <!--v-if-->
@@ -91,7 +107,7 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is false 1`] = `
   <summary data-v-21c9158a="" class="mb-1">Advanced Search</summary>
   <form data-v-21c9158a="" class="mb-2">
     <div data-v-21c9158a="" class="input-group my-1">
-      <div data-v-21c9158a="" type="button" class="query-input form-control bg-secondary text-white"><span data-v-21c9158a="" class="my-auto">Query Filter</span><button data-v-21c9158a="" class="btn btn-sm text-white" type="button"><i data-v-21c9158a="" class="bi bi-question-circle-fill fs-5" aria-label="hide query filter"></i></button></div><textarea data-v-21c9158a="" class="form-control"></textarea><button data-v-21c9158a="" disabled="" class="btn btn-sm btn-secondary rounded-0 py-0" title="Clear query" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-secondary py-0" type="button"><i data-v-21c9158a="" class="bi bi-x fs-5" aria-label="hide query filter"></i></button>
+      <div data-v-21c9158a="" type="button" class="query-input form-control bg-secondary text-white"><span data-v-21c9158a="" class="my-auto">Query Filter</span><button data-v-21c9158a="" class="btn btn-sm text-white" type="button"><i data-v-21c9158a="" class="bi bi-question-circle-fill fs-5" aria-label="hide query filter"></i></button></div><textarea data-v-21c9158a="" class="form-control" style="height: 38px;"></textarea><button data-v-21c9158a="" disabled="" class="btn btn-sm btn-secondary rounded-0 py-0" title="Clear query" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-secondary py-0" type="button"><i data-v-21c9158a="" class="bi bi-x fs-5" aria-label="hide query filter"></i></button>
     </div>
     <div data-v-21c9158a="" class="input-group my-1"><select data-v-21c9158a="" class="form-select search-facet-field">
         <option data-v-21c9158a="" selected="" disabled="" value="">Select field...</option>
@@ -122,9 +138,9 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is false 1`] = `
       <!--v-if-->
       <!--v-if--><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button>
     </div>
-    <div data-v-21c9158a="" class="d-flex mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit" aria-label="Advance search button">
+    <div data-v-21c9158a="" class="d-flex mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit" style="width: 23ch;" aria-label="Advance search button">
         <!--v-if--> Search
-      </button><button data-v-21c9158a="" class="btn btn-primary me-2" aria-label="Save filters as default" type="button"> Save as Default </button>
+      </button>
       <!--v-if--><select data-v-21c9158a="" class="sort-by-select form-select search-facet-field" title="When using this sorting with active table column sort, the table column field will be used as secondary sorting key">
         <option data-v-21c9158a="" selected="" disabled="" label="Sort By..."></option>
         <option data-v-21c9158a="" hidden="" label="" value=""></option>
@@ -136,6 +152,22 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is false 1`] = `
       <!--v-if-->
     </div>
   </form>
+</details>
+<details data-v-21c9158a="" open="" class="osim-advanced-search-container container-fluid">
+  <summary data-v-21c9158a=""> Saved Searches</summary>
+  <div data-v-21c9158a="" class="container-fluid mt-2"><button data-v-21c9158a="" title="Query: django query
+Fields: affects__ps_component: test" class="btn me-2 mt-1 border" type="button">name <i data-v-21c9158a="" class="bi ms-2 bi-star"></i></button></div>
+  <!--v-if-->
+  <transition-stub data-v-a347fd2c="" name="modal" appear="false" persisted="false" css="true">
+    <!--v-if-->
+  </transition-stub>
+  <transition-stub data-v-a347fd2c="" name="modal-bg" appear="false" persisted="false" css="true">
+    <!--v-if-->
+  </transition-stub>
+  <div data-v-21c9158a="" class="d-flex mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" aria-label="Save search" type="button" disabled=""> Save Search </button>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
 </details>
 <transition-stub data-v-a347fd2c="" name="modal" appear="false" persisted="false" css="true">
   <!--v-if-->
@@ -150,7 +182,7 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is true 1`] = `
   <summary data-v-21c9158a="" class="mb-1">Advanced Search</summary>
   <form data-v-21c9158a="" class="mb-2">
     <div data-v-21c9158a="" class="input-group my-1">
-      <div data-v-21c9158a="" type="button" class="query-input form-control bg-secondary text-white"><span data-v-21c9158a="" class="my-auto">Query Filter</span><button data-v-21c9158a="" class="btn btn-sm text-white" type="button"><i data-v-21c9158a="" class="bi bi-question-circle-fill fs-5" aria-label="hide query filter"></i></button></div><textarea data-v-21c9158a="" class="form-control"></textarea><button data-v-21c9158a="" disabled="" class="btn btn-sm btn-secondary rounded-0 py-0" title="Clear query" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-secondary py-0" type="button"><i data-v-21c9158a="" class="bi bi-x fs-5" aria-label="hide query filter"></i></button>
+      <div data-v-21c9158a="" type="button" class="query-input form-control bg-secondary text-white"><span data-v-21c9158a="" class="my-auto">Query Filter</span><button data-v-21c9158a="" class="btn btn-sm text-white" type="button"><i data-v-21c9158a="" class="bi bi-question-circle-fill fs-5" aria-label="hide query filter"></i></button></div><textarea data-v-21c9158a="" class="form-control" style="height: 38px;"></textarea><button data-v-21c9158a="" disabled="" class="btn btn-sm btn-secondary rounded-0 py-0" title="Clear query" type="button"><i data-v-21c9158a="" class="bi bi-eraser fs-5"></i></button><button data-v-21c9158a="" class="btn btn-secondary py-0" type="button"><i data-v-21c9158a="" class="bi bi-x fs-5" aria-label="hide query filter"></i></button>
     </div>
     <div data-v-21c9158a="" class="input-group my-1"><select data-v-21c9158a="" class="form-select search-facet-field">
         <option data-v-21c9158a="" selected="" disabled="" value="">Select field...</option>
@@ -181,9 +213,9 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is true 1`] = `
       <!--v-if-->
       <!--v-if--><button data-v-21c9158a="" class="btn btn-primary py-0" type="button"><i data-v-21c9158a="" class="bi-x fs-5" aria-label="remove field"></i></button>
     </div>
-    <div data-v-21c9158a="" class="d-flex mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit" disabled="" aria-label="Advance search button">
+    <div data-v-21c9158a="" class="d-flex mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" type="submit" style="width: 23ch;" disabled="" aria-label="Advance search button">
         <div data-v-21c9158a="" class="spinner-border spinner-border-sm"></div> Search
-      </button><button data-v-21c9158a="" class="btn btn-primary me-2" aria-label="Save filters as default" type="button" disabled=""> Save as Default </button>
+      </button>
       <!--v-if--><select data-v-21c9158a="" class="sort-by-select form-select search-facet-field" title="When using this sorting with active table column sort, the table column field will be used as secondary sorting key">
         <option data-v-21c9158a="" selected="" disabled="" label="Sort By..."></option>
         <option data-v-21c9158a="" hidden="" label="" value=""></option>
@@ -195,6 +227,22 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is true 1`] = `
       <!--v-if-->
     </div>
   </form>
+</details>
+<details data-v-21c9158a="" open="" class="osim-advanced-search-container container-fluid">
+  <summary data-v-21c9158a=""> Saved Searches</summary>
+  <div data-v-21c9158a="" class="container-fluid mt-2"><button data-v-21c9158a="" title="Query: django query
+Fields: affects__ps_component: test" class="btn me-2 mt-1 border" type="button">name <i data-v-21c9158a="" class="bi ms-2 bi-star"></i></button></div>
+  <!--v-if-->
+  <transition-stub data-v-a347fd2c="" name="modal" appear="false" persisted="false" css="true">
+    <!--v-if-->
+  </transition-stub>
+  <transition-stub data-v-a347fd2c="" name="modal-bg" appear="false" persisted="false" css="true">
+    <!--v-if-->
+  </transition-stub>
+  <div data-v-21c9158a="" class="d-flex mt-2"><button data-v-21c9158a="" class="btn btn-primary me-2" aria-label="Save search" type="button" disabled=""> Save Search </button>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
 </details>
 <transition-stub data-v-a347fd2c="" name="modal" appear="false" persisted="false" css="true">
   <!--v-if-->

--- a/src/composables/useSearchParams.ts
+++ b/src/composables/useSearchParams.ts
@@ -5,7 +5,7 @@ import { useRoute, useRouter } from 'vue-router';
 
 import { flawFields, allowedEmptyFieldMapping } from '@/constants/flawFields';
 
-type Facet = {
+export type Facet = {
   field: string;
   value: string;
 };

--- a/src/composables/useSearchParams.ts
+++ b/src/composables/useSearchParams.ts
@@ -153,6 +153,19 @@ export function useSearchParams() {
     });
   }
 
+  function loadAdvancedSearch(query: string, params: Record<string, string>) {
+    params = query
+      ? { ...params, query: query }
+      : params;
+    router.replace({
+      query: {
+        ...params,
+      },
+    }).then(() => {
+      facets.value = populateFacets();
+    });
+  }
+
   return {
     facets,
     query,
@@ -166,6 +179,7 @@ export function useSearchParams() {
     populateFacets,
     getSearchParams,
     submitAdvancedSearch,
+    loadAdvancedSearch,
     submitQuickSearch,
   };
 }

--- a/src/stores/SearchStore.ts
+++ b/src/stores/SearchStore.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia';
 import { useLocalStorage } from '@vueuse/core';
 
 export type SearchSchema = {
+  name: string;
   queryFilter: string;
   searchFilters: Record<string, string>;
 };
@@ -11,8 +12,8 @@ export type SearchSchema = {
 const _searchStoreKey = 'SearchStore';
 const searches = useLocalStorage(_searchStoreKey, [] as SearchSchema[]);
 
-function saveSearch(filters: Record<string, string>, query: string) {
-  const search: SearchSchema = { searchFilters: filters, queryFilter: query };
+function saveSearch(name: string, filters: Record<string, string>, query: string) {
+  const search: SearchSchema = { name: name, searchFilters: filters, queryFilter: query };
   searches.value.push(search);
 }
 

--- a/src/stores/SearchStore.ts
+++ b/src/stores/SearchStore.ts
@@ -8,27 +8,29 @@ export type SearchSchema = {
   searchFilters: Record<string, string>;
 };
 
-const defaultValues: SearchSchema = { searchFilters: {}, queryFilter: '' };
-
 const _searchStoreKey = 'SearchStore';
-const search = useLocalStorage(_searchStoreKey, defaultValues);
-function saveFilter(filters: Record<string, string>, query: string) {
-  search.value.searchFilters = filters;
-  search.value.queryFilter = query;
+const searches = useLocalStorage(_searchStoreKey, [] as SearchSchema[]);
+
+function saveSearch(filters: Record<string, string>, query: string) {
+  const search: SearchSchema = { searchFilters: filters, queryFilter: query };
+  searches.value.push(search);
 }
 
-function resetFilter() {
-  search.value.searchFilters = {};
-  search.value.queryFilter = '';
+function removeSearch(index: number) {
+  searches.value.splice(index, 1);
 }
+
+function resetSearches() {
+  searches.value = [];
+}
+
 export const useSearchStore = defineStore('SearchStore', () => {
-  const searchFilters = computed(() => search.value.searchFilters || {});
-  const queryFilter = computed(() => search.value.queryFilter || '');
+  const savedSearches = computed(() => searches.value || []);
 
   return {
-    searchFilters,
-    queryFilter,
-    saveFilter,
-    resetFilter,
+    savedSearches,
+    saveSearch,
+    removeSearch,
+    resetSearches,
   };
 });

--- a/src/stores/SearchStore.ts
+++ b/src/stores/SearchStore.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia';
 import { useLocalStorage } from '@vueuse/core';
 
 export type SearchSchema = {
+  default: boolean;
   name: string;
   queryFilter: string;
   searchFilters: Record<string, string>;
@@ -13,7 +14,7 @@ const _searchStoreKey = 'SearchStore';
 const searches = useLocalStorage(_searchStoreKey, [] as SearchSchema[]);
 
 function saveSearch(name: string, filters: Record<string, string>, query: string) {
-  const search: SearchSchema = { name: name, searchFilters: filters, queryFilter: query };
+  const search: SearchSchema = { name: name, searchFilters: filters, queryFilter: query, default: false };
   searches.value.push(search);
 }
 
@@ -25,11 +26,25 @@ function resetSearches() {
   searches.value = [];
 }
 
+function setDefaultSearch(index: number) {
+  if (defaultSearch.value === searches.value[index] && searches.value[index].default) {
+    searches.value[index].default = false;
+  } else {
+    searches.value.forEach((search, i) => {
+      search.default = i === index;
+    });
+  }
+}
+
+const defaultSearch = computed(() => searches.value.find(search => search.default) || null);
+
 export const useSearchStore = defineStore('SearchStore', () => {
   const savedSearches = computed(() => searches.value || []);
 
   return {
     savedSearches,
+    defaultSearch,
+    setDefaultSearch,
     saveSearch,
     removeSearch,
     resetSearches,

--- a/src/stores/__tests__/SearchStore.spec.ts
+++ b/src/stores/__tests__/SearchStore.spec.ts
@@ -16,9 +16,7 @@ vi.mock('@vueuse/core', () => ({
   useLocalStorage: vi.fn((key: string, defaults) => {
     return {
       SearchStore: {
-        value: defaults || {
-          searchFilters: { test: 'test' },
-        },
+        value: defaults,
       },
     }[key];
   }),
@@ -33,18 +31,40 @@ describe('settingsStore', () => {
   });
 
   it('initializes', () => {
-    expect(searchStore.searchFilters).toEqual({});
+    expect(searchStore.savedSearches).toEqual([]);
   });
 
-  it('saveFilter', () => {
-    searchStore.saveFilter({ component: 'test' }, 'test');
+  it('saveSearch', () => {
+    searchStore.saveSearch('name', { component: 'test' }, 'test');
 
-    expect(searchStore.searchFilters).toEqual({ component: 'test' });
-    expect(searchStore.queryFilter).toBe('test');
+    expect(searchStore.savedSearches[0].name).toEqual('name');
+    expect(searchStore.savedSearches[0].searchFilters).toEqual({ component: 'test' });
+    expect(searchStore.savedSearches[0].queryFilter).toBe('test');
   });
 
-  it('resetFilter', () => {
-    searchStore.resetFilter();
-    expect(searchStore.searchFilters).toEqual({});
+  it('removeSearch', () => {
+    searchStore.removeSearch(0);
+    expect(searchStore.savedSearches).toEqual([]);
+  });
+
+  it('setDefaultSearch', () => {
+    searchStore.saveSearch('name', { component: 'test' }, 'test');
+    searchStore.setDefaultSearch(0);
+    expect(searchStore.savedSearches[0].isDefault).toBeTruthy();
+  });
+
+  it('swap DefaultSearch', () => {
+    searchStore.saveSearch('name1', { component: 'test1' }, 'test1');
+    searchStore.setDefaultSearch(0);
+    searchStore.saveSearch('name2', { component: 'test2' }, 'test2');
+    searchStore.setDefaultSearch(1);
+    expect(!searchStore.savedSearches[0].isDefault && searchStore.savedSearches[1].isDefault).toBeTruthy();
+  });
+
+  it('resetSearches', () => {
+    searchStore.saveSearch('name1', { component: 'test1' }, 'test1');
+    searchStore.saveSearch('name2', { component: 'test2' }, 'test2');
+    searchStore.resetSearches();
+    expect(searchStore.savedSearches).toEqual([]);
   });
 });

--- a/src/views/FlawSearchView.vue
+++ b/src/views/FlawSearchView.vue
@@ -137,6 +137,7 @@ function deleteSavedSearch() {
       :savedSearches="searchStore.savedSearches"
       :changedSlot
       @savedSearch:select="selectSavedSearch"
+      @savedSearch:setDefault="searchStore.setDefaultSearch"
       @filter:save="saveSearch"
       @filter:update="updateSavedSearch"
       @filter:delete="deleteSavedSearch"

--- a/src/views/FlawSearchView.vue
+++ b/src/views/FlawSearchView.vue
@@ -51,7 +51,7 @@ function setTableFilters(newFilters: Ref<Record<string, string>>) {
   };
 }
 
-function saveFilter() {
+function saveSearch() {
   const filters = facets.value.reduce(
     (fields, { field, value }) => {
       if (field && (value || allowedEmptyFieldMapping[field])) {
@@ -61,7 +61,7 @@ function saveFilter() {
     },
     {} as Record<string, string>,
   );
-  searchStore.saveFilter(filters, query.value);
+  searchStore.saveSearch(filters, query.value);
   addToast({
     title: 'Default Filter',
     body: 'User\'s default filter saved',
@@ -73,7 +73,7 @@ function saveFilter() {
   <main class="mt-3">
     <IssueSearchAdvanced
       :isLoading="isLoading"
-      @filter:save="saveFilter"
+      @filter:save="saveSearch"
     />
     <IssueQueue
       :issues="issues"

--- a/src/views/IndexView.vue
+++ b/src/views/IndexView.vue
@@ -73,7 +73,7 @@ function selectSavedSearch(index: number) {
             type="button"
             @click="selectSavedSearch(index)"
           >
-            Slot {{ index + 1 }}
+            {{ savedSearch.name }}
           </button>
         </template>
       </div>

--- a/src/views/IndexView.vue
+++ b/src/views/IndexView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onDeactivated, onMounted, ref, watch, type Ref } from 'vue';
+import { computed, onActivated, onDeactivated, ref, watch, type Ref } from 'vue';
 
 import IssueQueue from '@/components/IssueQueue.vue';
 
@@ -14,21 +14,21 @@ const { isFinalPageFetched, isLoading, issues, loadFlaws, loadMoreFlaws, total }
 const tableFilters = ref<Record<string, string>>({});
 
 const showSavedSearches = ref(true);
-const loadedSearch = ref<number>(-1);
+const loadedSearchIndex = ref<number>(-1);
 
 const params = computed(() => {
   const paramsObj = {
     ...tableFilters.value,
-    ...loadedSearch.value !== -1 && searchStore.savedSearches[loadedSearch.value].searchFilters,
-    ...loadedSearch.value !== -1 && { query: searchStore.savedSearches[loadedSearch.value].queryFilter },
+    ...loadedSearchIndex.value !== -1 && searchStore.savedSearches[loadedSearchIndex.value].searchFilters,
+    ...loadedSearchIndex.value !== -1 && { query: searchStore.savedSearches[loadedSearchIndex.value].queryFilter },
   };
 
   return paramsObj;
 });
 
-onMounted(() => {
+onActivated(() => {
   if (searchStore.defaultSearch) {
-    loadedSearch.value = searchStore.savedSearches.findIndex(search => search.default);
+    loadedSearchIndex.value = searchStore.savedSearches.findIndex(search => search.isDefault);
   }
 });
 
@@ -53,12 +53,12 @@ onDeactivated(() => {
 });
 
 function selectSavedSearch(index: number) {
-  if (loadedSearch.value === index) {
-    loadedSearch.value = -1;
+  if (loadedSearchIndex.value === index) {
+    loadedSearchIndex.value = -1;
     return;
   }
 
-  loadedSearch.value = index;
+  loadedSearchIndex.value = index;
 }
 </script>
 
@@ -69,20 +69,20 @@ function selectSavedSearch(index: number) {
       class="osim-advanced-search-container container-fluid ms-3 ps-3"
     >
       <summary @click="showSavedSearches === true"> Saved Searches</summary>
-      <div class="d-flex mt-2">
+      <div class="container-fluid mt-2">
         <template v-for="(savedSearch, index) in searchStore.savedSearches" :key="index">
           <button
             :title="'Query: ' + savedSearch.queryFilter + '\nFields: '
               + Object.entries(savedSearch.searchFilters).map(([key, value]) => `${key}: ${value}`).join(', ')"
-            class="btn me-2"
-            :class="index === loadedSearch ? 'btn-secondary' : 'border'"
+            class="btn me-2 mt-1"
+            :class="index === loadedSearchIndex ? 'btn-secondary' : 'border'"
             type="button"
             @click="selectSavedSearch(index)"
           >
             {{ savedSearch.name }}
             <i
               class="bi ms-2"
-              :class="savedSearch.default ? 'bi-star-fill' : 'bi-star'"
+              :class="savedSearch.isDefault ? 'bi-star-fill' : 'bi-star'"
               @click.stop="searchStore.setDefaultSearch(index)"
             />
           </button>
@@ -104,6 +104,7 @@ function selectSavedSearch(index: number) {
 <style scoped lang="scss">
 details {
   user-select: none;
+
   summary {
     width: fit-content;
   }

--- a/src/views/IndexView.vue
+++ b/src/views/IndexView.vue
@@ -100,3 +100,12 @@ function selectSavedSearch(index: number) {
     />
   </main>
 </template>
+
+<style scoped lang="scss">
+details {
+  user-select: none;
+  summary {
+    width: fit-content;
+  }
+}
+</style>

--- a/src/views/IndexView.vue
+++ b/src/views/IndexView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onDeactivated, ref, watch, type Ref } from 'vue';
+import { computed, onDeactivated, onMounted, ref, watch, type Ref } from 'vue';
 
 import IssueQueue from '@/components/IssueQueue.vue';
 
@@ -24,6 +24,12 @@ const params = computed(() => {
   };
 
   return paramsObj;
+});
+
+onMounted(() => {
+  if (searchStore.defaultSearch) {
+    loadedSearch.value = searchStore.savedSearches.findIndex(search => search.default);
+  }
 });
 
 watch(() => params, () => {
@@ -74,6 +80,11 @@ function selectSavedSearch(index: number) {
             @click="selectSavedSearch(index)"
           >
             {{ savedSearch.name }}
+            <i
+              class="bi ms-2"
+              :class="savedSearch.default ? 'bi-star-fill' : 'bi-star'"
+              @click.stop="searchStore.setDefaultSearch(index)"
+            />
           </button>
         </template>
       </div>

--- a/src/views/__tests__/FlawSearchView.spec.ts
+++ b/src/views/__tests__/FlawSearchView.spec.ts
@@ -2,25 +2,18 @@ import { ref, type ComponentPublicInstance, type Ref } from 'vue';
 
 import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
 import { describe, it, expect, vi } from 'vitest';
-import { createTestingPinia } from '@pinia/testing';
 
 import { useSearchParams } from '@/composables/useSearchParams';
 import { useFlawsFetching } from '@/composables/useFlawsFetching';
 
 import FlawSearchView from '@/views/FlawSearchView.vue';
-import { useSearchStore } from '@/stores/SearchStore';
-import { useToastStore } from '@/stores/ToastStore';
 
 const mountFlawSearchView = (): VueWrapper<ComponentPublicInstance
   & Partial<{
     fetchMoreFlaws: () => void;
     params: Record<string, string>;
-    saveFilter: () => void;
     setTableFilters: (filters: Ref<Record<string, string>>) => void;
   }>> => mount(FlawSearchView, {
-  global: {
-    plugins: [createTestingPinia()],
-  },
   shallow: true,
 });
 
@@ -110,24 +103,5 @@ describe('flawSearchView', () => {
     await flushPromises();
 
     expect(loadMoreFlaws).toHaveBeenCalledTimes(1);
-  });
-
-  it('should save filters to store', async () => {
-    vi.mocked(useSearchParams, {
-      partial: true,
-    }).mockReturnValue({
-      getSearchParams: vi.fn().mockReturnValue({}),
-      facets: ref([{ field: 'cve_id', value: 'CVE-2024-1234' }]),
-      query: ref('django query'),
-    });
-    const wrapper = mountFlawSearchView();
-    const searchStore = useSearchStore();
-    const toastStore = useToastStore();
-
-    wrapper.vm.saveFilter!();
-    await flushPromises();
-
-    expect(searchStore.saveFilter).toHaveBeenNthCalledWith(1, { cve_id: 'CVE-2024-1234' }, 'django query');
-    expect(toastStore.addToast).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/views/__tests__/IndexView.spec.ts
+++ b/src/views/__tests__/IndexView.spec.ts
@@ -24,8 +24,9 @@ vi.mock('@/composables/useFlawsFetching', () => ({
 
 vi.mock('@/stores/SearchStore', () => ({
   useSearchStore: vi.fn().mockReturnValue({
-    queryFilter: 'django query',
-    searchFilters: { affects__ps_component: 'test' },
+    savedSearches: [
+      { name: 'name', searchFilters: { affects__ps_component: 'test' }, queryFilter: 'django query', isDefault: false },
+    ],
   }),
 }));
 
@@ -51,16 +52,13 @@ describe('indexView', () => {
     expect(loadFlaws).toHaveBeenCalledWith(expect.objectContaining({
       _value: {
         order: '-created_dt',
-        affects__ps_component: 'test',
-        query: 'django query',
       },
     }));
   });
 
   it('should call loadFlaws on mount without filters', async () => {
     vi.mocked(useSearchStore, { partial: true }).mockReturnValue({
-      queryFilter: '',
-      searchFilters: {},
+      savedSearches: [],
     });
     const { loadFlaws } = useFlawsFetching();
     const wrapper = mountWithConfig(IndexView);
@@ -74,6 +72,45 @@ describe('indexView', () => {
         order: '-created_dt',
       },
     }));
+  });
+
+  it('should load default saved search when set', async () => {
+    vi.mocked(useSearchStore, { partial: true }).mockReturnValue({
+      savedSearches: [
+        {
+          name: 'name',
+          searchFilters: { affects__ps_component: 'test' },
+          queryFilter: 'django query',
+          isDefault: true,
+        },
+      ],
+      defaultSearch: null,
+    });
+    const wrapper = mountWithConfig(IndexView);
+
+    await flushPromises();
+
+    const savedSearches = wrapper.findAll('details > div > .btn');
+    expect(savedSearches[0].find('i.bi-star-fill').exists()).toBeTruthy();
+  });
+
+  it('should not load default saved search when not set', async () => {
+    vi.mocked(useSearchStore, { partial: true }).mockReturnValue({
+      savedSearches: [
+        {
+          name: 'name',
+          searchFilters: { affects__ps_component: 'test' },
+          queryFilter: 'django query',
+          isDefault: false,
+        },
+      ],
+    });
+    const wrapper = mountWithConfig(IndexView);
+
+    await flushPromises();
+
+    const savedSearches = wrapper.findAll('details > div > .btn');
+    expect(savedSearches[0].find('i.bi-star-fill').exists()).toBeFalsy();
   });
 
   it('should call loadFlaws when filters are changed', async () => {
@@ -90,6 +127,102 @@ describe('indexView', () => {
     expect(loadFlaws).toHaveBeenCalledWith(expect.objectContaining({
       _value: {
         order: 'updated_dt',
+      },
+    }));
+  });
+
+  it('shouldn\'t render empty saved searches', async () => {
+    vi.mocked(useSearchStore, { partial: true }).mockReturnValue({
+      savedSearches: [],
+    });
+    const wrapper = mountWithConfig(IndexView);
+    const savedSearches = wrapper.findAll('details > div > .btn');
+    expect(savedSearches.length).toBe(0);
+  });
+
+  it('should render saved searches', async () => {
+    vi.mocked(useSearchStore, { partial: true }).mockReturnValue({
+      savedSearches: [
+        {
+          name: 'name',
+          searchFilters: { affects__ps_component: 'test' },
+          queryFilter: 'django query',
+          isDefault: false,
+        },
+      ],
+    });
+    const wrapper = mountWithConfig(IndexView);
+    const savedSearches = wrapper.findAll('details > div > .btn');
+    expect(savedSearches[0].attributes('title')).toBe('Query: django query\nFields: affects__ps_component: test');
+  });
+
+  it('should select saved searches', async () => {
+    vi.mocked(useSearchStore, { partial: true }).mockReturnValue({
+      savedSearches: [
+        {
+          name: 'name',
+          searchFilters: { affects__ps_component: 'test' },
+          queryFilter: 'django query',
+          isDefault: false,
+        },
+      ],
+    });
+    const wrapper: VueWrapper<Partial<{ selectSavedSearch: (index: number) => void }>> = mountWithConfig(IndexView);
+
+    wrapper.vm.selectSavedSearch!(0);
+    await flushPromises();
+
+    const selectedSavedSearch = wrapper.find('details > div > .btn-secondary');
+    expect(selectedSavedSearch.exists()).toBeTruthy();
+  });
+
+  it('should deselect saved searches', async () => {
+    vi.mocked(useSearchStore, { partial: true }).mockReturnValue({
+      savedSearches: [
+        {
+          name: 'name',
+          searchFilters: { affects__ps_component: 'test' },
+          queryFilter: 'django query',
+          isDefault: false,
+        },
+      ],
+    });
+    const wrapper: VueWrapper<Partial<{ selectSavedSearch: (index: number) => void }>> = mountWithConfig(IndexView);
+
+    wrapper.vm.selectSavedSearch!(0);
+    await flushPromises();
+
+    let selectedSavedSearch = wrapper.find('details > div > .btn-secondary');
+    await selectedSavedSearch.trigger('click');
+    selectedSavedSearch = wrapper.find('details > div > .btn-secondary');
+    expect(selectedSavedSearch.exists()).toBeFalsy();
+  });
+
+  it('should apply saved search', async () => {
+    vi.mocked(useSearchStore, { partial: true }).mockReturnValue({
+      savedSearches: [
+        {
+          name: 'name',
+          searchFilters: { affects__ps_component: 'test' },
+          queryFilter: 'django query',
+          isDefault: false,
+        },
+      ],
+    });
+    const { loadFlaws } = useFlawsFetching();
+    const wrapper = mountWithConfig(IndexView);
+
+    const savedSearches = wrapper.findAll('details > div > .btn');
+
+    await savedSearches[0].trigger('click');
+    await flushPromises();
+
+    expect(loadFlaws).toHaveBeenCalledTimes(1);
+    expect(loadFlaws).toHaveBeenCalledWith(expect.objectContaining({
+      _value: {
+        order: '-created_dt',
+        affects__ps_component: 'test',
+        query: 'django query',
       },
     }));
   });

--- a/src/views/__tests__/__snapshots__/FlawSearchView.spec.ts.snap
+++ b/src/views/__tests__/__snapshots__/FlawSearchView.spec.ts.snap
@@ -3,6 +3,6 @@
 exports[`flawSearchView > should render 1`] = `
 "<main class="mt-3">
   <issue-search-advanced-stub isloading="false"></issue-search-advanced-stub>
-  <issue-queue-stub issues="" total="1337" isfinalpagefetched="false" isloading="false" showfilter="false" isdefaultfilterselected="true"></issue-queue-stub>
+  <issue-queue-stub issues="" total="1337" isfinalpagefetched="false" isloading="false"></issue-queue-stub>
 </main>"
 `;

--- a/src/views/__tests__/__snapshots__/IndexView.spec.ts.snap
+++ b/src/views/__tests__/__snapshots__/IndexView.spec.ts.snap
@@ -1,20 +1,19 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`indexView > should render 1`] = `
-"<main class="mt-3">
-  <div data-v-5f4ac70c="" class="osim-content container-fluid osim-issue-queue">
+"<main data-v-fb5dc0f2="" class="mt-3">
+  <details data-v-fb5dc0f2="" open="" class="osim-advanced-search-container container-fluid ms-3 ps-3">
+    <summary data-v-fb5dc0f2=""> Saved Searches</summary>
+    <div data-v-fb5dc0f2="" class="container-fluid mt-2"><button data-v-fb5dc0f2="" title="Query: django query
+Fields: affects__ps_component: test" class="btn me-2 mt-1 border" type="button">name <i data-v-fb5dc0f2="" class="bi ms-2 bi-star"></i></button></div>
+    <!--v-if-->
+  </details>
+  <div data-v-5f4ac70c="" data-v-fb5dc0f2="" class="osim-content container-fluid osim-issue-queue">
     <div data-v-5f4ac70c="" class="osim-incident-filter">
       <div data-v-5fd32c51="" data-v-5f4ac70c="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-5fd32c51="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-5fd32c51="" class="d-inline-block form-check-input" type="checkbox"><span data-v-5fd32c51="" class="form-check-label">My Issues</span></label></div>
       <div data-v-5fd32c51="" data-v-5f4ac70c="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-5fd32c51="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-5fd32c51="" class="d-inline-block form-check-input" type="checkbox"><span data-v-5fd32c51="" class="form-check-label">Open Issues</span></label></div>
-      <div data-v-5fd32c51="" data-v-5f4ac70c="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-5fd32c51="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-5fd32c51="" class="d-inline-block form-check-input" type="checkbox" checked=""><span data-v-5fd32c51="" class="form-check-label">Default Filter</span></label></div>
       <!--v-if-->
       <!--v-if-->
-    </div>
-    <div data-v-5f4ac70c="" class="d-flex gap-2">
-      <details data-v-5f4ac70c="" class="osim-default-filter">
-        <summary data-v-5f4ac70c="">Default Filters <button data-v-5f4ac70c="" class="btn btn-sm btn-primary lh-0 py-0"> clear </button></summary>
-        <div data-v-5f4ac70c="" class="my-2"><span data-v-5f4ac70c="" class="badge bg-secondary me-1">Query : django query</span><span data-v-5f4ac70c="" class="badge bg-secondary me-1">Affected Component : test</span></div>
-      </details>
     </div>
     <div data-v-5f4ac70c="" class="osim-incident-list">
       <table data-v-5f4ac70c="" class="table align-middle">


### PR DESCRIPTION
# OSIDB-3137: Allow multiple user saved searches

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Adds logic and UI adjustments to support multiple user saved searches.

## Changes:

- Updates `searchStore` to handle an array of searches
- Updates advance search components logic and UI to support loading, editing and removing saved searches
- Updates index view to display a list of saved searches
- Reduces initial query `textarea` height to be same as other input elements (still resizable)
- Adds support to set one saved search as favorite/default, so it is directly used on the issue queue of the index view
- Allows keeping draft advance search values so when deselecting a loaded saved search the previous 'non saved' search remains the same
- Blocks text selection on `summary` elements
- Changes naming of 'filters' to 'searches' for everything referencing to user saved searches
- Some code cleanup
- Updates snapshots
- Update and adds new test cases

## Demo

https://github.com/user-attachments/assets/f3c17aa0-f42b-4074-a0aa-811455ecb43c

*Update: Properly display saved searches when too many saved

![image](https://github.com/user-attachments/assets/4b9c7caf-3070-4da4-b723-a2071dff2cc0)

![image](https://github.com/user-attachments/assets/e5e1a627-26af-42e2-baf7-6b8bb0a942e4)


Closes OSIDB-3554
Closes OSIDB-3555
Closes OSIDB-3556
Closes OSIDB-3137
