### PR TITLE
[OSIDB-4026] Fix infinite loop on flaw update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Provide seconds in flaw history timestamps (`OSIDB-3958`)
 * Add justification field for not affected affects (`OSIDB-4009`)
 
+### Fixed
+* Fix infinite loop on flaw update (`OSIDB-4026`)
+
 ### Changed
 * Add a checkbox to hide/show flaw labels (`OSIDB-3991`)
 

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -99,7 +99,7 @@ onMounted(() => {
 watch(() => props.flaw, () => { // Shallow watch so as to avoid reseting on any change (though that shouldn't happen)
   initialFlaw = deepCopyFromRaw(props.flaw) as ZodFlawType;
   isEmbargoed.value = initialFlaw?.embargoed;
-  onReset();
+  shouldCreateJiraTask.value = false;
 });
 
 const isEmbargoed = ref<boolean>(false);


### PR DESCRIPTION
# [OSIDB-4026] Fix infinite loop on flaw update

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [x] Jira ticket updated

## Summary:

On af49e86 we introduced a global "flaw store", with this, the flaw passed to `FlawForm` by props and the flaw used by `useFlawModel` refers to the same in-memory location.

When the flaw is updated by the `useFlawModel`, the watcher of `FlawForm` triggers, this watcher is calling `onReset` which updates the flaw in `useFlawModel`, triggering again the watcher and so on, creating an infinite loop, in large flaws, this loop crashes the browser.

This was detected to happen when the `Reset changes` button was clicked and when adding a reference, since that triggers a flaw update without updating the `updated_dt` so the view is not updated and thus, the watcher triggers

## Changes:
Here's a simplified workflow on what's happening, in $\color{lime}{\textsf{green}}$, the path taken once the loop is triggered
![image](https://github.com/user-attachments/assets/66530cac-cf25-4e25-a379-003456c9cac5)


## Considerations:

Closes OSIDB-4026