### PR TITLE
✨ Show all affects button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,12 @@
 ## [Unreleased]
 ### Added
 * Show Flaw Labels on Flaw List Component (`OSIDB-3805`)
+* Support PURLs in affected components (`OSIDB-3412`)
+* Support showing all trackers/affects in single page (`OSIDB-3506`)
 
 ### Fixed
 * Fix incorrect affects ordering by Impact and Resolution (`OSIDB-3480`)
 * Fix incorrect embargoed state of CVSS scores (`OSIDB-3861`)
-
-### Added
-* Support PURLs in affected components (`OSIDB-3412`)
 
 ## [2024.12.1]
 ### Fixed

--- a/src/components/FlawAffects/FlawAffects.vue
+++ b/src/components/FlawAffects/FlawAffects.vue
@@ -71,7 +71,7 @@ const {
   sortAffects,
 } = useFilterSortAffects();
 
-const displayMode = ref(displayModes.ALL);
+const displayMode = ref(displayModes.DEFAULT);
 
 const allAffects = computed((): ZodAffectType[] => affectsToDelete.value.concat(flaw.value.affects));
 
@@ -112,6 +112,9 @@ const {
   totalPages,
 } = usePaginationWithSettings(sortedAffects, { setting: 'affectsPerPage' });
 
+const tableAffects = computed(() =>
+  displayMode.value === displayModes.ALL ? sortedAffects.value : paginatedAffects.value,
+);
 const modulesExpanded = ref(true);
 const specificAffectsToTrack = ref<ZodAffectType[]>([]);
 
@@ -120,7 +123,7 @@ const hasAffects = computed(() => allAffects.value.length > 0);
 
 watch(flaw.value.affects, (newAffects) => {
   if (newAffects.length <= 0) {
-    setDisplayMode(displayModes.ALL);
+    setDisplayMode(displayModes.DEFAULT);
   }
 });
 
