### PR TITLE
OSIDB-3675: Fix Unable to remove affect cvss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Time format on history dates changed from 12h to 24h (`OSIDB-3645`)
 * Fix some update streams not showing until De/Select All button is clicked on PS Modules with *some but not all* trackers already filed (`OSIDB-3674`)
 * Prevent flaw saving if CVSS vector is invalid (`OSIDB-3275`)
+* Unable to remove affect CVSS (`OSIDB-3675`)
 
 ### Changed
 * Extend advance search UI to handle multiple saved searches (`OSIDB-3556`)

--- a/src/components/FlawAffects/FlawAffectsTableRow.vue
+++ b/src/components/FlawAffects/FlawAffectsTableRow.vue
@@ -247,8 +247,8 @@ function affectednessChange(event: Event, affect: ZodAffectType) {
       <div class="affect-tracker-cell">
         <span class="me-2 my-auto">{{ affect.trackers.length }}</span>
         <button
+          v-if="!(isBeingEdited || isRemoved)"
           type="button"
-          :disabled="isBeingEdited || isRemoved"
           class="btn btn-sm px-1 py-0 d-flex rounded-circle"
           @click.prevent.stop="emit('affect:track', affect)"
         >
@@ -327,8 +327,6 @@ function affectednessChange(event: Event, affect: ZodAffectType) {
 
 tr {
   height: 39.2px;
-  position: relative;
-  transition: filter 0.25s;
 
   td {
     transition:

--- a/src/composables/__tests__/useFlawAffectsModel.spec.ts
+++ b/src/composables/__tests__/useFlawAffectsModel.spec.ts
@@ -1,0 +1,105 @@
+import { ref } from 'vue';
+
+import { setActivePinia } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
+
+import { osimFullFlawTest } from '@/components/__tests__/test-suite-helpers';
+
+import { IssuerEnum } from '@/generated-client';
+import { CVSS_V3 } from '@/constants';
+
+import { useFlawAffectsModel } from '../useFlawAffectsModel';
+
+setActivePinia(createTestingPinia());
+
+describe('useFlawAffectsModel', () => {
+  osimFullFlawTest('should return the expected values', ({ flaw }) => {
+    const model = useFlawAffectsModel(ref(flaw));
+
+    expect(model).toBeDefined();
+    expect(model).toBeInstanceOf(Object);
+
+    [
+      'addAffect',
+      'removeAffect',
+      'recoverAffect',
+      'saveAffects',
+      'removeAffects',
+      'updateAffectCvss',
+      'affectsToDelete',
+      'affectCvssToDelete',
+      'initialAffects',
+      'refreshAffects',
+      'modifiedAffects',
+      'wereAffectsEditedOrAdded',
+    ].forEach((key) => {
+      expect(model).toHaveProperty(key);
+    });
+  });
+
+  osimFullFlawTest('should add an affect', ({ flaw }) => {
+    const flawRef = ref({ ...flaw, affects: [] });
+    const { addAffect, wereAffectsEditedOrAdded } = useFlawAffectsModel(flawRef);
+
+    addAffect({
+      embargoed: false,
+      ps_module: 'rhel-8',
+      ps_component: 'kernel',
+      affectedness: 'AFFECTED',
+      resolution: 'DELEGATED',
+      impact: 'LOW',
+      cvss_scores: [],
+      alerts: [],
+      trackers: [],
+    });
+
+    expect(wereAffectsEditedOrAdded.value).toBe(true);
+    expect(flawRef.value.affects.length).toBe(1);
+  });
+
+  osimFullFlawTest('should remove an affect', ({ flaw }) => {
+    const flawRef = ref(flaw);
+    const { affectsToDelete, removeAffect } = useFlawAffectsModel(flawRef);
+
+    removeAffect(flawRef.value.affects[0]);
+
+    expect(affectsToDelete.value.length).toBe(1);
+  });
+
+  osimFullFlawTest('should update an affect', ({ flaw }) => {
+    const flawRef = ref(flaw);
+    const { wereAffectsEditedOrAdded } = useFlawAffectsModel(flawRef);
+
+    flawRef.value.affects[0].impact = 'CRITICAL';
+
+    expect(wereAffectsEditedOrAdded.value).toBe(true);
+  });
+
+  osimFullFlawTest('should update an affect CVSS', ({ flaw }) => {
+    const flawRef = ref(flaw);
+    const { updateAffectCvss, wereAffectsEditedOrAdded } = useFlawAffectsModel(flawRef);
+
+    updateAffectCvss(flawRef.value.affects[0], 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H', 7.8, -1);
+
+    expect(wereAffectsEditedOrAdded.value).toBe(true);
+  });
+
+  osimFullFlawTest('should delete an affect CVSS', ({ flaw }) => {
+    const flawRef = ref(flaw);
+    flawRef.value.affects[0].cvss_scores.push({
+      issuer: IssuerEnum.Rh,
+      cvss_version: CVSS_V3,
+      score: 7.8,
+      vector: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H',
+      uuid: '123',
+      alerts: [],
+    });
+    const { affectCvssToDelete, updateAffectCvss, wereAffectsEditedOrAdded } = useFlawAffectsModel(flawRef);
+
+    updateAffectCvss(flawRef.value.affects[0], '', null, 0);
+
+    expect(wereAffectsEditedOrAdded.value).toBe(true);
+    expect(affectCvssToDelete.value).toHaveProperty(flawRef.value.affects[0].uuid!);
+    expect(affectCvssToDelete.value[flawRef.value.affects[0].uuid!]).toBe('123');
+  });
+});

--- a/src/composables/useFlawAffectsModel.ts
+++ b/src/composables/useFlawAffectsModel.ts
@@ -52,6 +52,8 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
   const modifiedAffects = computed(() => [
     ...affectsToUpdate.value,
     ...affectCvssToUpsert.value.filter(({ uuid }) => uuid),
+    ...Object.keys(affectCvssToDelete.value)
+      .flatMap(affectId => flaw.value.affects.filter(({ uuid }) => uuid === affectId)),
   ]);
 
   const wereAffectsEditedOrAdded = computed(() => modifiedAffects.value.length > 0 || affectsToCreate.value.length > 0);
@@ -171,7 +173,7 @@ export function useFlawAffectsModel(flaw: Ref<ZodFlawType>) {
     if (affectCvssToUpsert.value.length) {
       let cvssScoresSavedCount = 0;
       for (const affect of affectCvssToUpsert.value) {
-        // For any new affects that have just been saved, we need to update the affect's
+        // For any new affects that have just been saved, we need to update the affect's uuid
         if (!affect.uuid) {
           const savedAffect = savedAffects.find(matcherForAffect(affect));
 


### PR DESCRIPTION
# OSIDB-3675: Fix Unable to remove affect cvss

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

- Variable `affectsCvssToDelete` was not considered when calculating `modifiedAffects`
- Added tests for `useFlawAffectsModel` composable
- Fixed z-fighting on the CVSS Calculator overlay

## Changes:

### Z fighting
|before|after|
|---|---|
|![ezgif-5-1cca0c949c](https://github.com/user-attachments/assets/e5ee5dad-624e-451a-b5b5-6fd89b9b9395)|![ezgif-5-3e6fd8a961](https://github.com/user-attachments/assets/86a92b75-ada2-4e47-b7ad-1134e412891e)|

## Considerations:

Closes OSIDB-3675