### PR TITLE
✨ Increase step value for items per page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,12 @@
 ## [Unreleased]
 ### Added
 * Show Flaw Labels on Flaw List Component (`OSIDB-3805`)
+* Support PURLs in affected components (`OSIDB-3412`)
+* Increase step value for affects and trackers per page (`OSIDB-3508`)
 
 ### Fixed
 * Fix incorrect affects ordering by Impact and Resolution (`OSIDB-3480`)
 * Fix incorrect embargoed state of CVSS scores (`OSIDB-3861`)
-
-### Added
-* Support PURLs in affected components (`OSIDB-3412`)
 
 ## [2024.12.1]
 ### Fixed

--- a/src/components/FlawAffects/__tests__/FlawAffects.spec.ts
+++ b/src/components/FlawAffects/__tests__/FlawAffects.spec.ts
@@ -131,9 +131,7 @@ describe('flawAffects', () => {
     expect(itemsPerPageIndicator.text()).toBe('Per page: 10');
 
     const reduceItemsBtn = subject.find('.affects-toolbar .badges .btn .bi-dash-square');
-    for (let i = 0; i < 5; i++) {
-      await reduceItemsBtn.trigger('click');
-    }
+    await reduceItemsBtn.trigger('click');
 
     affectsTableRows = subject.findAll('.affects-management table tbody tr');
     rowCount = affectsTableRows.length;
@@ -142,9 +140,7 @@ describe('flawAffects', () => {
     expect(itemsPerPageIndicator.text()).toBe('Per page: 5');
 
     const increaseItemsBtn = subject.find('.affects-toolbar .badges .btn .bi-plus-square');
-    for (let i = 0; i < 5; i++) {
-      await increaseItemsBtn.trigger('click');
-    }
+    await increaseItemsBtn.trigger('click');
 
     affectsTableRows = subject.findAll('.affects-management table tbody tr');
     rowCount = affectsTableRows.length;

--- a/src/components/__tests__/FlawTrackers.spec.ts
+++ b/src/components/__tests__/FlawTrackers.spec.ts
@@ -65,9 +65,7 @@ describe('flawTrackers', () => {
     expect(itemsPerPageIndicator.text()).toBe('Per page: 10');
 
     const reduceItemsBtn = subject.find('.trackers-toolbar .tracker-badges .btn .bi-dash-square');
-    for (let i = 0; i < 5; i++) {
-      await reduceItemsBtn.trigger('click');
-    }
+    await reduceItemsBtn.trigger('click');
 
     trackersTableRows = subject.findAll('.affects-trackers .osim-tracker-card table tbody tr');
     rowCount = trackersTableRows.length;
@@ -76,9 +74,7 @@ describe('flawTrackers', () => {
     expect(itemsPerPageIndicator.text()).toBe('Per page: 5');
 
     const increaseItemsBtn = subject.find('.trackers-toolbar .tracker-badges .btn .bi-plus-square');
-    for (let i = 0; i < 5; i++) {
-      await increaseItemsBtn.trigger('click');
-    }
+    await increaseItemsBtn.trigger('click');
 
     trackersTableRows = subject.findAll('.affects-trackers .osim-tracker-card table tbody tr');
     rowCount = trackersTableRows.length;

--- a/src/composables/usePaginationWithSettings.ts
+++ b/src/composables/usePaginationWithSettings.ts
@@ -24,15 +24,11 @@ export function usePaginationWithSettings(itemsToPaginate: Ref<any[]>, options: 
   } = options;
 
   function decreaseItemsPerPage() {
-    if (settings.value[setting] > minItemsPerPage) {
-      settings.value[setting]--;
-    }
+    settings.value[setting] = Math.max(settings.value[setting] - 5, minItemsPerPage);
   }
 
   function increaseItemsPerPage() {
-    if (settings.value[setting] < maxItemsPerPage) {
-      settings.value[setting]++;
-    }
+    settings.value[setting] = Math.min(settings.value[setting] + 5, maxItemsPerPage);
   }
 
   const totalPages = computed(() =>


### PR DESCRIPTION
# OSIDB-3508 Increase step value for items per page

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:
Changing the step value for the "Per page" actions on the trackers/affects tables.

## Changes:

- Changes the step value on the pagination composable

## Demo:

https://github.com/user-attachments/assets/257c7d3c-7a0c-4956-94ba-36b4b8f327e1

## Considerations:

- Min/Max function are used to control the range limits (max items per page and min items per page)

Closes OSIDB-3508