@@ -128,7 +131,7 @@ onUnmounted(resetSelections);
 
 function setDisplayMode(mode: displayModes) {
   if (displayMode.value === mode) {
-    displayMode.value = displayModes.ALL;
+    displayMode.value = displayModes.DEFAULT;
   } else {
     displayMode.value = mode;
   }
@@ -300,7 +303,7 @@ const displayedTrackers = computed(() => {
       </LabelCollapsible>
     </div>
     <div class="affects-management">
-      <div v-if="hasAffects" class="pagination-controls gap-1 my-2">
+      <div v-if="hasAffects && displayMode !== displayModes.ALL" class="pagination-controls gap-1 my-2">
         <button
           type="button"
           tabindex="-1"
@@ -334,7 +337,7 @@ const displayedTrackers = computed(() => {
       <div class="affects-toolbar">
         <div class="badges my-auto gap-1" :class="{ 'me-3': hasAffects }">
           <div
-            v-if="paginatedAffects.length > 0"
+            v-if="paginatedAffects.length > 0 && displayMode !== displayModes.ALL"
             class="per-page-btn btn btn-sm btn-secondary"
           >
             <i
@@ -363,7 +366,7 @@ const displayedTrackers = computed(() => {
             :title="displayMode !== displayModes.ALL ? 'Display all affects' : 'Displaying all affects'"
             @click.stop="setDisplayMode(displayModes.ALL)"
           >
-            <span>All affects {{ allAffects.length }}</span>
+            <span>Show all affects ({{ allAffects.length }})</span>
           </div>
           <div
             v-if="selectedAffects.length > 0"
@@ -496,7 +499,7 @@ const displayedTrackers = computed(() => {
         </div>
       </div>
       <FlawAffectsTable
-        v-model:affects="paginatedAffects"
+        v-model:affects="tableAffects"
         :errors="errors"
         :selectedModules="selectedModules"
         :totalPages="totalPages"

--- a/src/components/FlawAffects/__tests__/FlawAffects.spec.ts
+++ b/src/components/FlawAffects/__tests__/FlawAffects.spec.ts
@@ -152,6 +152,21 @@ describe('flawAffects', () => {
     expect(itemsPerPageIndicator.text()).toBe('Per page: 10');
   });
 
+  osimFullFlawTest('Show all button works properly', async () => {
+    let badgeButtons = subject.findAll('.badges div');
+    const showAllBtn = badgeButtons[1];
+    expect(badgeButtons.length).toBe(2);
+    expect(showAllBtn.text()).toBe('Show all affects (6)');
+
+    await showAllBtn.trigger('click');
+
+    const affectsTableRows = subject.findAll('.affects-management table tbody tr');
+    const rowCount = affectsTableRows.length;
+    expect(rowCount).toBe(6);
+    badgeButtons = subject.findAll('.badges div');
+    expect(badgeButtons.length).toBe(1);
+  });
+
   osimFullFlawTest('Affects are selectable by clicking in the row', async () => {
     let affectsTableSelectedRows = subject.findAll('.affects-management table tbody tr.selected');
     expect(affectsTableSelectedRows.length).toBe(0);

--- a/src/components/FlawAffects/__tests__/__snapshots__/FlawAffects.spec.ts.snap
+++ b/src/components/FlawAffects/__tests__/__snapshots__/FlawAffects.spec.ts.snap
@@ -27,7 +27,7 @@ This module has no trackers associated"><i data-v-2d3c4208="" class="bi bi-excla
     <div data-v-2d3c4208="" class="affects-toolbar">
       <div data-v-2d3c4208="" class="badges my-auto gap-1 me-3">
         <div data-v-2d3c4208="" class="per-page-btn btn btn-sm btn-secondary"><i data-v-2d3c4208="" style="pointer-events: auto;" class="bi bi-dash-square fs-6 my-auto" title="Reduce affects per page"></i><span data-v-2d3c4208="" class="mx-2 my-auto">Per page: 10</span><i data-v-2d3c4208="" style="pointer-events: auto;" class="bi bi-plus-square fs-6 my-auto" title="Increase affects per page"></i></div>
-        <div data-v-2d3c4208="" class="badge-btn btn btn-sm border-secondary bg-secondary text-white" style="cursor: auto;" title="Displaying all affects"><span data-v-2d3c4208="">All affects 6</span></div>
+        <div data-v-2d3c4208="" class="badge-btn btn btn-sm border-secondary bg-light-gray text-black" style="cursor: pointer;" title="Display all affects"><span data-v-2d3c4208="">Show all affects (6)</span></div>
         <!--v-if-->
         <!--v-if-->
         <!--v-if-->
@@ -234,8 +234,7 @@ This module has no trackers associated"><i data-v-2d3c4208="" class="bi bi-excla
         <div data-v-89a61d08="" class="trackers-toolbar p-2 pt-1">
           <div data-v-89a61d08="" class="tracker-badges">
             <div data-v-89a61d08="" class="per-page-btn btn btn-sm badge"><i data-v-89a61d08="" style="pointer-events: auto;" class="bi bi-dash-square fs-6 my-auto" title="Reduce trackers per page"></i><span data-v-89a61d08="" class="mx-2 my-auto">Per page: 10</span><i data-v-89a61d08="" style="pointer-events: auto;" class="bi bi-plus-square fs-6 my-auto" title="Increase trackers per page"></i></div>
-            <div data-v-89a61d08="" class="badge" title="All trackers in this flaw"><span data-v-89a61d08="">All trackers 6</span></div>
-            <div data-v-89a61d08="" class="badge" title="Trackers displayed in current page"><span data-v-89a61d08="">Displaying 6</span></div>
+            <div data-v-89a61d08="" class="badge bg-light-cyan" style="cursor: pointer;"><span data-v-89a61d08="">Show All Trackers (6)</span></div>
           </div><button data-v-89a61d08="" type="button" class="btn btn-sm btn-info ms-auto"><i data-v-89a61d08="" class="bi bi-binoculars"></i> Show Trackers Manager </button>
         </div>
       </div>
@@ -422,7 +421,6 @@ exports[`flawAffects > Correctly renders the component when there are no affects
           <div data-v-89a61d08="" class="tracker-badges">
             <!--v-if-->
             <!--v-if-->
-            <!--v-if-->
           </div><button data-v-89a61d08="" type="button" class="btn btn-sm btn-info ms-auto"><i data-v-89a61d08="" class="bi bi-binoculars"></i> Show Trackers Manager </button>
         </div>
       </div>
@@ -487,7 +485,7 @@ This module has no trackers associated"><i data-v-2d3c4208="" class="bi bi-excla
     <div data-v-2d3c4208="" class="affects-toolbar">
       <div data-v-2d3c4208="" class="badges my-auto gap-1 me-3">
         <div data-v-2d3c4208="" class="per-page-btn btn btn-sm btn-secondary"><i data-v-2d3c4208="" style="pointer-events: auto;" class="bi bi-dash-square fs-6 my-auto" title="Reduce affects per page"></i><span data-v-2d3c4208="" class="mx-2 my-auto">Per page: 10</span><i data-v-2d3c4208="" style="pointer-events: auto;" class="bi bi-plus-square fs-6 my-auto" title="Increase affects per page"></i></div>
-        <div data-v-2d3c4208="" class="badge-btn btn btn-sm border-secondary bg-secondary text-white" style="cursor: auto;" title="Displaying all affects"><span data-v-2d3c4208="">All affects 6</span></div>
+        <div data-v-2d3c4208="" class="badge-btn btn btn-sm border-secondary bg-light-gray text-black" style="cursor: pointer;" title="Display all affects"><span data-v-2d3c4208="">Show all affects (6)</span></div>
         <div data-v-2d3c4208="" class="badge-btn btn btn-sm border-secondary bg-light-gray text-black" title="Display selected affects"><i data-v-2d3c4208="" class="bi bi-check-square me-1 h-fit"></i><span data-v-2d3c4208="">Selected 3</span></div>
         <!--v-if-->
         <!--v-if-->
@@ -693,8 +691,7 @@ This module has no trackers associated"><i data-v-2d3c4208="" class="bi bi-excla
         <div data-v-89a61d08="" class="trackers-toolbar p-2 pt-1">
           <div data-v-89a61d08="" class="tracker-badges">
             <div data-v-89a61d08="" class="per-page-btn btn btn-sm badge"><i data-v-89a61d08="" style="pointer-events: auto;" class="bi bi-dash-square fs-6 my-auto" title="Reduce trackers per page"></i><span data-v-89a61d08="" class="mx-2 my-auto">Per page: 10</span><i data-v-89a61d08="" style="pointer-events: auto;" class="bi bi-plus-square fs-6 my-auto" title="Increase trackers per page"></i></div>
-            <div data-v-89a61d08="" class="badge" title="All trackers in this flaw"><span data-v-89a61d08="">All trackers 6</span></div>
-            <div data-v-89a61d08="" class="badge" title="Trackers displayed in current page"><span data-v-89a61d08="">Displaying 6</span></div>
+            <div data-v-89a61d08="" class="badge bg-light-cyan" style="cursor: pointer;"><span data-v-89a61d08="">Show All Trackers (6)</span></div>
           </div><button data-v-89a61d08="" type="button" class="btn btn-sm btn-info ms-auto"><i data-v-89a61d08="" class="bi bi-binoculars"></i> Show Trackers Manager </button>
         </div>
       </div>
@@ -897,7 +894,7 @@ This module has no trackers associated"><i data-v-2d3c4208="" class="bi bi-excla
     <div data-v-2d3c4208="" class="affects-toolbar">
       <div data-v-2d3c4208="" class="badges my-auto gap-1 me-3">
         <div data-v-2d3c4208="" class="per-page-btn btn btn-sm btn-secondary"><i data-v-2d3c4208="" style="pointer-events: auto;" class="bi bi-dash-square fs-6 my-auto" title="Reduce affects per page"></i><span data-v-2d3c4208="" class="mx-2 my-auto">Per page: 10</span><i data-v-2d3c4208="" style="pointer-events: auto;" class="bi bi-plus-square fs-6 my-auto" title="Increase affects per page"></i></div>
-        <div data-v-2d3c4208="" class="badge-btn btn btn-sm border-secondary bg-secondary text-white" style="cursor: auto;" title="Displaying all affects"><span data-v-2d3c4208="">All affects 6</span></div>
+        <div data-v-2d3c4208="" class="badge-btn btn btn-sm border-secondary bg-light-gray text-black" style="cursor: pointer;" title="Display all affects"><span data-v-2d3c4208="">Show all affects (6)</span></div>
         <!--v-if-->
         <!--v-if-->
         <!--v-if-->
@@ -1104,8 +1101,7 @@ This module has no trackers associated"><i data-v-2d3c4208="" class="bi bi-excla
         <div data-v-89a61d08="" class="trackers-toolbar p-2 pt-1">
           <div data-v-89a61d08="" class="tracker-badges">
             <div data-v-89a61d08="" class="per-page-btn btn btn-sm badge"><i data-v-89a61d08="" style="pointer-events: auto;" class="bi bi-dash-square fs-6 my-auto" title="Reduce trackers per page"></i><span data-v-89a61d08="" class="mx-2 my-auto">Per page: 10</span><i data-v-89a61d08="" style="pointer-events: auto;" class="bi bi-plus-square fs-6 my-auto" title="Increase trackers per page"></i></div>
-            <div data-v-89a61d08="" class="badge" title="All trackers in this flaw"><span data-v-89a61d08="">All trackers 6</span></div>
-            <div data-v-89a61d08="" class="badge" title="Trackers displayed in current page"><span data-v-89a61d08="">Displaying 6</span></div>
+            <div data-v-89a61d08="" class="badge bg-light-cyan" style="cursor: pointer;"><span data-v-89a61d08="">Show All Trackers (6)</span></div>
           </div><button data-v-89a61d08="" type="button" class="btn btn-sm btn-info ms-auto"><i data-v-89a61d08="" class="bi bi-binoculars"></i> Show Trackers Manager </button>
         </div>
       </div>

--- a/src/components/FlawAffects/flawAffectConstants.ts
+++ b/src/components/FlawAffects/flawAffectConstants.ts
@@ -3,6 +3,7 @@ import { type ZodAffectType } from '@/types';
 export enum displayModes {
   ALL = 'All',
   CREATED = 'Created',
+  DEFAULT = 'Default',
   DELETED = 'Deleted',
   EDITING = 'Editing',
   MODIFIED = 'Modified',

--- a/src/components/FlawTrackers/FlawTrackers.vue
+++ b/src/components/FlawTrackers/FlawTrackers.vue
@@ -34,6 +34,8 @@ const showTrackerManager = ref(false);
 
 const hasTrackers = computed(() => props.allTrackersCount > 0);
 
+const showAllTrackers = ref(false);
+
 // Sorting
 const sortedTrackers = computed(() => sortTrackers(filteredTrackers.value));
 
@@ -106,6 +108,10 @@ const {
   paginatedItems: paginatedTrackers,
   totalPages,
 } = usePaginationWithSettings(sortedTrackers, { setting: 'trackersPerPage' });
+
+const tableTrackers = computed(() => {
+  return showAllTrackers.value ? filteredTrackers.value : paginatedTrackers.value;
+});
 </script>
 
 <template>
@@ -115,7 +121,7 @@ const {
         <div class="affect-trackers-heading d-flex p-1 pt-2 px-3">
           <h5 class="m-0">Trackers</h5>
         </div>
-        <div v-if="hasTrackers" class="pagination-controls gap-1 ms-2">
+        <div v-if="hasTrackers && !showAllTrackers" class="pagination-controls gap-1 ms-2">
           <button
             type="button"
             class="btn btn-sm btn-info rounded-end-0"
@@ -145,7 +151,7 @@ const {
         <div class="trackers-toolbar p-2 pt-1">
           <div class="tracker-badges">
             <div
-              v-if="paginatedTrackers.length > 0"
+              v-if="paginatedTrackers.length > 0 && !showAllTrackers"
               class="per-page-btn btn btn-sm badge"
             >
               <i
@@ -169,16 +175,11 @@ const {
             <div
               v-if="hasTrackers"
               class="badge"
-              title="All trackers in this flaw"
+              :class="showAllTrackers ? 'bg-info' : 'bg-light-cyan'"
+              style="cursor: pointer;"
+              @click.stop="showAllTrackers = !showAllTrackers"
             >
-              <span>All trackers {{ allTrackersCount }}</span>
-            </div>
-            <div
-              v-if="paginatedTrackers.length > 0"
-              class="badge"
-              title="Trackers displayed in current page"
-            >
-              <span>Displaying {{ paginatedTrackers.length }}</span>
+              <span>Show All Trackers ({{ allTrackersCount }})</span>
             </div>
           </div>
           <button
@@ -280,7 +281,7 @@ const {
           </thead>
           <tbody>
             <tr
-              v-for="(tracker, trackerIndex) in paginatedTrackers"
+              v-for="(tracker, trackerIndex) in tableTrackers"
               :key="trackerIndex"
             >
               <td>

--- a/src/components/__tests__/FlawTrackers.spec.ts
+++ b/src/components/__tests__/FlawTrackers.spec.ts
@@ -87,6 +87,30 @@ describe('flawTrackers', () => {
     expect(itemsPerPageIndicator.text()).toBe('Per page: 10');
   });
 
+  osimFullFlawTest('Show all button works properly', async ({ flaw }) => {
+    const subject = mountFlawTrackers({
+      flaw: flaw as ZodFlawType,
+      relatedFlaws: [flaw as ZodFlawType],
+      displayedTrackers: flaw.affects
+        .flatMap(affect => affect.trackers
+          .map(tracker => ({ ...tracker, ps_module: affect.ps_module })),
+        ),
+      allTrackersCount: 6,
+    });
+
+    let badgeButtons = subject.findAll('.tracker-badges div');
+    const showAllBtn = badgeButtons[1];
+    expect(showAllBtn.text()).toBe('Show All Trackers (6)');
+
+    await showAllBtn.trigger('click');
+
+    const affectsTableRows = subject.findAll('.osim-tracker-card table tbody tr');
+    const rowCount = affectsTableRows.length;
+    expect(rowCount).toBe(6);
+    badgeButtons = subject.findAll('.tracker-badges div');
+    expect(badgeButtons.length).toBe(1);
+  });
+
   osimFullFlawTest('Trackers can be sorted by clicking on the date field columns', async ({ flaw }) => {
     const subject = mountFlawTrackers({
       flaw: flaw as ZodFlawType,

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -527,7 +527,7 @@ This module has no trackers associated"><i data-v-2d3c4208="" class="bi bi-excla
         <div data-v-2d3c4208="" class="affects-toolbar">
           <div data-v-2d3c4208="" class="badges my-auto gap-1 me-3">
             <div data-v-2d3c4208="" class="per-page-btn btn btn-sm btn-secondary"><i data-v-2d3c4208="" style="pointer-events: auto;" class="bi bi-dash-square fs-6 my-auto" title="Reduce affects per page"></i><span data-v-2d3c4208="" class="mx-2 my-auto">Per page: 10</span><i data-v-2d3c4208="" style="pointer-events: auto;" class="bi bi-plus-square fs-6 my-auto" title="Increase affects per page"></i></div>
-            <div data-v-2d3c4208="" class="badge-btn btn btn-sm border-secondary bg-secondary text-white" style="cursor: auto;" title="Displaying all affects"><span data-v-2d3c4208="">All affects 6</span></div>
+            <div data-v-2d3c4208="" class="badge-btn btn btn-sm border-secondary bg-light-gray text-black" style="cursor: pointer;" title="Display all affects"><span data-v-2d3c4208="">Show all affects (6)</span></div>
             <!--v-if-->
             <!--v-if-->
             <!--v-if-->
@@ -734,8 +734,7 @@ This module has no trackers associated"><i data-v-2d3c4208="" class="bi bi-excla
             <div data-v-89a61d08="" class="trackers-toolbar p-2 pt-1">
               <div data-v-89a61d08="" class="tracker-badges">
                 <div data-v-89a61d08="" class="per-page-btn btn btn-sm badge"><i data-v-89a61d08="" style="pointer-events: auto;" class="bi bi-dash-square fs-6 my-auto" title="Reduce trackers per page"></i><span data-v-89a61d08="" class="mx-2 my-auto">Per page: 10</span><i data-v-89a61d08="" style="pointer-events: auto;" class="bi bi-plus-square fs-6 my-auto" title="Increase trackers per page"></i></div>
-                <div data-v-89a61d08="" class="badge" title="All trackers in this flaw"><span data-v-89a61d08="">All trackers 6</span></div>
-                <div data-v-89a61d08="" class="badge" title="Trackers displayed in current page"><span data-v-89a61d08="">Displaying 6</span></div>
+                <div data-v-89a61d08="" class="badge bg-light-cyan" style="cursor: pointer;"><span data-v-89a61d08="">Show All Trackers (6)</span></div>
               </div><button data-v-89a61d08="" type="button" class="btn btn-sm btn-info ms-auto"><i data-v-89a61d08="" class="bi bi-binoculars"></i> Show Trackers Manager </button>
             </div>
           </div>

--- a/src/components/__tests__/__snapshots__/FlawTrackers.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawTrackers.spec.ts.snap
@@ -12,7 +12,6 @@ exports[`flawTrackers > Correctly renders the component when there are not track
         <div data-v-89a61d08="" class="tracker-badges">
           <!--v-if-->
           <!--v-if-->
-          <!--v-if-->
         </div><button data-v-89a61d08="" type="button" class="btn btn-sm btn-info ms-auto"><i data-v-89a61d08="" class="bi bi-binoculars"></i> Show Trackers Manager </button>
       </div>
     </div>
@@ -53,7 +52,6 @@ exports[`flawTrackers > Correctly renders the component when there are trackers 
         <div data-v-89a61d08="" class="tracker-badges">
           <div data-v-89a61d08="" class="per-page-btn btn btn-sm badge"><i data-v-89a61d08="" style="pointer-events: auto;" class="bi bi-dash-square fs-6 my-auto" title="Reduce trackers per page"></i><span data-v-89a61d08="" class="mx-2 my-auto">Per page: 10</span><i data-v-89a61d08="" style="pointer-events: auto;" class="bi bi-plus-square fs-6 my-auto" title="Increase trackers per page"></i></div>
           <!--v-if-->
-          <div data-v-89a61d08="" class="badge" title="Trackers displayed in current page"><span data-v-89a61d08="">Displaying 6</span></div>
         </div><button data-v-89a61d08="" type="button" class="btn btn-sm btn-info ms-auto"><i data-v-89a61d08="" class="bi bi-binoculars"></i> Show Trackers Manager </button>
       </div>
     </div>
@@ -158,7 +156,6 @@ exports[`flawTrackers > Displays embedded trackers manager 1`] = `
         <div data-v-89a61d08="" class="tracker-badges">
           <div data-v-89a61d08="" class="per-page-btn btn btn-sm badge"><i data-v-89a61d08="" style="pointer-events: auto;" class="bi bi-dash-square fs-6 my-auto" title="Reduce trackers per page"></i><span data-v-89a61d08="" class="mx-2 my-auto">Per page: 10</span><i data-v-89a61d08="" style="pointer-events: auto;" class="bi bi-plus-square fs-6 my-auto" title="Increase trackers per page"></i></div>
           <!--v-if-->
-          <div data-v-89a61d08="" class="badge" title="Trackers displayed in current page"><span data-v-89a61d08="">Displaying 6</span></div>
         </div><button data-v-89a61d08="" type="button" class="btn btn-sm btn-info ms-auto"><i data-v-89a61d08="" class="bi bi-binoculars"></i> Show Trackers Manager </button>
       </div>
     </div>


### PR DESCRIPTION
# OSIDB-3506: Show all affects button

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

New buttons to display all trackers/affects in a single page.

## Changes:

- Add new button feature to affect and trackers table

## Demo:

https://github.com/user-attachments/assets/38d868a4-fedb-4275-92f1-c67b118b6312

## Considerations:

- When the show all is enabled the pagination controls are hidden

Closes OSIDB-3506
