### PR TITLE
[OSIDB-3861] CVSS embargoed status does not match Flaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * Fix incorrect affects ordering by Impact and Resolution (`OSIDB-3480`)
+* Fix incorrect embargoed state of CVSS scores (`OSIDB-3861`)
 
 ### Added
 * Support PURLs in affected components (`OSIDB-3412`)

--- a/src/composables/__tests__/useFlawCvssScores.spec.ts
+++ b/src/composables/__tests__/useFlawCvssScores.spec.ts
@@ -6,6 +6,9 @@ import { useFlawCvssScores } from '@/composables/useFlawCvssScores';
 import { blankFlaw } from '@/composables/useFlaw';
 
 import { IssuerEnum } from '@/generated-client';
+import { putFlawCvssScores } from '@/services/FlawService';
+
+vi.mock('@/services/FlawService');
 
 describe('useFlawCvssScores', () => {
   osimFullFlawTest('should return an object', ({ flaw }) => {
@@ -45,5 +48,16 @@ describe('useFlawCvssScores', () => {
 
       expect(shouldDisplayEmailNistForm.value).toBeTruthy();
     });
+  });
+
+  osimFullFlawTest('should match flaw embargo status', ({ flaw }) => {
+    flaw.cvss_scores.forEach(score => score.embargoed = true);
+    flaw.embargoed = false;
+    const { saveCvssScores } = useFlawCvssScores(ref(flaw));
+
+    saveCvssScores();
+
+    expect(vi.mocked(putFlawCvssScores))
+      .toHaveBeenCalledWith(flaw.uuid, flaw.cvss_scores[0].uuid, expect.objectContaining({ embargoed: false }));
   });
 });

--- a/src/composables/useFlawCvssScores.ts
+++ b/src/composables/useFlawCvssScores.ts
@@ -109,7 +109,9 @@ export function useFlawCvssScores(flaw: Ref<ZodFlawType>) {
       if (flawRhCvss3.value?.vector === null && flawRhCvss3.value?.uuid != null) {
         return deleteFlawCvssScores(flaw.value.uuid, flawRhCvss3.value.uuid);
       }
-      return putFlawCvssScores(flaw.value.uuid, flawRhCvss3.value.uuid || '', flawRhCvss3.value as unknown);
+      // Update embargoed state from parent flaw
+      flawRhCvss3.value.embargoed = flaw.value.embargoed;
+      return putFlawCvssScores(flaw.value.uuid, flawRhCvss3.value.uuid || '', flawRhCvss3.value);
     }
 
     // Handle newly created CVSS score

--- a/src/composables/useFlawCvssScores.ts
+++ b/src/composables/useFlawCvssScores.ts
@@ -7,6 +7,7 @@ import type { ZodFlawType } from '@/types/zodFlaw';
 import { deepCopyFromRaw } from '@/utils/helpers';
 import { IssuerEnum } from '@/generated-client';
 import { CVSS_V3 } from '@/constants';
+import type { Nullable } from '@/utils/typeHelpers';
 
 export const issuerLabels: Record<string, string> = {
   [IssuerEnum.Nist]: 'NVD',
@@ -15,7 +16,7 @@ export const issuerLabels: Record<string, string> = {
   [IssuerEnum.Osv]: 'OSV',
 };
 
-const formatScore = (score: any) => score?.toFixed(1);
+const formatScore = (score: Nullable<number>) => score?.toFixed(1) ?? '';
 // TODO: This composable should be ideally refactored into a more modular
 // solution when CVSSv4 starts being used
 export function useFlawCvssScores(flaw: Ref<ZodFlawType>) {
@@ -123,7 +124,7 @@ export function useFlawCvssScores(flaw: Ref<ZodFlawType>) {
       vector: flawRhCvss3.value?.vector,
       embargoed: flaw.value.embargoed,
     };
-    return postFlawCvssScores(flaw.value.uuid, requestBody as unknown);
+    return postFlawCvssScores(flaw.value.uuid, requestBody);
   }
 
   return {


### PR DESCRIPTION
# OSIDB-3861 CVSS embargoed status does not match Flaw
## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

CVSS Objects have an `embargoed` field independent from `Flaw.embargoed`, when a Flaw is unembargoed and the CVSS score is updated on the same action, the fields don't match and OSIDB returns an ACL error.
This change synchronizes both fields before CVSS update.

## Changes:

- Fixed CVSS embargo status
- Removed some weak types on the same files

## Considerations:

Closes OSIDB-3861
