### PR TITLE
[OSIDB-4014] Allow empty flaw label contributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Provide seconds in flaw history timestamps (`OSIDB-3958`)
 * Add justification field for not affected affects (`OSIDB-4009`)
 
+### Fixed
+* Flaw label contributor can now be removed (`OSIDB-4014`)
+
 ### Changed
 * Add a checkbox to hide/show flaw labels (`OSIDB-3991`)
 

--- a/src/components/FlawLabels/FlawLabelsContributor.vue
+++ b/src/components/FlawLabels/FlawLabelsContributor.vue
@@ -54,6 +54,12 @@ const handleSuggestionClick = (user: ZodJiraUserAssignableType) => {
   results.value = [];
 };
 
+const onBlur = () => {
+  if (contributor.value === '') {
+    modelValue.value = '';
+  }
+};
+
 watchDebounced(contributor, onQueryChange, { debounce: 300 });
 </script>
 <template>
@@ -74,6 +80,7 @@ watchDebounced(contributor, onQueryChange, { debounce: 300 });
       type="text"
       class="form-control"
       :disabled="isLoading"
+      @blur="onBlur"
     >
     <button
       type="button"

--- a/src/components/FlawLabels/__tests__/FlawLabelsContributor.spec.ts
+++ b/src/components/FlawLabels/__tests__/FlawLabelsContributor.spec.ts
@@ -27,6 +27,14 @@ vi.mock('@/composables/useFlaw', () => ({
   }),
 }));
 
+const mountFlawLabelsContributor = (props = {}) => {
+  const wrapper = mountWithConfig(FlawLabelsContributor, { props: {
+    'onUpdate:modelValue': (e: string) => wrapper.setProps({ modelValue: e }),
+    ...props,
+  } });
+  return wrapper;
+};
+
 describe('flawLabelsContributor', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -37,16 +45,14 @@ describe('flawLabelsContributor', () => {
   });
 
   it('should render', () => {
-    const wrapper = mountWithConfig(FlawLabelsContributor);
+    const wrapper = mountFlawLabelsContributor();
 
     expect(wrapper.html()).toMatchSnapshot();
   });
 
   it('should assign the contributor on self assign', async () => {
-    const wrapper = mountWithConfig(FlawLabelsContributor, {
-      props: {
-        modelValue: 'skynet',
-      },
+    const wrapper = mountFlawLabelsContributor({
+      modelValue: 'not-skynet',
     });
 
     await wrapper.find('button').trigger('click');
@@ -55,9 +61,7 @@ describe('flawLabelsContributor', () => {
   });
 
   it('should assign the contributor on click', async () => {
-    const wrapper = mountWithConfig(FlawLabelsContributor, {
-      props: { 'onUpdate:modelValue': (e: string) => wrapper.setProps({ modelValue: e }) },
-    });
+    const wrapper = mountFlawLabelsContributor();
 
     await wrapper.find('input').setValue('skynet');
 
@@ -66,5 +70,25 @@ describe('flawLabelsContributor', () => {
     await wrapper.find('div.item').trigger('click');
 
     expect(wrapper.props('modelValue')).toBe('skynet');
+  });
+
+  it('should not allow arbitrary input', async () => {
+    const wrapper = mountFlawLabelsContributor({ modelValue: 'skynet' });
+
+    await wrapper.find('input').setValue('not-skynet');
+    await wrapper.find('input').trigger('blur');
+
+    expect(wrapper.props('modelValue')).toBe('skynet');
+  });
+
+  it('should allow empty input', async () => {
+    const wrapper = mountFlawLabelsContributor({
+      modelValue: 'skynet',
+    });
+
+    await wrapper.find('input').setValue('');
+    await wrapper.find('input').trigger('blur');
+
+    expect(wrapper.props('modelValue')).toBe('');
   });
 });


### PR DESCRIPTION
# OSIDB-4014 Allow empty flaw label contributor

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Flaw label contributor can be removed

## Changes:

Added an `onBlur` event to the input that overrides the value if it is empty

## Considerations:

Closes OSIDB-4014