### PR TITLE
🚸 Add new affects in edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Public comments privacy notice banner (`OSIDB-3997`)
 * Provide seconds in flaw history timestamps (`OSIDB-3958`)
 * Add justification field for not affected affects (`OSIDB-4009`)
+* New affects are added in edit mode (`OSIDB-3953`)
 
 ### Changed
 * Add a checkbox to hide/show flaw labels (`OSIDB-3991`)

--- a/src/components/FlawAffects/FlawAffects.vue
+++ b/src/components/FlawAffects/FlawAffects.vue
@@ -186,8 +186,8 @@ function addNewAffect() {
     affectedness: 'NEW',
     resolution: '',
     delegated_resolution: '',
-    ps_module: `NewModule-${newAffects.value.length}`,
-    ps_component: `NewComponent-${newAffects.value.length}`,
+    ps_module: `Module${newAffects.value.length}`,
+    ps_component: `Component${newAffects.value.length}`,
     purl: '',
     impact: '',
     cvss_scores: [{

--- a/src/components/FlawAffects/FlawAffects.vue
+++ b/src/components/FlawAffects/FlawAffects.vue
@@ -36,6 +36,7 @@ const affectsEditingStore = useAffectsEditingStore();
 const {
   cancelAllChanges,
   commitAllChanges,
+  editAffect,
   editSelectedAffects,
   getAffectPriorEdit,
   isAffectSelected,
@@ -202,6 +203,7 @@ function addNewAffect() {
     trackers: [],
     alerts: [],
   });
+  editAffect(newAffects.value[0]);
 }
 
 // Remove affects

--- a/src/components/FlawAffects/__tests__/FlawAffects.spec.ts
+++ b/src/components/FlawAffects/__tests__/FlawAffects.spec.ts
@@ -182,6 +182,21 @@ describe('flawAffects', () => {
     expect(badgeButtons.length).toBe(1);
   });
 
+  osimFullFlawTest('new affects are added in edit mode', async () => {
+    await flushPromises();
+
+    let affectsTableEditingRows = subject.findAll('.affects-management table tbody tr.editing');
+    expect(affectsTableEditingRows.length).toBe(0);
+
+    const actionBtns = subject.findAll('.affects-toolbar .affects-table-actions .btn');
+    const addAffectBtn = actionBtns.find(button => button.text() === 'Add New Affect');
+    addAffectBtn?.trigger('click');
+    await flushPromises();
+
+    affectsTableEditingRows = subject.findAll('.affects-management table tbody tr.editing');
+    expect(affectsTableEditingRows.length).toBe(1);
+  });
+
   osimFullFlawTest('Affects are selectable by clicking in the row', async () => {
     let affectsTableSelectedRows = subject.findAll('.affects-management table tbody tr.selected');
     expect(affectsTableSelectedRows.length).toBe(0);


### PR DESCRIPTION
# OSIDB-3953: Add new affects in edit mode

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Makes new affect rows added to the table directly in edit mode.

## Changes:

- Updates `addNewAffect` function to make the new affect in edit mode
- Small adjustment for the example names in the component and module of the new affect
- Adds new unit test case

## Considerations:

- Specific request from stakeholders

Closes OSIDB-3953
