### PR TITLE
🐛 Fix cvss not created on new affects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixed
 * Fix save all button behavior for affects table (`OSIDB-3664`)
 * Fix loss of focus and undesirable sorting on affects being edited (`OSIDB-3700`)
+* Fix CVSS not created for new affects on save (`OSIDB-3777`)
 
 ### Changed
 * Move notifications to left side (`OSIDB-3543`)

--- a/src/composables/useFlawAffectsModel.ts
+++ b/src/composables/useFlawAffectsModel.ts
@@ -109,7 +109,7 @@ export function useFlawAffectsModel() {
   }
 
   function shouldUpsertAffectCvss(affect: ZodAffectType) {
-    return affectRhCvss3(affect)?.vector && didAffectCvssChange(affect);
+    return affectRhCvss3(affect)?.vector && (didAffectCvssChange(affect) || !affect.uuid);
   }
 
   async function removeAffects() {


### PR DESCRIPTION
# OSIDB-3777: Fix cvss not created on new affects

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [x] Jira ticket updated

## Summary:

CVSS was not being created on new affects on flaw save.

## Changes:

Extends a condition related to the affect CVSS to be created to consider also new affects.

## Demo:

https://github.com/user-attachments/assets/7fa93b5a-16e0-4b76-a90f-8ce082135d43

Closes OSIDB-3777
