### PR TITLE
Disable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     labels:
       - "internal"
       - "dependencies"
+    # Disable version updates, only make PRs for security updates
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Dependabot is making PRs for version updates not related to any security patches. We only want it to make PRs for security updates, so this commit disables the number of version updates it makes, while still allowing it to make security updates.
