### PR TITLE
✨   Hide labels that have contributor assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 * Show privacy notice to users only once (`OSIDB-4077`)
+* Hide labels that are already assigned to a contributor on flaw queue (`OSIDB-3993`)
 
 ## [2025.3.1]
 ### Fixed

--- a/src/components/IssueQueue/IssueQueueItem.vue
+++ b/src/components/IssueQueue/IssueQueueItem.vue
@@ -91,18 +91,22 @@ function getLabelColor(label: string, type: string): string {
           class="badge rounded-pill text-bg-danger border border-primary"
         >Embargoed</span>
         <template v-if="showLabels">
-          <span
+          <template
             v-for="label in sortedLabels"
             :key="label.label"
-            :style="{ backgroundColor: getLabelColor(label.label, label.type) }"
-            class="badge rounded-pill border"
-            :class="{
-              'text-bg-warning fw-bold border-warning': label.state == 'REQ',
-              'text-black': label.state != 'REQ' && label.relevant,
-              'text-decoration-line-through text-bg-gray border-secondary': !label.relevant,
-            }"
-            :title="label.state == 'REQ' ? 'Requested' : ''"
-          >{{ label.label }}</span>
+          >
+            <span
+              v-if="!label.contributor"
+              :style="{ backgroundColor: getLabelColor(label.label, label.type) }"
+              class="badge rounded-pill border"
+              :class="{
+                'text-bg-warning fw-bold border-warning': label.state == 'REQ',
+                'text-black': label.state != 'REQ' && label.relevant,
+                'text-decoration-line-through text-bg-gray border-secondary': !label.relevant,
+              }"
+              :title="label.state == 'REQ' ? 'Requested' : ''"
+            >{{ label.label }}</span>
+          </template>
         </template>
       </div>
     </td>

--- a/src/components/IssueQueue/IssueQueueItem.vue
+++ b/src/components/IssueQueue/IssueQueueItem.vue
@@ -104,7 +104,7 @@ function getLabelColor(label: string, type: string): string {
                 'text-black': label.state != 'REQ' && label.relevant,
                 'text-decoration-line-through text-bg-gray border-secondary': !label.relevant,
               }"
-              :title="label.state == 'REQ' ? 'Requested' : ''"
+              :title="label.state === 'REQ' ? 'Requested' : ''"
             >{{ label.label }}</span>
           </template>
         </template>

--- a/src/components/__tests__/IssueQueue.spec.ts
+++ b/src/components/__tests__/IssueQueue.spec.ts
@@ -215,6 +215,23 @@ describe('issueQueue', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
+  it('should not render flaw labels that are already assigned', () => {
+    const wrapper = mountIssueQueue({
+      issues: [{
+        ...mockData[0],
+        labels: [
+          { label: 'test', state: 'REQ', contributor: 'test' },
+          { label: 'test-2', state: 'NEW', contributor: 'test-2' },
+        ],
+      } as ZodFlawType],
+    });
+
+    const labels = wrapper.findComponent(IssueQueueItem).findAll('span.badge');
+
+    expect(labels.length).toBe(0);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
   it('should not render flaw labels when isHidingLabels is true', async () => {
     const wrapper = mountIssueQueue({
       issues: [{

--- a/src/components/__tests__/__snapshots__/IssueQueue.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/IssueQueue.spec.ts.snap
@@ -1,5 +1,56 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`issueQueue > should not render flaw labels that are already assigned 1`] = `
+"<div data-v-48717bcb="" class="osim-content container-fluid osim-issue-queue">
+  <div data-v-48717bcb="" class="osim-incident-filter">
+    <div data-v-b2ceeac4="" data-v-48717bcb="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-b2ceeac4="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-b2ceeac4="" class="d-inline-block form-check-input" type="checkbox"><span data-v-b2ceeac4="" class="form-check-label">My Issues</span></label></div>
+    <div data-v-b2ceeac4="" data-v-48717bcb="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-b2ceeac4="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-b2ceeac4="" class="d-inline-block form-check-input" type="checkbox"><span data-v-b2ceeac4="" class="form-check-label">Open Issues</span></label></div>
+    <div data-v-b2ceeac4="" data-v-48717bcb="" class="osim-input ps-3 d-inline-block d-inline-block"><label data-v-b2ceeac4="" class="form-check h-100 d-inline-block ps-4 p-1"><input data-v-b2ceeac4="" class="d-inline-block form-check-input" type="checkbox"><span data-v-b2ceeac4="" class="form-check-label">Hide labels</span></label></div>
+    <!--v-if--><span data-v-48717bcb="" class="float-end"> Loaded 1 of 10</span>
+  </div>
+  <div data-v-48717bcb="" class="osim-incident-list">
+    <table data-v-48717bcb="" class="table align-middle">
+      <thead data-v-48717bcb="" class="sticky-top">
+        <!-- <thead class=""> -->
+        <tr data-v-48717bcb="">
+          <th data-v-48717bcb="">ID <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
+          <th data-v-48717bcb="">Impact <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
+          <th data-v-48717bcb="">Created <i data-v-48717bcb="" class="bi-caret-down-fill bi"></i></th>
+          <th data-v-48717bcb="">Title <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
+          <th data-v-48717bcb="">State <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
+          <th data-v-48717bcb="">Owner <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
+        </tr>
+      </thead>
+      <tbody data-v-48717bcb="" class="table-group-divider">
+        <tr data-v-15d9c71d="" class="osim-issue-queue-item osim-shaded">
+          <td data-v-15d9c71d="" class="osim-issue-title pb-0"><a data-v-15d9c71d="" href="/flaws/CVE-2903-0092" class="">CVE-2903-0092</a></td>
+          <td data-v-15d9c71d="" class="pb-0">MODERATE</td>
+          <td data-v-15d9c71d="" class="pb-0">2021-07-29</td>
+          <td data-v-15d9c71d="" class="pb-0">title</td>
+          <td data-v-15d9c71d="" class="pb-0">NEW</td>
+          <td data-v-15d9c71d="" class="pb-0">test@redhat.com</td>
+          <!--<td>{{ issue.assigned }}</td>-->
+        </tr>
+        <tr data-v-15d9c71d="" class="osim-badge-lane osim-shaded">
+          <td data-v-15d9c71d="" colspan="1">
+            <div data-v-15d9c71d="" class="gap-1 d-flex flex-wrap">
+              <!--v-if-->
+              <!--v-if-->
+              <!--v-if-->
+            </div>
+          </td>
+          <td data-v-15d9c71d="" colspan="90%"></td>
+        </tr>
+      </tbody>
+    </table><button data-v-48717bcb="" class="btn btn-primary" type="button">
+      <!--v-if--><span data-v-48717bcb=""> Load More Flaws </span>
+    </button>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+</div>"
+`;
+
 exports[`issueQueue > should not render flaw labels when isHidingLabels is true 1`] = `
 "<div data-v-48717bcb="" class="osim-content container-fluid osim-issue-queue">
   <div data-v-48717bcb="" class="osim-incident-filter">


### PR DESCRIPTION
# OSIDB-3993 Hide labels that have contributor assigned

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Hides labels on the flaw queue view if they have already a contributor assigned.
So only labels without contributors are displayed.

## Changes:

- Adjust template for labels iteration
- Adds conditional render to labels on flaw queue
- Update test cases

## Considerations:
 
I considered "display: none" method but the default vue conditional render looked proper and and fit better.

Closes OSIDB-3993
