### PR TITLE
🐛 Fix unfiled update streams for ps module with some trackers already…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 * Time format on history dates changed from 12h to 24h (`OSIDB-3645`)
+* Fix some update streams not showing until De/Select All button is clicked on PS Modules with *some but not all* trackers already filed (`OSIDB-3674`)
 
 ### Added
 * Support multiple user saved searches (`OSIDB-3554`)

--- a/src/composables/useSingleFlawTrackers.ts
+++ b/src/composables/useSingleFlawTrackers.ts
@@ -148,8 +148,10 @@ export function useSingleFlawTrackers(
       );
       for (const tracker of trackers) {
         if (undefined === alreadyFiledTrackers.value.find(
-          (filedTracker: ZodTrackerTypeWithAffect) => filedTracker.ps_module === tracker.ps_module
-          && filedTracker.ps_component === tracker.ps_component,
+          (filedTracker: ZodTrackerTypeWithAffect) =>
+            filedTracker.ps_update_stream === tracker.ps_update_stream
+            && filedTracker.ps_module === tracker.ps_module
+            && filedTracker.ps_component === tracker.ps_component,
         )) {
           trackerSelections.value.set(tracker as UpdateStreamOsim, Boolean(tracker.selected));
         }


### PR DESCRIPTION
# OSIDB-3674 Fix 

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

When some update stream already have trackers filed for a given ps_module,  unfiled tracker update streams for that same module will not be visible until clicking Select All or Deselect All.


## Changes:

[Replace with a detailed description of the changes made in this PR, including any new features, enhancements, bug fixes, or refactorings.]

## Considerations:

[Replace with any additional considerations, notes, or instructions for reviewers.]

Closes OSIDB-3674
