### PR TITLE
🐛 OSIDB-3708: Fix affect resolution on not affected changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Changed
 * Enable manual flaw association in Trackers Manager while query for related flaws resolves (`OSIDB-3739`)
 * Fix save all button behavior for affects table (`OSIDB-3664`)
+* Fix loss of focus and undesirable sorting on affects being edited (`OSIDB-3700`)
 
 ## [2024.11.1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # OSIM Changelog
+## [Unreleased]
+### Changed
+* Move notifications to left side (`OSIDB-3543`)
+* Don't show notifications when they are disabled (`OSIDB-3543`)
 
 ## [2024.12.0]
 ### Added
@@ -15,8 +19,7 @@
 
 ### Changed
 * Enable manual flaw association in Trackers Manager while query for related flaws resolves (`OSIDB-3739`)
-* Move notifications to left side (`OSIDB-3543`)
-* Don't show notifications when they are disabled (`OSIDB-3543`)
+* Fix save all button behavior for affects table (`OSIDB-3664`)
 
 ## [2024.11.1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@
 
 ### Changed
 * Enable manual flaw association in Trackers Manager while query for related flaws resolves (`OSIDB-3739`)
-* Fix save all button behavior for affects table (`OSIDB-3664`)
-* Fix loss of focus and undesirable sorting on affects being edited (`OSIDB-3700`)
+* Move notifications to left side (`OSIDB-3543`)
+* Don't show notifications when they are disabled (`OSIDB-3543`)
 
 ## [2024.11.1]
 ### Added

--- a/src/components/FlawAffects/FlawAffectsTableRow.vue
+++ b/src/components/FlawAffects/FlawAffectsTableRow.vue
@@ -188,13 +188,13 @@ function affectednessChange(event: Event, affect: ZodAffectType) {
         v-model="affect.affectedness"
         class="form-select"
         @keydown="handleKeystroke($event, affect)"
+        @change="affectednessChange($event, affect)"
       >
         <option
           v-for="affectedness in affectAffectedness"
           :key="affectedness"
           :value="affectedness"
           :selected="affectedness === affect.affectedness"
-          @change="affectednessChange($event, affect)"
         >
           {{ affectedness }}
         </option>

--- a/src/components/FlawAffects/__tests__/FlawAffects.spec.ts
+++ b/src/components/FlawAffects/__tests__/FlawAffects.spec.ts
@@ -233,6 +233,30 @@ describe('flawAffects', () => {
     expect(resolutionOptions.includes('DEFER')).toBe(false);
   });
 
+  osimFullFlawTest('Changing affect to not affected automatically sets empty resolution', async () => {
+    const affectsTableRows = subject.findAll('.affects-management table tbody tr');
+
+    let resolutionSelect = affectsTableRows[0].find('td:nth-of-type(6) span');
+    expect(resolutionSelect.text()).not.toEqual('');
+
+    const affectRowEditBtn = affectsTableRows[0].find('td:last-of-type button:first-of-type');
+    expect(affectRowEditBtn.exists()).toBe(true);
+    await affectRowEditBtn.trigger('click');
+
+    const affectsTableEditingRows = subject.findAll('.affects-management table tbody tr.editing');
+    const affectednessSelect = affectsTableEditingRows[0].find('td:nth-of-type(5) select');
+    await affectednessSelect.setValue('NOTAFFECTED');
+    const selectedAffectedness = affectednessSelect.find('option[selected]');
+    expect(selectedAffectedness.text()).toBe('NOTAFFECTED');
+
+    const affectRowCommitBtn = affectsTableEditingRows[0].find('td:last-of-type button:first-of-type');
+    expect(affectRowCommitBtn.exists()).toBe(true);
+    await affectRowCommitBtn.trigger('click');
+
+    resolutionSelect = affectsTableRows[0].find('td:nth-of-type(6) span');
+    expect(resolutionSelect.text()).toBe('');
+  });
+
   osimFullFlawTest('Affects can be modified', async () => {
     let affectsTableEditingRows = subject.findAll('.affects-management table tbody tr.modified');
     expect(affectsTableEditingRows.length).toBe(0);


### PR DESCRIPTION
# OSIDB-3708: Fix affect resolution on not affected changes

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Affect resolution needs to be set to empty value when the affectedness is set to `NOTAFFECTED`. The bug was preventing this change to be automatic when changing an affect to `NOTAFFECTED`, forcing the users to manually set the resolution to empty prior to changing the affectedness.

## Changes:

- Move the `onChange` event designated to handle the automatic resolution change, from the affectedness option element to the the select element
- Add new test case to cover the bus scenario


## Considerations:

- Depends on https://github.com/RedHatProductSecurity/osim/pull/478

## Demo:

https://github.com/user-attachments/assets/b8c0d0aa-d035-4d35-9b4d-a3cff7e6afda

Closes OSIDB-3708
