### PR TITLE
🐛 Fix affects impact and resolution ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OSIM Changelog
 
+## [Unreleased]
+### Fixed
+* Fix incorrect affects ordering by Impact and Resolution (`OSIDB-3480`)
+
 ## [2024.12.1]
 ### Fixed
 * Fix save all button behavior for affects table (`OSIDB-3664`)

--- a/src/components/FlawAffects/__tests__/FlawAffects.spec.ts
+++ b/src/components/FlawAffects/__tests__/FlawAffects.spec.ts
@@ -358,73 +358,30 @@ describe('flawAffects', () => {
     expect(lastAffect.find(`td:nth-of-type(${columnIndex}) span`).text()).toBe(first);
   });
 
-  osimFullFlawTest('Affects can be filtered by affectedness', async () => {
-    let affectsTableRows = subject.findAll('.affects-management table tbody tr');
-    expect(affectsTableRows.length).toBe(6);
+  osimFullFlawTest.each([
+    { column: 'Affectedness', columnIndex: 5, option: 'EMPTY', optionValue: '', optionIndex: 1 },
+    { column: 'Resolution', columnIndex: 6, option: 'WONTFIX', optionValue: 'WONTFIX', optionIndex: 4 },
+    { column: 'Impact', columnIndex: 7, option: 'CRITICAL', optionValue: 'CRITICAL', optionIndex: 4 },
+  ])('Affects can be filtered by $column', async ({ column, columnIndex, option, optionIndex, optionValue }) => {
+    const componentHeader = subject.find(`.affects-management table thead tr th:nth-of-type(${columnIndex})`);
+    expect(componentHeader.text()).toStrictEqual(expect.stringMatching(column));
 
-    let affectednessFilterBtn = subject.find('#affectedness-filter');
-    expect(affectednessFilterBtn.find('i.bi-funnel').exists()).toBe(true);
-    await affectednessFilterBtn.trigger('click');
+    const filterBtn = componentHeader.find('button');
+    expect(filterBtn.find('i.bi-funnel').exists()).toBe(true);
+    await filterBtn.trigger('click');
 
-    const affectednessFilterDropdownMenu = subject.findAll('ul.dropdown-menu')[0];
-    expect(affectednessFilterDropdownMenu.exists()).toBe(true);
+    const filterDropdownMenu = componentHeader.find('ul.dropdown-menu');
+    expect(filterDropdownMenu.exists()).toBe(true);
 
-    const affectednessEmptyFilterOption = affectednessFilterDropdownMenu.find('li:first-of-type a');
-    expect(affectednessEmptyFilterOption.exists()).toBe(true);
-    expect(affectednessEmptyFilterOption.find('span').text()).toBe('EMPTY');
-    await affectednessEmptyFilterOption.trigger('click');
+    const filterOption = filterDropdownMenu.find(`li:nth-of-type(${optionIndex}) a`);
+    expect(filterOption.find('span').text()).toBe(option);
+    await filterOption.trigger('click');
+    await filterBtn.trigger('click');
 
-    affectsTableRows = subject.findAll('.affects-management table tbody tr');
-    expect(affectsTableRows.length).toBe(1);
-
-    affectednessFilterBtn = subject.find('#affectedness-filter');
-    expect(affectednessFilterBtn.find('i.bi-funnel-fill').exists()).toBe(true);
-  });
-
-  osimFullFlawTest('Affects can be filtered by resolution', async () => {
-    let affectsTableRows = subject.findAll('.affects-management table tbody tr');
-    expect(affectsTableRows.length).toBe(6);
-
-    let resolutionFilterBtn = subject.find('#resolution-filter');
-    expect(resolutionFilterBtn.find('i.bi-funnel').exists()).toBe(true);
-    await resolutionFilterBtn.trigger('click');
-
-    const resolutionFilterDropdownMenu = subject.findAll('ul.dropdown-menu')[1];
-    expect(resolutionFilterDropdownMenu.exists()).toBe(true);
-
-    const resolutionWontfixFilterOption = resolutionFilterDropdownMenu.find('li:nth-of-type(4) a');
-    expect(resolutionWontfixFilterOption.exists()).toBe(true);
-    expect(resolutionWontfixFilterOption.find('span').text()).toBe('WONTFIX');
-    await resolutionWontfixFilterOption.trigger('click');
-
-    affectsTableRows = subject.findAll('.affects-management table tbody tr');
-    expect(affectsTableRows.length).toBe(1);
-
-    resolutionFilterBtn = subject.find('#resolution-filter');
-    expect(resolutionFilterBtn.find('i.bi-funnel-fill').exists()).toBe(true);
-  });
-
-  osimFullFlawTest('Affects can be filtered by impact', async () => {
-    let affectsTableRows = subject.findAll('.affects-management table tbody tr');
-    expect(affectsTableRows.length).toBe(6);
-
-    let impactFilterBtn = subject.find('#impact-filter');
-    expect(impactFilterBtn.find('i.bi-funnel').exists()).toBe(true);
-    await impactFilterBtn.trigger('click');
-
-    const impactFilterDropdownMenu = subject.findAll('ul.dropdown-menu')[2];
-    expect(impactFilterDropdownMenu.exists()).toBe(true);
-
-    const impactWontfixFilterOption = impactFilterDropdownMenu.find('li:nth-of-type(4) a');
-    expect(impactWontfixFilterOption.exists()).toBe(true);
-    expect(impactWontfixFilterOption.find('span').text()).toBe('CRITICAL');
-    await impactWontfixFilterOption.trigger('click');
-
-    affectsTableRows = subject.findAll('.affects-management table tbody tr');
-    expect(affectsTableRows.length).toBe(1);
-
-    impactFilterBtn = subject.find('#impact-filter');
-    expect(impactFilterBtn.find('i.bi-funnel-fill').exists()).toBe(true);
+    const affectsTableRows = subject.findAll('.affects-management table tbody tr');
+    for (const row of affectsTableRows) {
+      expect(row.find(`td:nth-of-type(${columnIndex}) span`).text()).toBe(optionValue);
+    }
   });
 
   osimFullFlawTest('Affect modules table cell have correct tootltip', async () => {

--- a/src/components/FlawAffects/__tests__/FlawAffects.spec.ts
+++ b/src/components/FlawAffects/__tests__/FlawAffects.spec.ts
@@ -326,24 +326,36 @@ describe('flawAffects', () => {
     expect(affectsTableRows.length).toBe(6);
   });
 
-  osimFullFlawTest('Affects can be sorted by clicking on the field column', async () => {
+  osimFullFlawTest.each([
+    { column: 'Module', columnIndex: 3, first: 'openshift-6', last: 'openshift-1' },
+    { column: 'Component', columnIndex: 4, first: 'openshift-1-1', last: 'openshift-6-1' },
+    { column: 'Affectedness', columnIndex: 5, first: 'AFFECTED', last: '' },
+    { column: 'Resolution', columnIndex: 6, first: 'DELEGATED', last: 'WONTFIX' },
+    { column: 'Impact', columnIndex: 7, first: 'CRITICAL', last: 'LOW' },
+    { column: 'Trackers', columnIndex: 9, first: '0', last: '4' },
+  ])('Affects can be sorted by $column column', async ({ column, columnIndex, first, last }) => {
+    const componentHeader = subject.find(`.affects-management table thead tr th:nth-of-type(${columnIndex})`);
+    expect(componentHeader.text()).toStrictEqual(expect.stringMatching(column));
+
+    // Ascending order
+    await componentHeader.trigger('click');
+
     let affectsTableRows = subject.findAll('.affects-management table tbody tr');
     let firstAffect = affectsTableRows[0];
-    expect(firstAffect.find('td:nth-of-type(4) span').text()).toBe('openshift-1-1');
-    let secondAffect = affectsTableRows[1];
-    expect(secondAffect.find('td:nth-of-type(4) span').text()).toBe('openshift-2-1');
+    let lastAffect = affectsTableRows.at(-1)!;
 
-    const componentHeader = subject.find('.affects-management table thead tr th:nth-of-type(4)');
-    expect(componentHeader.exists()).toBe(true);
-    expect(componentHeader.text()).toBe('Component');
-    await componentHeader.trigger('click');
+    expect(firstAffect.find(`td:nth-of-type(${columnIndex}) span`).text()).toBe(first);
+    expect(lastAffect.find(`td:nth-of-type(${columnIndex}) span`).text()).toBe(last);
+
+    // Descending order
     await componentHeader.trigger('click');
 
     affectsTableRows = subject.findAll('.affects-management table tbody tr');
     firstAffect = affectsTableRows[0];
-    expect(firstAffect.find('td:nth-of-type(4) span').text()).toBe('openshift-6-1');
-    secondAffect = affectsTableRows[1];
-    expect(secondAffect.find('td:nth-of-type(4) span').text()).toBe('openshift-5-1');
+    lastAffect = affectsTableRows.at(-1)!;
+
+    expect(firstAffect.find(`td:nth-of-type(${columnIndex}) span`).text()).toBe(last);
+    expect(lastAffect.find(`td:nth-of-type(${columnIndex}) span`).text()).toBe(first);
   });
 
   osimFullFlawTest('Affects can be filtered by affectedness', async () => {

--- a/src/components/FlawAffects/useFilterSortAffects.ts
+++ b/src/components/FlawAffects/useFilterSortAffects.ts
@@ -65,13 +65,18 @@ export function useFilterSortAffects() {
       } else if (sortKey.value === 'cvss_scores') {
         return affect[sortKey.value].length;
       }
+      if (affect[sortKey.value] === '') {
+        return sortOrder.value === ascend ? '_' : 'Z';
+      }
       return affect[sortKey.value] || 0;
     };
 
     const comparators = standard
       ? [ascend<ZodAffectType>(prop('ps_module')), ascend<ZodAffectType>(prop('ps_component'))]
-      : [order<ZodAffectType>(customSortFn),
-          order<ZodAffectType>(sortKey.value === 'ps_module' ? prop('ps_component') : prop('ps_module'))];
+      : [
+          order<ZodAffectType>(customSortFn),
+          order<ZodAffectType>(sortKey.value === 'ps_module' ? prop('ps_component') : prop('ps_module')),
+        ];
 
     return sortWith([
       ascend((affect: ZodAffectType) => !affect.uuid ? 0 : 1),


### PR DESCRIPTION
# OSIDB-3480: Fix incorrect affects ordering

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Fix wrong sorting on affects table by Impact and Resolution

## Changes:

- Fix affects sorting comparator
- Add new test cases

Closes OSIDB-3480
