### PR TITLE
🚸 Show privacy notice only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # OSIM Changelog
 
+## [Unreleased]
+### Changed
+* Show privacy notice to users only once (`OSIDB-4077`)
+
+## [2025.3.1]
+### Fixed
+* Issue with affect justifications (`OSIDB-4075`)
+
 ## [2025.3.0]
 ### Added
 * Global privacy notice toast (`OSIDB-3997`)

--- a/src/App.vue
+++ b/src/App.vue
@@ -48,11 +48,14 @@ onMounted(() => {
   buildDateIntervalId = setInterval(updateRelativeOsimBuildDate, ms15Minutes);
   updateRelativeOsimBuildDate();
 
-  addToast({
-    title: 'Privacy Notice',
-    body: 'OSIM transmits input information externally to Bugzilla for the purpose of retrieving bug data.' +
-    ' In some cases that information may be publicly visible.',
-  });
+  if (!localStorage.getItem('privacyNoticeShown')) {
+    addToast({
+      title: 'Privacy Notice',
+      body: 'OSIM transmits input information externally to Bugzilla for the purpose of retrieving bug data.' +
+      ' In some cases that information may be publicly visible.',
+    });
+    localStorage.setItem('privacyNoticeShown', 'true');
+  }
 });
 onBeforeUnmount(() => {
   clearInterval(buildDateIntervalId);


### PR DESCRIPTION
# OSIDB-4077 Show privacy notice only once

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [x] Jira ticket updated

## Summary:

It is annoying for the users that the privacy notice is shown every time OSIM is loaded. Is preferable to be shown only once to every user.

## Changes:

- Add a local storage variable to track if the privacy notice alert has been shown to an user

## Considerations:

- With this change it is intended to show the notice alert only once

Closes OSIDB-4077
