### PR TITLE
Configure Dependabot to add internal label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "internal"
+      - "dependencies"


### PR DESCRIPTION
By default Dependabot adds the dependencies label. Since we want the Dependabot PRs to skip the Jira pipeline, we need it to also add the internal label.

Related to OSIDB-3713
