### PR TITLE
✨ Add global Jira link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Support showing all trackers/affects in single page (`OSIDB-3506`)
 * Add suggestions on CWE Field (`OSIDB-3743`)
 * Show Flaw contributors table on edit view (`OSIDB-3806`)
+* Add a link to Jira task on top right of the flaw form (`OSIDB-3964`)
 
 ### Fixed
 * Fix incorrect affects ordering by Impact and Resolution (`OSIDB-3480`)

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -31,6 +31,7 @@ import { type ZodFlawType, descriptionRequiredStates, flawImpactEnum, flawSource
 import { useDraftFlawStore } from '@/stores/DraftFlawStore';
 import { deepCopyFromRaw } from '@/utils/helpers';
 import { allowedSources } from '@/constants/';
+import { jiraTaskUrl } from '@/services/JiraService';
 
 const props = defineProps<{
   flaw: ZodFlawType;
@@ -175,15 +176,25 @@ const createdDate = computed(() => {
       >
         <div class="row osim-flaw-form-section pt-0">
           <div class="osim-flaw-form-header">
-            <div v-if="flaw.meta_attr?.bz_id" class="osim-flaw-header-link">
+            <div class="osim-flaw-header-link">
               <a
+                v-if="flaw.meta_attr?.bz_id"
                 :href="bugzillaLink"
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 Open in Bugzilla <i class="bi-box-arrow-up-right ms-2" />
               </a>
+              <a
+                v-if="flaw.task_key"
+                :href="jiraTaskUrl(flaw.task_key)"
+                target="_blank"
+                :disabled="isSaving"
+              >
+                Open in Jira <i class="bi-box-arrow-up-right ms-2" />
+              </a>
             </div>
+
             <FlawAlertsList
               :flaw="flaw"
               class="col-12 osim-alerts-banner"
@@ -557,8 +568,10 @@ div.osim-content {
 
 .osim-flaw-header-link {
   position: absolute;
+  display: flex;
+  flex-direction: column;
   right: 0;
-  top: 1rem;
+  top: 0.25rem;
   width: auto;
 }
 </style>

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -474,6 +474,46 @@ describe('flawForm', () => {
     expect(bugzillaLink.exists()).toBe(false);
   });
 
+  osimFullFlawTest('should show a link to Jira if task_key exists', async ({ flaw }) => {
+    flaw.task_key = 'OSIM-1234';
+
+    vi.mock(import('@/services/JiraService'), async (importOriginal) => {
+      const actual = await importOriginal();
+      return {
+        ...actual,
+        jiraTaskUrl: () => 'http://jira-example.com',
+      };
+    });
+
+    const subject = mountWithProps(flawEditModeProps(flaw));
+
+    const flawLinks = subject.findAll('.osim-flaw-header-link > a');
+    expect(flawLinks.length).toBe(2);
+    expect(flawLinks[1].text()).contain('Jira');
+
+    vi.clearAllMocks();
+  });
+
+  osimFullFlawTest('should not show a link to Jira if task_key does not exists', async ({ flaw }) => {
+    flaw.task_key = '';
+
+    vi.mock(import('@/services/JiraService'), async (importOriginal) => {
+      const actual = await importOriginal();
+      return {
+        ...actual,
+        jiraTaskUrl: () => 'http://jira-example.com',
+      };
+    });
+
+    const subject = mountWithProps(flawEditModeProps(flaw));
+
+    const flawLinks = subject.findAll('.osim-flaw-header-link > a');
+    expect(flawLinks.length).toBe(1);
+    expect(flawLinks[0].text()).not.toContain('Jira');
+
+    vi.clearAllMocks();
+  });
+
   osimFullFlawTest('should show CreatedDate on Flaw Edit', async ({ flaw }) => {
     const subject = mountWithProps(flawEditModeProps(flaw));
     const createdAtField = subject

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -6,7 +6,9 @@ exports[`flawForm > mounts and renders 1`] = `
     <div data-v-76e7a15d="" class="row px-4 my-3">
       <div data-v-76e7a15d="" class="row osim-flaw-form-section pt-0">
         <div data-v-76e7a15d="" class="osim-flaw-form-header">
-          <div data-v-76e7a15d="" class="osim-flaw-header-link"><a data-v-76e7a15d="" href="/show_bug.cgi?id=1984541" target="_blank" rel="noopener noreferrer"> Open in Bugzilla <i data-v-76e7a15d="" class="bi-box-arrow-up-right ms-2"></i></a></div>
+          <div data-v-76e7a15d="" class="osim-flaw-header-link"><a data-v-76e7a15d="" href="/show_bug.cgi?id=1984541" target="_blank" rel="noopener noreferrer"> Open in Bugzilla <i data-v-76e7a15d="" class="bi-box-arrow-up-right ms-2"></i></a>
+            <!--v-if-->
+          </div>
           <div data-v-4715e8e2="" data-v-76e7a15d="" class="osim-collapsible-label my-2 col-12 osim-alerts-banner"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-plus-square-dotted"></i><label class="mx-2 mb-0 form-label"> Alerts: </label><span><div class="badge text-bg-danger mx-1"><i class="bi bi-x-circle-fill"></i> 1 Errors </div><div class="badge text-bg-warning mx-1"><i class="bi bi-exclamation-triangle-fill"></i> 1 Warnings </div></span></button>
             <div data-v-4715e8e2="" class="ps-3 border-start">
               <div data-v-4715e8e2="" class="visually-hidden">

--- a/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
+++ b/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
@@ -7,7 +7,10 @@ exports[`flawCreateView > should render 1`] = `
       <div data-v-76e7a15d="" class="row px-4 my-3">
         <div data-v-76e7a15d="" class="row osim-flaw-form-section pt-0">
           <div data-v-76e7a15d="" class="osim-flaw-form-header">
-            <!--v-if-->
+            <div data-v-76e7a15d="" class="osim-flaw-header-link">
+              <!--v-if-->
+              <!--v-if-->
+            </div>
             <!--v-if-->
           </div>
           <div data-v-76e7a15d="" id="" class="col-6"><label data-v-76509415="" data-v-76e7a15d="" class="osim-input ps-3 mb-2 input-group">


### PR DESCRIPTION
# OSIDB-3964 Add global Jira link

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Adds a link to Jira task if existing in the top right side of the flaw form view, just below the BZ link.
This requeriment appeared cause previously the only Jira link was on the internal comments, making it for read-only users who don't have an Jira API key set, difficult to quickly access to the related Jira task of a flaw.

## Changes:

- Adds the new Jira link on the flaw form view

## Screenshot:

![image](https://github.com/user-attachments/assets/27e061bf-3323-4eb0-ae2d-919b8d250e0a)

Closes OSIDB-3964
