### PR TITLE
💄 Move contributors table before affect section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 * Add a checkbox to hide/show flaw labels (`OSIDB-3991`)
+* Move contributors table next to affect section (`OSIDB-3995`)
 
 ## [2025.2.0]
 ### Added

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -269,7 +269,6 @@ const createdDate = computed(() => {
               :error="errors.source"
               :options-hidden="hiddenSources"
             />
-            <FlawLabelsTable v-if="flaw.uuid" v-model="flaw.labels!" />
           </div>
 
           <div class="col-6">
@@ -393,6 +392,9 @@ const createdDate = computed(() => {
               @acknowledgment:delete="deleteAcknowledgment"
             />
           </div>
+        </div>
+        <div class="osim-flaw-form-section">
+          <FlawLabelsTable v-if="flaw.uuid" v-model="flaw.labels!" />
         </div>
         <div class="osim-flaw-form-section">
           <FlawAffects

--- a/src/components/FlawLabels/FlawLabelsTable.vue
+++ b/src/components/FlawLabels/FlawLabelsTable.vue
@@ -31,7 +31,7 @@ const availableLabels = computed(() =>
     !Object.values(labels.value).some(({ label }) => label === contextLabel),
   ),
 );
-const [isExpanded, toggleExpanded] = useToggle(false);
+const [isExpanded, toggleExpanded] = useToggle(true);
 
 function handleNewLabel(label: ZodFlawLabelType) {
   newLabels.value.add(label.label);
@@ -61,7 +61,10 @@ function handleUndoDelete(label: ZodFlawLabelType) {
 }
 </script>
 <template>
-  <LabelCollapsible label="Contributors" :isExpanded @toggle-expanded="toggleExpanded()">
+  <LabelCollapsible :isExpanded @toggle-expanded="toggleExpanded()">
+    <template #label>
+      <span class="section-label">Contributors</span>
+    </template>
     <div v-if="!(Object.keys(labels).length || availableLabels.length)">
       <p>No available labels</p>
     </div>
@@ -163,6 +166,12 @@ function handleUndoDelete(label: ZodFlawLabelType) {
 </template>
 
 <style scoped lang="scss">
+.section-label {
+  font-size: 1.5rem;
+  margin-left: 0.5rem;
+  font-weight: 500;
+}
+
 .table {
   --bs-table-bg: #eee;
 

--- a/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTable.spec.ts.snap
+++ b/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTable.spec.ts.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`flawLabelsTable > should handle add label 1`] = `
-"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-plus-square-dotted"></i><label data-v-4715e8e2="" class="ms-2 form-label">Contributors</label></button>
+"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
   <div data-v-4715e8e2="" class="ps-3 border-start">
-    <div data-v-4715e8e2="" class="visually-hidden">
+    <div data-v-4715e8e2="" class="">
       <table data-v-5d530569="" class="table table-striped table-hover">
         <thead data-v-5d530569="" class="table-dark">
           <tr data-v-5d530569="">
@@ -44,9 +44,9 @@ exports[`flawLabelsTable > should handle add label 1`] = `
 `;
 
 exports[`flawLabelsTable > should handle delete label 1`] = `
-"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-plus-square-dotted"></i><label data-v-4715e8e2="" class="ms-2 form-label">Contributors</label></button>
+"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
   <div data-v-4715e8e2="" class="ps-3 border-start">
-    <div data-v-4715e8e2="" class="visually-hidden">
+    <div data-v-4715e8e2="" class="">
       <table data-v-5d530569="" class="table table-striped table-hover">
         <thead data-v-5d530569="" class="table-dark">
           <tr data-v-5d530569="">
@@ -80,9 +80,9 @@ exports[`flawLabelsTable > should handle delete label 1`] = `
 `;
 
 exports[`flawLabelsTable > should handle edit label 1`] = `
-"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-plus-square-dotted"></i><label data-v-4715e8e2="" class="ms-2 form-label">Contributors</label></button>
+"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
   <div data-v-4715e8e2="" class="ps-3 border-start">
-    <div data-v-4715e8e2="" class="visually-hidden">
+    <div data-v-4715e8e2="" class="">
       <table data-v-5d530569="" class="table table-striped table-hover">
         <thead data-v-5d530569="" class="table-dark">
           <tr data-v-5d530569="">
@@ -123,9 +123,9 @@ exports[`flawLabelsTable > should handle edit label 1`] = `
 `;
 
 exports[`flawLabelsTable > should handle undo delete label 1`] = `
-"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-plus-square-dotted"></i><label data-v-4715e8e2="" class="ms-2 form-label">Contributors</label></button>
+"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
   <div data-v-4715e8e2="" class="ps-3 border-start">
-    <div data-v-4715e8e2="" class="visually-hidden">
+    <div data-v-4715e8e2="" class="">
       <table data-v-5d530569="" class="table table-striped table-hover">
         <thead data-v-5d530569="" class="table-dark">
           <tr data-v-5d530569="">
@@ -158,9 +158,9 @@ exports[`flawLabelsTable > should handle undo delete label 1`] = `
 `;
 
 exports[`flawLabelsTable > should render flaw labels table 1`] = `
-"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-plus-square-dotted"></i><label data-v-4715e8e2="" class="ms-2 form-label">Contributors</label></button>
+"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
   <div data-v-4715e8e2="" class="ps-3 border-start">
-    <div data-v-4715e8e2="" class="visually-hidden">
+    <div data-v-4715e8e2="" class="">
       <table data-v-5d530569="" class="table table-striped table-hover">
         <thead data-v-5d530569="" class="table-dark">
           <tr data-v-5d530569="">

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -316,15 +316,6 @@ exports[`flawForm > mounts and renders 1`] = `
         </div>
       </div>
     </label>
-    <div data-v-4715e8e2="" data-v-5d530569="" data-v-76e7a15d="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-plus-square-dotted"></i><label data-v-4715e8e2="" class="ms-2 form-label">Contributors</label></button>
-      <div data-v-4715e8e2="" class="ps-3 border-start">
-        <div data-v-4715e8e2="" class="visually-hidden">
-          <div data-v-5d530569="">
-            <p data-v-5d530569="">No available labels</p>
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
   <div data-v-76e7a15d="" class="col-6">
     <div data-v-d6c306ee="" data-v-76e7a15d="" class="osim-workflow-state-container mb-2">
@@ -511,6 +502,17 @@ exports[`flawForm > mounts and renders 1`] = `
             </div>
           </div>
           <form data-v-b4f0a608=""><button data-v-b4f0a608="" type="button" class="btn btn-primary me-2"> Save Changes to Acknowledgments</button><button data-v-b4f0a608="" type="button" class="btn btn-secondary"> Add Acknowledgment</button></form>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div data-v-76e7a15d="" class="osim-flaw-form-section">
+    <div data-v-4715e8e2="" data-v-5d530569="" data-v-76e7a15d="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
+      <div data-v-4715e8e2="" class="ps-3 border-start">
+        <div data-v-4715e8e2="" class="">
+          <div data-v-5d530569="">
+            <p data-v-5d530569="">No available labels</p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
+++ b/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
@@ -255,7 +255,6 @@ exports[`flawCreateView > should render 1`] = `
                 </div>
               </div>
             </label>
-            <!--v-if-->
           </div>
           <div data-v-76e7a15d="" class="col-6">
             <!--v-if--><label data-v-001a00e0="" data-v-76e7a15d="" class="osim-input mb-2 ps-3">
@@ -376,6 +375,9 @@ exports[`flawCreateView > should render 1`] = `
               </div>
             </div>
           </div>
+        </div>
+        <div data-v-76e7a15d="" class="osim-flaw-form-section">
+          <!--v-if-->
         </div>
         <div data-v-76e7a15d="" class="osim-flaw-form-section">
           <!--v-if-->


### PR DESCRIPTION
# OSIDB-3995: Move contributors table before affect section

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Moves contributors table next to the affect section.

## Changes:

- Move contributors table
- Apply new style for section label
- Update snapshots

## Demo:
![image](https://github.com/user-attachments/assets/de5e8c71-121d-45f4-b02b-25161c4b8f00)

## Considerations:

- New style for the label was a consideration to make the contributors section being easily visible between other sections, specially cause it is a collapsible section, and it was a bit difficult to locate with the previous section-label style.

Closes OSIDB-3995
