### PR TITLE
🔒️ In-app privacy notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OSIM Changelog
 
+## [Unreleased]
+### Added
+* Global privacy notice toast (`OSIDB-3997`)
+* Public comments privacy notice banner (`OSIDB-3997`)
+
 ## [2025.2.0]
 ### Added
 * Show Flaw Labels on Flaw List Component (`OSIDB-3805`)

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,9 +19,11 @@ import {
 import { footerHeight, footerTop } from '@/stores/responsive';
 
 import { updateCWEData } from './services/CweService';
+import { useToastStore } from './stores/ToastStore';
 
 setup();
 
+const { addToast } = useToastStore();
 watch(osimRuntimeStatus, () => {
   if (osimRuntimeStatus.value === OsimRuntimeStatus.READY) {
     updateRelativeOsimBuildDate();
@@ -45,6 +47,12 @@ onMounted(() => {
   const ms15Minutes = 15 * 60 * 60 * 1000;
   buildDateIntervalId = setInterval(updateRelativeOsimBuildDate, ms15Minutes);
   updateRelativeOsimBuildDate();
+
+  addToast({
+    title: 'Privacy Notice',
+    body: 'OSIM transmits input information externally to Bugzilla for the purpose of retrieving bug data.' +
+    ' In some cases that information may be publicly visible.',
+  });
 });
 onBeforeUnmount(() => {
   clearInterval(buildDateIntervalId);

--- a/src/components/FlawComments/FlawComments.vue
+++ b/src/components/FlawComments/FlawComments.vue
@@ -280,6 +280,9 @@ const clearSuggestions = (event: FocusEvent | KeyboardEvent | MouseEvent) => {
             tabindex="-1"
             @blur.capture="clearSuggestions"
           >
+            <div v-if="selectedTab === CommentType.Public" class="alert alert-warning">
+              Any information provided in this comment will be publicly visible on Bugzilla.
+            </div>
             <template v-if="!isInternalComment">
               <LabelTextarea v-model="newComment" :label="`New ${CommentType[selectedTab]} Comment`" />
             </template>


### PR DESCRIPTION
# OSIDB-3997: 🔒️ In-app privacy notices

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Add in app message that will let users know that data input in this system will be transmitted to bugzilla thus
will be shared externally. Confirm completion and share evidence of
implementation.

## Changes:
- Add global toast for general Bugzilla data privacy notice
- Add specific banner on internal comments

## Demo:
###  Global privacy toast:
![image](https://github.com/user-attachments/assets/c12ed6fb-f2e9-49f4-ae1d-fb87b0ae9c8c)

### Public comment banner:
![image](https://github.com/user-attachments/assets/30ba2f01-90a9-4d12-aa11-b7a3a9860cd8)


## Considerations:
- Requirement for PIA

Closes OSIDB-3997
