### PR TITLE
🐛 Fix sorting for new affects (don't sort them)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 * Fix incorrect affects ordering by Impact and Resolution (`OSIDB-3480`)
 * Fix incorrect embargoed state of CVSS scores (`OSIDB-3861`)
+* Prevent focus-loss when editing new affects by exempting them from auto-sort (`OSIDB-3972`)
 
 ## [2024.12.1]
 ### Fixed

--- a/src/components/FlawAffects/useFilterSortAffects.ts
+++ b/src/components/FlawAffects/useFilterSortAffects.ts
@@ -78,10 +78,9 @@ export function useFilterSortAffects() {
           order<ZodAffectType>(sortKey.value === 'ps_module' ? prop('ps_component') : prop('ps_module')),
         ];
 
-    return sortWith([
-      ascend((affect: ZodAffectType) => !affect.uuid ? 0 : 1),
-      ...comparators,
-    ])(affects);
+    const savedAffects = affects.filter(({ uuid }) => uuid);
+    const newAffects = affects.filter(({ uuid }) => !uuid);
+    return [...newAffects, ...sortWith(comparators)(savedAffects)];
   }
 
   function setAffectednessFilter(affectedness: string) {


### PR DESCRIPTION
# OSIDB-3972 Don't sort new affects, prevent loss of focus when editing

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
~- [ ] Test cases added/updated~
- [x] Jira ticket updated

## Summary:

Auto-sort causes new affects to be sorted which does not make sense and causes focus-loss.

## Changes:

Prevent focus-loss when editing new affects by exempting them from auto-sort 


Closes OSIDB-3972
