### PR TITLE
[OSIDB-3991] Show all flaw labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Public comments privacy notice banner (`OSIDB-3997`)
 * Provide seconds in flaw history timestamps (`OSIDB-3958`)
 
+### Changed
+* Add a checkbox to hide/show flaw labels (`OSIDB-3991`)
+
 ## [2025.2.0]
 ### Added
 * Show Flaw Labels on Flaw List Component (`OSIDB-3805`)

--- a/src/components/IssueQueue/IssueQueue.vue
+++ b/src/components/IssueQueue/IssueQueue.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref, watch } from 'vue';
 
 import { DateTime } from 'luxon';
 import { useElementVisibility } from '@vueuse/core';
+import { storeToRefs } from 'pinia';
 
 import IssueQueueItem from '@/components/IssueQueue/IssueQueueItem.vue';
 
@@ -10,6 +11,7 @@ import LabelCheckbox from '@/widgets/LabelCheckbox/LabelCheckbox.vue';
 import { useUserStore } from '@/stores/UserStore';
 import { FlawClassificationStateEnum } from '@/generated-client';
 import type { ZodFlawType } from '@/types';
+import { useSettingsStore } from '@/stores/SettingsStore';
 
 const props = defineProps<{
   isFinalPageFetched: boolean;
@@ -20,6 +22,7 @@ const props = defineProps<{
 
 const emit = defineEmits(['flaws:fetch', 'flaws:load-more']);
 const userStore = useUserStore();
+const { settings } = storeToRefs(useSettingsStore());
 
 export type FilteredIssue = ReturnType<typeof relevantFields>;
 
@@ -139,6 +142,7 @@ watch(isButtonVisible, (isVisible) => {
     <div class="osim-incident-filter">
       <LabelCheckbox v-model="isMyIssuesSelected" label="My Issues" class="d-inline-block" />
       <LabelCheckbox v-model="isOpenIssuesSelected" label="Open Issues" class="d-inline-block" />
+      <LabelCheckbox v-model="settings.isHidingLabels" label="Hide labels" class="d-inline-block" />
       <div v-if="isLoading" class="d-inline-block float-end">
         <span
           class="spinner-border spinner-border-sm"
@@ -181,6 +185,7 @@ watch(isButtonVisible, (isVisible) => {
           <template v-for="(relevantIssue, index) of issues" :key="relevantIssue.id">
             <IssueQueueItem
               :issue="relevantIssue"
+              :showLabels="!settings.isHidingLabels"
               :class="{
                 'osim-shaded': index % 2 === 0,
               }"

--- a/src/components/__tests__/__snapshots__/IssueQueue.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/IssueQueue.spec.ts.snap
@@ -1,10 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`issueQueue > should render flaw labels 1`] = `
+exports[`issueQueue > should not render flaw labels when isHidingLabels is true 1`] = `
 "<div data-v-48717bcb="" class="osim-content container-fluid osim-issue-queue">
   <div data-v-48717bcb="" class="osim-incident-filter">
     <div data-v-b2ceeac4="" data-v-48717bcb="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-b2ceeac4="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-b2ceeac4="" class="d-inline-block form-check-input" type="checkbox"><span data-v-b2ceeac4="" class="form-check-label">My Issues</span></label></div>
     <div data-v-b2ceeac4="" data-v-48717bcb="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-b2ceeac4="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-b2ceeac4="" class="d-inline-block form-check-input" type="checkbox"><span data-v-b2ceeac4="" class="form-check-label">Open Issues</span></label></div>
+    <div data-v-b2ceeac4="" data-v-48717bcb="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-b2ceeac4="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-b2ceeac4="" class="d-inline-block form-check-input" type="checkbox" checked=""><span data-v-b2ceeac4="" class="form-check-label">Hide labels</span></label></div>
     <!--v-if--><span data-v-48717bcb="" class="float-end"> Loaded 1 of 10</span>
   </div>
   <div data-v-48717bcb="" class="osim-incident-list">
@@ -22,22 +23,15 @@ exports[`issueQueue > should render flaw labels 1`] = `
       </thead>
       <tbody data-v-48717bcb="" class="table-group-divider">
         <tr data-v-15d9c71d="" class="osim-issue-queue-item osim-shaded">
-          <td data-v-15d9c71d="" class="osim-issue-title pb-0"><a data-v-15d9c71d="" href="/flaws/CVE-2903-0092" class="">CVE-2903-0092</a></td>
-          <td data-v-15d9c71d="" class="pb-0">MODERATE</td>
-          <td data-v-15d9c71d="" class="pb-0">2021-07-29</td>
-          <td data-v-15d9c71d="" class="pb-0">title</td>
-          <td data-v-15d9c71d="" class="pb-0">NEW</td>
-          <td data-v-15d9c71d="" class="pb-0">test@redhat.com</td>
+          <td data-v-15d9c71d="" class="osim-issue-title"><a data-v-15d9c71d="" href="/flaws/CVE-2903-0092" class="">CVE-2903-0092</a></td>
+          <td data-v-15d9c71d="" class="">MODERATE</td>
+          <td data-v-15d9c71d="" class="">2021-07-29</td>
+          <td data-v-15d9c71d="" class="">title</td>
+          <td data-v-15d9c71d="" class="">NEW</td>
+          <td data-v-15d9c71d="" class="">test@redhat.com</td>
           <!--<td>{{ issue.assigned }}</td>-->
         </tr>
-        <tr data-v-15d9c71d="" class="osim-badge-lane osim-shaded">
-          <td data-v-15d9c71d="" colspan="100%">
-            <div data-v-15d9c71d="" class="gap-1 d-flex">
-              <!--v-if--><span data-v-15d9c71d="" class="badge rounded-pill text-capitalize border text-bg-warning fw-bold border-warning text-decoration-line-through text-bg-gray border-secondary" title="Requested">test-3</span><span data-v-15d9c71d="" class="badge rounded-pill text-capitalize border text-decoration-line-through text-bg-gray border-secondary" title="">test</span><span data-v-15d9c71d="" class="badge rounded-pill text-capitalize border text-decoration-line-through text-bg-gray border-secondary" title="">test-2</span>
-              <!--v-if-->
-            </div>
-          </td>
-        </tr>
+        <!--v-if-->
       </tbody>
     </table><button data-v-48717bcb="" class="btn btn-primary" type="button">
       <!--v-if--><span data-v-48717bcb=""> Load More Flaws </span>
@@ -48,11 +42,12 @@ exports[`issueQueue > should render flaw labels 1`] = `
 </div>"
 `;
 
-exports[`issueQueue > should truncate flaw labels 1`] = `
+exports[`issueQueue > should render flaw labels 1`] = `
 "<div data-v-48717bcb="" class="osim-content container-fluid osim-issue-queue">
   <div data-v-48717bcb="" class="osim-incident-filter">
     <div data-v-b2ceeac4="" data-v-48717bcb="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-b2ceeac4="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-b2ceeac4="" class="d-inline-block form-check-input" type="checkbox"><span data-v-b2ceeac4="" class="form-check-label">My Issues</span></label></div>
     <div data-v-b2ceeac4="" data-v-48717bcb="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-b2ceeac4="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-b2ceeac4="" class="d-inline-block form-check-input" type="checkbox"><span data-v-b2ceeac4="" class="form-check-label">Open Issues</span></label></div>
+    <div data-v-b2ceeac4="" data-v-48717bcb="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-b2ceeac4="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-b2ceeac4="" class="d-inline-block form-check-input" type="checkbox"><span data-v-b2ceeac4="" class="form-check-label">Hide labels</span></label></div>
     <!--v-if--><span data-v-48717bcb="" class="float-end"> Loaded 1 of 10</span>
   </div>
   <div data-v-48717bcb="" class="osim-incident-list">
@@ -79,11 +74,12 @@ exports[`issueQueue > should truncate flaw labels 1`] = `
           <!--<td>{{ issue.assigned }}</td>-->
         </tr>
         <tr data-v-15d9c71d="" class="osim-badge-lane osim-shaded">
-          <td data-v-15d9c71d="" colspan="100%">
-            <div data-v-15d9c71d="" class="gap-1 d-flex">
-              <!--v-if--><span data-v-15d9c71d="" class="badge rounded-pill text-capitalize border text-decoration-line-through text-bg-gray border-secondary" title="">test-0</span><span data-v-15d9c71d="" class="badge rounded-pill text-capitalize border text-decoration-line-through text-bg-gray border-secondary" title="">test-1</span><span data-v-15d9c71d="" class="badge rounded-pill text-capitalize border text-decoration-line-through text-bg-gray border-secondary" title="">test-2</span><span data-v-15d9c71d="" class="badge rounded-pill text-capitalize border text-decoration-line-through text-bg-gray border-secondary" title="">test-3</span><i data-v-15d9c71d="" class="bi pe-1 cursor-pointer osim-show-all-labels bi-caret-right-fill" title="Show all labels"></i>
+          <td data-v-15d9c71d="" colspan="1">
+            <div data-v-15d9c71d="" class="gap-1 d-flex flex-wrap">
+              <!--v-if--><span data-v-15d9c71d="" class="badge rounded-pill text-capitalize border text-bg-warning fw-bold border-warning text-decoration-line-through text-bg-gray border-secondary" title="Requested">test-3</span><span data-v-15d9c71d="" class="badge rounded-pill text-capitalize border text-decoration-line-through text-bg-gray border-secondary" title="">test</span><span data-v-15d9c71d="" class="badge rounded-pill text-capitalize border text-decoration-line-through text-bg-gray border-secondary" title="">test-2</span>
             </div>
           </td>
+          <td data-v-15d9c71d="" colspan="90%"></td>
         </tr>
       </tbody>
     </table><button data-v-48717bcb="" class="btn btn-primary" type="button">

--- a/src/stores/SettingsStore.ts
+++ b/src/stores/SettingsStore.ts
@@ -13,6 +13,7 @@ export const SettingsSchema = z.object({
   showNotifications: z.boolean(),
   affectsPerPage: z.number(),
   trackersPerPage: z.number(),
+  isHidingLabels: z.boolean().optional().default(false),
 });
 
 export type SettingsType = z.infer<typeof SettingsSchema>;
@@ -23,8 +24,9 @@ const defaultValues: SettingsType = {
   showNotifications: false,
   affectsPerPage: 10,
   trackersPerPage: 10,
+  isHidingLabels: false,
 };
-const osimSettings = useStorage('OSIM::USER-SETTINGS', defaultValues);
+const osimSettings = useStorage('OSIM::USER-SETTINGS', structuredClone(defaultValues));
 
 export const useSettingsStore = defineStore('SettingsStore', () => {
   const settings = ref<SettingsType>(osimSettings.value);
@@ -36,7 +38,7 @@ export const useSettingsStore = defineStore('SettingsStore', () => {
       settings.value = validatedSettings.data;
     }
   } else {
-    settings.value = defaultValues;
+    settings.value = structuredClone(defaultValues);
   }
 
   watch(settings, () => {
@@ -48,7 +50,7 @@ export const useSettingsStore = defineStore('SettingsStore', () => {
   }
 
   function $reset() {
-    settings.value = defaultValues;
+    settings.value = structuredClone(defaultValues);
   }
 
   return {

--- a/src/stores/__tests__/SettingsStore.spec.ts
+++ b/src/stores/__tests__/SettingsStore.spec.ts
@@ -2,14 +2,15 @@ import { describe, it, expect } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { createPinia, setActivePinia } from 'pinia';
 
-import { useSettingsStore } from '../SettingsStore';
+import { useSettingsStore, type SettingsType } from '../SettingsStore';
 
-const initialState = {
+const initialState: SettingsType = {
   bugzillaApiKey: '',
   jiraApiKey: '',
   showNotifications: false,
   affectsPerPage: 10,
   trackersPerPage: 10,
+  isHidingLabels: false,
 };
 
 // While not used in this file, store below depends on global pinia test instance
@@ -28,27 +29,26 @@ describe('settingsStore', () => {
   it('initializes', () => {
     expect(settingsStore.$state.settings).toEqual(initialState);
   });
+
   it('saves values', () => {
-    settingsStore.save({
+    const settings = {
       bugzillaApiKey: 'beep-beep-who-got-the-keys-to-the-jeep',
       jiraApiKey: 'beep-beep-who-got-the-keys-to-the-jeep',
-      showNotifications: true,
-      affectsPerPage: 10,
-      trackersPerPage: 10,
-    });
-    expect(
-      settingsStore.settings.bugzillaApiKey === 'beep-beep-who-got-the-keys-to-the-jeep',
-    ).toBe(true);
-    expect(
-      settingsStore.settings.jiraApiKey === 'beep-beep-who-got-the-keys-to-the-jeep',
-    ).toBe(true);
-    expect(
-      settingsStore.settings.showNotifications,
-    ).toBe(true);
+      showNotifications: !initialState.showNotifications,
+      affectsPerPage: 1337,
+      trackersPerPage: 1337,
+      isHidingLabels: !initialState.isHidingLabels,
+    };
+
+    settingsStore.save(settings);
+
+    expect(settingsStore.settings).toEqual(settings);
   });
+
   it('reset', () => {
     settingsStore.settings.showNotifications = true;
     settingsStore.$reset();
+
     expect(settingsStore.settings.showNotifications).toBe(false);
   });
 });

--- a/src/views/__tests__/__snapshots__/IndexView.spec.ts.snap
+++ b/src/views/__tests__/__snapshots__/IndexView.spec.ts.snap
@@ -12,6 +12,7 @@ Fields: affects__ps_component: test" class="btn me-2 mt-1 border" type="button">
     <div data-v-48717bcb="" class="osim-incident-filter">
       <div data-v-b2ceeac4="" data-v-48717bcb="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-b2ceeac4="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-b2ceeac4="" class="d-inline-block form-check-input" type="checkbox"><span data-v-b2ceeac4="" class="form-check-label">My Issues</span></label></div>
       <div data-v-b2ceeac4="" data-v-48717bcb="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-b2ceeac4="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-b2ceeac4="" class="d-inline-block form-check-input" type="checkbox"><span data-v-b2ceeac4="" class="form-check-label">Open Issues</span></label></div>
+      <div data-v-b2ceeac4="" data-v-48717bcb="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-b2ceeac4="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-b2ceeac4="" class="d-inline-block form-check-input" type="checkbox"><span data-v-b2ceeac4="" class="form-check-label">Hide labels</span></label></div>
       <!--v-if-->
       <!--v-if-->
     </div>


### PR DESCRIPTION
# [OSIDB-3991] Show all flaw labels

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Instead of only showing 4 labels and hiding the rest behind a collapsible, show all the labels, wrapping them to the column

## Changes:

Added a `Hide labels` checkbox to optionally hide the labels, the setting is persisted in the storage

## Capture:
![ScreencastFrom2025-02-1913-15-20-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/7211ef98-014b-4a0b-a61e-5db0452ac60e)

Closes OSIDB-3991
