### PR TITLE
🔧 Don't Validate FlawHistory with Zod

### DIFF
--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -151,7 +151,7 @@ export const ZodFlawSchema = z.object({
   components: z.array(z.string().min(1).max(100)),
   title: z.string().min(4),
   owner: z.string().nullish(),
-  history: z.array(ZodHistoryItemSchema).nullish(),
+  history: z.array(z.any()).nullish(),
   team_id: z.string().nullish(),
   trackers: z.array(z.string()).nullish(), // read-only
   classification: ZodFlawClassification.nullish(),


### PR DESCRIPTION
# [OSIDB-3977] Fix Flaw saving after user mapping is merged

## Checklist:

- [x] Commits consolidated
- [x] Jira ticket updated

## Summary:

Removes or updates schema so that flaws wont be prevented from being saved by Zod encountering unexpected value types (strings) in the `history.pgh_context.user` field.

## Changes:

[Replace with a detailed description of the changes made in this PR, including any new features, enhancements, bug fixes, or refactorings.]

## Considerations:

[Replace with any additional considerations, notes, or instructions for reviewers.]

Closes OSIDB-3977
