### PR TITLE
🐛 OSIDB-3645: Use 24h format on history dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OSIM Changelog
 
+## [Unreleased]
+### Fixed
+* Time format on history dates changed from 12h to 24h (`OSIDB-3645`)
+
 ## [2024.11.0]
 ### Added
 * Add multi-flaw tracker filing (`OSIDB-3129`)

--- a/src/components/__tests__/FlawHistory.spec.ts
+++ b/src/components/__tests__/FlawHistory.spec.ts
@@ -8,7 +8,7 @@ import { osimEmptyFlawTest, osimFullFlawTest } from './test-suite-helpers';
 
 function sampleHistoryItem(): ZodFlawHistoryItemType {
   return {
-    pgh_created_at: '2024-10-04T12:06:56.760289Z',
+    pgh_created_at: '2024-10-04T15:06:56.760289Z',
     pgh_slug: 'osidb.FlawAudit:123456',
     pgh_label: 'update',
     pgh_context: { url: 'osidb/api/v1/flaws/12d3820a-a43b-417c-a22e-46e47c232a63', user: 1 },

--- a/src/components/__tests__/__snapshots__/FlawHistory.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawHistory.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`flawHistory > is shown if history present on flaw 1`] = `
   <div data-v-357e30d7="" class="ps-3 border-start">
     <div data-v-357e30d7="" class="visually-hidden">
       <div class="mt-2"><label class="mx-2 form-label w-100">
-          <div class="alert alert-info mb-1 p-2"><span>2024-10-04 12:06 UTC - 1</span>
+          <div class="alert alert-info mb-1 p-2"><span>2024-10-04 15:06 UTC - 1</span>
             <ul class="mb-2">
               <li>
                 <div class="ms-3 pb-0"><span>Update</span><span class="fw-bold"> Owner</span><span>:  </span><i class="bi bi-arrow-right"></i> noemail@example.com</div>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -73,7 +73,7 @@ export function formatDate(date: Date | string, includeTime: boolean): string {
 
 export function formatDateWithTimezone(value: string) {
   return DateTime.fromISO(value, { setZone: true })
-    .toFormat('yyyy-MM-dd hh:mm ZZZZ');
+    .toFormat('yyyy-MM-dd HH:mm ZZZZ');
 }
 
 export function getSpecficCvssScore(scores: any[], issuer: string, version: string) {


### PR DESCRIPTION
# OSIDB-3645: Use 24h format on history dates

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Small fix to correct the format of dates in the history section, which was in 12h.
As in all other dates we use 24h time format this will correct the parse function being used by the history section dates.

## Changes:

- Correct time format on `formatDateWithTimezone` helper function
- Adjust history test time to verify format is in 24h

## Demo:
![image](https://github.com/user-attachments/assets/478da91f-8da9-4c39-b0b2-4561ba35a341)

Closes OSIDB-3645
