### PR TITLE
✨ Enable manual flaw association in tracker manager during query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Fixed
 * Fix duplicated values on CVSS displays (`OSIDB-3658`)
+### Changed
+* Enable manual flaw association in Trackers Manager while query for related flaws resolves (`OSIDB-3739`)
 
 ## [2024.11.1]
 ### Added

--- a/src/components/FlawAffects/__tests__/__snapshots__/FlawAffects.spec.ts.snap
+++ b/src/components/FlawAffects/__tests__/__snapshots__/FlawAffects.spec.ts.snap
@@ -774,7 +774,14 @@ This module has no trackers associated"><i data-v-2d3c4208="" class="bi bi-excla
                   <div data-v-4940748f="" data-v-f682b1b0="">
                     <ul data-v-4940748f="" class="nav nav-tabs">
                       <li data-v-4940748f="" class="nav-item"><button data-v-4940748f="" type="button" class="nav-link active"><span data-v-4940748f="">CVE-2024-1234</span></button></li>
-                      <div data-v-f682b1b0="" class="ms-2 mt-2"><span data-v-f682b1b0="" class="spinner-border spinner-border-sm me-1 text-info" role="status"><span data-v-f682b1b0="" class="visually-hidden">Loading...</span></span><span data-v-f682b1b0="" class="ms-1">Querying available trackers…</span></div>
+                      <li data-v-4940748f="" class="nav-item"><button data-v-4940748f="" type="button" class="nav-link osim-add-tab" data-bs-toggle="dropdown"><i data-v-4940748f="" class="bi bi-plus"></i></button>
+                        <ul data-v-4940748f="" class="p-2 osim-dropdown-menu dropdown-menu dropdown-menu-end">
+                          <li data-v-4940748f=""><input data-v-4940748f="" class="border border-info px-1 mx-2 focus-ring focus-ring-info" type="text" placeholder="Search..."><button data-v-4940748f="" disabled="" class="btn btn-info btn-sm font-white" type="button">Add</button></li>
+                          <li data-v-4940748f="">
+                            <div data-v-f682b1b0="" class="ms-2 mt-2"><span data-v-f682b1b0="" class="spinner-border spinner-border-sm me-1 text-info" role="status"><span data-v-f682b1b0="" class="visually-hidden">Loading...</span></span><span data-v-f682b1b0="" class="ms-1">Querying available trackers…</span></div>
+                          </li>
+                        </ul>
+                      </li>
                     </ul>
                     <div data-v-4940748f="" class="">
                       <div data-v-f682b1b0="" class="osim-tracker-tabs">
@@ -1159,7 +1166,14 @@ This module has no trackers associated"><i data-v-2d3c4208="" class="bi bi-excla
                   <div data-v-4940748f="" data-v-f682b1b0="">
                     <ul data-v-4940748f="" class="nav nav-tabs">
                       <li data-v-4940748f="" class="nav-item"><button data-v-4940748f="" type="button" class="nav-link active"><span data-v-4940748f="">CVE-2024-1234</span></button></li>
-                      <div data-v-f682b1b0="" class="ms-2 mt-2"><span data-v-f682b1b0="" class="spinner-border spinner-border-sm me-1 text-info" role="status"><span data-v-f682b1b0="" class="visually-hidden">Loading...</span></span><span data-v-f682b1b0="" class="ms-1">Querying available trackers…</span></div>
+                      <li data-v-4940748f="" class="nav-item"><button data-v-4940748f="" type="button" class="nav-link osim-add-tab" data-bs-toggle="dropdown"><i data-v-4940748f="" class="bi bi-plus"></i></button>
+                        <ul data-v-4940748f="" class="p-2 osim-dropdown-menu dropdown-menu dropdown-menu-end">
+                          <li data-v-4940748f=""><input data-v-4940748f="" class="border border-info px-1 mx-2 focus-ring focus-ring-info" type="text" placeholder="Search..."><button data-v-4940748f="" disabled="" class="btn btn-info btn-sm font-white" type="button">Add</button></li>
+                          <li data-v-4940748f="">
+                            <div data-v-f682b1b0="" class="ms-2 mt-2"><span data-v-f682b1b0="" class="spinner-border spinner-border-sm me-1 text-info" role="status"><span data-v-f682b1b0="" class="visually-hidden">Loading...</span></span><span data-v-f682b1b0="" class="ms-1">Querying available trackers…</span></div>
+                          </li>
+                        </ul>
+                      </li>
                     </ul>
                     <div data-v-4940748f="" class="">
                       <div data-v-f682b1b0="" class="osim-tracker-tabs">

