### PR TITLE
🐛 OSIDB-3658: Fix incorrect CVSS displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OSIM Changelog
 
+## [Unreleased]
+### Fixed
+* Fix duplicated values on CVSS displays (`OSIDB-3658`)
+
 ## [2024.11.1]
 ### Added
 * Support multiple user saved searches (`OSIDB-3554`)

--- a/src/components/CvssSection/CvssSection.vue
+++ b/src/components/CvssSection/CvssSection.vue
@@ -6,9 +6,9 @@ import CvssNISTForm from '@/components/CvssNISTForm/CvssNISTForm.vue';
 import { issuerLabels } from '@/composables/useFlawCvssScores';
 
 import LabelDiv from '@/widgets/LabelDiv/LabelDiv.vue';
-import type { ZodFlawCVSSType } from '@/types/zodFlaw';
 import { IssuerEnum } from '@/generated-client';
 import { CVSS_V3 } from '@/constants';
+import type { ZodFlawCVSSType } from '@/types';
 
 const props = defineProps<{
   allCvss: ZodFlawCVSSType[];
@@ -27,6 +27,12 @@ const otherCvss = computed(() => props.allCvss.filter(cvssItem =>
   (
     !(cvssItem.cvss_version === CVSS_V3 && (cvssItem.issuer === IssuerEnum.Rh || cvssItem.issuer === IssuerEnum.Nist))
   )));
+
+function cvssDisplay(score: string, vector: string, version: string) {
+  return vector.includes('CVSS')
+    ? score + ' ' + vector
+    : score + ' CVSS:' + version + '/' + vector;
+}
 </script>
 
 <template>
@@ -81,7 +87,13 @@ const otherCvss = computed(() => props.allCvss.filter(cvssItem =>
           <div class="d-flex flex-row">
             <div class="form-control text-break h-auto">
               <span>
-                {{ cvssItem.score + ' CVSS:' + cvssItem.cvss_version.substring(1) + '/' + cvssItem.vector }}
+                {{
+                  cvssDisplay(
+                    cvssItem.score?.toString() || '',
+                    cvssItem.vector || '',
+                    cvssItem.cvss_version.substring(1)
+                  )
+                }}
               </span>
             </div>
           </div>

--- a/src/views/__tests__/FlawCreateView.spec.ts
+++ b/src/views/__tests__/FlawCreateView.spec.ts
@@ -1,8 +1,7 @@
 import { mountWithConfig } from '@/__tests__/helpers';
 import { server } from '@/__tests__/setup';
 import { getNextAccessTokenHandler } from '@/__tests__/handlers';
-
-import FlawCreateView from '../FlawCreateView.vue';
+import FlawCreateView from '@/views/FlawCreateView.vue';
 
 describe('flawCreateView', () => {
   beforeAll(() => {


### PR DESCRIPTION
# OSIDB-3658: Fix incorrect CVSS displays

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Fix to handle duplicated values on the CVSS displays.

## Changes:

Handles cases where vector values include CVSS version.

## Considerations:

- Sometimes the vector values of third party CVSS come in already display format (i.e. includes CVSS + Version values in the vector string) In other cases the vector value is just the vector and the display string must be formed by OSIM. For this reasons it is required a conditional display, where the string is formed based in the CVSS vector value received from OSIDB.
- This does not happen for RH values, those are static so it was only needed to handle the values in the new collapsible section where third party CVSS are displayed.

## Demo
Before:
![image](https://github.com/user-attachments/assets/ca25327e-ce8a-4ff4-94f4-dfaad420e194)

After:
![image](https://github.com/user-attachments/assets/36f273c4-675c-47ce-904a-c364d53e3a10)


Closes OSIDB-3658
