### PR TITLE
🐛 OSIDB-3609 Fix advance search order by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 * Fix trackers status filter not working (`OSIDB-3720`)
 * Fix duplicated values on CVSS displays (`OSIDB-3658`)
+* Fix wrong advance search custom order (`OSIDB-3609`)
 
 ### Changed
 * Enable manual flaw association in Trackers Manager while query for related flaws resolves (`OSIDB-3739`)

--- a/src/composables/useSearchParams.ts
+++ b/src/composables/useSearchParams.ts
@@ -22,7 +22,10 @@ const searchQuery = z.object({
 
 const facets = ref<Facet[]>([]);
 const query = ref<string>('');
-const order = computed(() => orderMode.value === 'asc' && orderField.value ? `-${orderField.value}` : orderField.value);
+const order = computed(() => orderMode.value === 'desc' && orderField.value
+  ? `-${orderField.value}`
+  : orderField.value,
+);
 const orderField = ref<string>('');
 const orderMode = ref<orderMode>('asc');
 const search = ref('');
@@ -66,10 +69,10 @@ export function useSearchParams() {
     if (parsedRoute.query.order) {
       params.order = parsedRoute.query.order;
       if ((route.query.order as string).startsWith('-')) {
-        orderMode.value = 'asc';
+        orderMode.value = 'desc';
         orderField.value = (route.query.order as string).slice(1);
       } else {
-        orderMode.value = 'desc';
+        orderMode.value = 'asc';
         orderField.value = route.query.order as string;
       }
     }


### PR DESCRIPTION
# OSIDB-3609 Fix advance search order by

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Ascendant and descendant order by fields on the advance search were working the opposite way.
This fix corrects that,

## Changes:

- Switch `asc` and `desc` orders on useSearchParams

## Demo:

https://github.com/user-attachments/assets/49cd1d0c-0489-4432-b942-6ad72c33ff60

Closes OSIDB-3609