--- a/src/components/TrackerManager/TrackerManager.vue
+++ b/src/components/TrackerManager/TrackerManager.vue
@@ -107,7 +107,6 @@ async function handleFileTrackers() {
       <span class="me-2">Managing trackers for {{ specificAffects.length }} affected offering(s):</span>
       <span v-for="affect in specificAffects" :key="affect" class="badge bg-info me-1">{{ affect }}</span>
     </div>
-
     <div class="osim-trackers-filing mb-2">
       <div class="osim-tracker-manager-controls">
         <input
@@ -131,7 +130,7 @@ async function handleFileTrackers() {
         :addableItems="relatedFlawIds"
         @addTab="addRelatedFlaw"
       >
-        <template v-if="isQuerying" #add-tab>
+        <template v-if="isQuerying" #loading-indicator>
           <div class="ms-2 mt-2">
             <span
               class="spinner-border spinner-border-sm me-1 text-info"

--- a/src/widgets/TabsDynamic/TabsDynamic.vue
+++ b/src/widgets/TabsDynamic/TabsDynamic.vue
@@ -51,43 +51,42 @@ function selectTab(index: number) {
           <span>{{ label }}</span>
         </button>
       </li>
-      <slot name="add-tab">
-        <li class="nav-item">
-          <button
-            type="button"
-            class="nav-link osim-add-tab"
-            data-bs-toggle="dropdown"
-          >
-            <i class="bi bi-plus"></i>
-          </button>
-          <ul class="p-2 osim-dropdown-menu dropdown-menu dropdown-menu-end">
-            <li>
-              <input
-                v-model="searchFilter"
-                class="border border-info px-1 mx-2 focus-ring focus-ring-info"
-                type="text"
-                placeholder="Search..."
-                @submit.prevent="emit('addTab', searchFilter)"
-              />
-              <button
-                :disabled="!isCveValid(searchFilter)"
-                class="btn btn-info btn-sm font-white"
-                type="button"
-                @click="emit('addTab', searchFilter)"
-              >Add</button>
-            </li>
-            <li v-for="item in filteredItems" :key="item">
-              <button
-                class="dropdown-item"
-                type="button"
-                @click="emit('addTab', item)"
-              >
-                {{ item }}
-              </button>
-            </li>
-          </ul>
-        </li>
-      </slot>
+      <li class="nav-item">
+        <button
+          type="button"
+          class="nav-link osim-add-tab"
+          data-bs-toggle="dropdown"
+        >
+          <i class="bi bi-plus"></i>
+        </button>
+        <ul class="p-2 osim-dropdown-menu dropdown-menu dropdown-menu-end">
+          <li>
+            <input
+              v-model="searchFilter"
+              class="border border-info px-1 mx-2 focus-ring focus-ring-info"
+              type="text"
+              placeholder="Search..."
+              @submit.prevent="emit('addTab', searchFilter)"
+            />
+            <button
+              :disabled="!isCveValid(searchFilter)"
+              class="btn btn-info btn-sm font-white"
+              type="button"
+              @click="emit('addTab', searchFilter)"
+            >Add</button>
+          </li>
+          <li><slot name="loading-indicator" /></li>
+          <li v-for="item in filteredItems" :key="item">
+            <button
+              class="dropdown-item"
+              type="button"
+              @click="emit('addTab', item)"
+            >
+              {{ item }}
+            </button>
+          </li>
+        </ul>
+      </li>
     </ul>
     <div v-for="(label, index) in labels" :key="index" :class="{ 'visually-hidden': index !== activeTabIndex }">
       <slot


### PR DESCRIPTION
# OSIDB-3739 Trackers Manager: Allow manual flaw association during related flaws query

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Allows user to not have to wait for query to finish when adding a related flaw CVE manually.

## Changes:

- Moves the loading indicator to the dropdown for adding a related flaw

## Considerations:

--

Closes OSIDB-3739.
