### PR TITLE
🐛 OSIDB-3720: Fix trackers status filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OSIM Changelog
 
+## [Unreleased]
+### Fixed
+* Fix trackers status filter not working (`OSIDB-3720`)
+
 ## [2024.11.1]
 ### Added
 * Support multiple user saved searches (`OSIDB-3554`)

--- a/src/components/FlawTrackers/FlawTrackers.vue
+++ b/src/components/FlawTrackers/FlawTrackers.vue
@@ -69,7 +69,7 @@ function sortTrackers(trackers: TrackerWithModule[]): TrackerWithModule[] {
 const filteredTrackers = computed(() => {
   return props.displayedTrackers.filter((tracker) => {
     const matchesStatusFilter =
-      statusFilter.value.length === 0 || statusFilter.value.includes(tracker.status ?? 'EMPTY');
+      statusFilter.value.length === 0 || statusFilter.value.includes(tracker.status?.toUpperCase() || 'EMPTY');
     return matchesStatusFilter;
   });
 });

--- a/src/components/__tests__/FlawTrackers.spec.ts
+++ b/src/components/__tests__/FlawTrackers.spec.ts
@@ -112,6 +112,31 @@ describe('flawTrackers', () => {
     expect(firstTracker.find('td:nth-of-type(3)').text()).toBe('xxxx-0-001');
   });
 
+  osimFullFlawTest('Trackers can be filtered by status', async ({ flaw }) => {
+    const subject = mountFlawTrackers({
+      flaw: flaw as ZodFlawType,
+      relatedFlaws: [flaw as ZodFlawType],
+      displayedTrackers: flaw.affects
+        .flatMap(affect => affect.trackers
+          .map(tracker => ({ ...tracker, ps_module: affect.ps_module })),
+        ),
+      allTrackersCount: 0,
+    });
+
+    let trackersTableRows = subject.findAll('.affects-trackers .osim-tracker-card table tbody tr');
+    expect(trackersTableRows.length).toBe(6);
+
+    const trackerStatusFilterBtn = subject.find('#status-filter');
+    await trackerStatusFilterBtn.trigger('click');
+
+    const statusFilterSelection = subject.find('ul.dropdown-menu > li > a');
+    expect(statusFilterSelection.find('span').text()).toBe('NEW');
+    await statusFilterSelection.find('input').trigger('click');
+
+    trackersTableRows = subject.findAll('.affects-trackers .osim-tracker-card table tbody tr');
+    expect(trackersTableRows.length).toBe(3);
+  });
+
   osimFullFlawTest('Trackers display functional external links', async ({ flaw }) => {
     const subject = mountFlawTrackers({
       flaw,


### PR DESCRIPTION
# OSIDB-3720: Fix trackers status filtering

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Fix  trackers status filter not working (always shows no results).

## Changes:

- Correct trackers status filter computed function

Closes OSIDB-3720
