### PR TITLE
🐛 Limit flaw form width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 * Added colors to flaw list labels (`OSIDB-3992`)
 
+### Fixed
+* Prevent flaw form UI rebasing screen bounds when using large input values (`OSIDB-4079`)
+
 ### Changed
 * Show privacy notice to users only once (`OSIDB-4077`)
 

--- a/src/components/FlawAffects/FlawAffectsTableRow.vue
+++ b/src/components/FlawAffects/FlawAffectsTableRow.vue
@@ -403,6 +403,7 @@ tr {
   height: 39.2px;
 
   td {
+    max-width: 24ch;
     transition:
       background-color 0.5s,
       color 0.5s,

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -201,7 +201,7 @@ const createdDate = computed(() => {
               @expandFocusedComponent="expandFocusedComponent"
             />
           </div>
-          <div :id="flaw.uuid" class="col-6">
+          <div :id="flaw.uuid" class="col-6 flaw-form-subdivision">
             <LabelEditable
               v-model="flaw.title"
               label="Title"
@@ -270,8 +270,7 @@ const createdDate = computed(() => {
               :options-hidden="hiddenSources"
             />
           </div>
-
-          <div class="col-6">
+          <div class="col-6 flaw-form-subdivision">
             <IssueFieldState
               v-if="mode === 'edit'"
               :classification="flaw.classification"
@@ -462,6 +461,10 @@ form.osim-flaw-form :deep(*) {
   .osim-flaw-form-header {
     min-height: 3rem;
     margin-block: 0.5rem;
+  }
+
+  .flaw-form-subdivision {
+    max-width: 100ch;
   }
 }
 

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -74,7 +74,7 @@ exports[`flawForm > mounts and renders 1`] = `
     </div>
   </div>
   </div>
-  <div data-v-76e7a15d="" id="734e9a1a-80d9-4ff5-a5b9-e2214da66dc0" class="col-6"><label data-v-76509415="" data-v-76e7a15d="" class="osim-input ps-3 mb-2 input-group">
+  <div data-v-76e7a15d="" id="734e9a1a-80d9-4ff5-a5b9-e2214da66dc0" class="col-6 flaw-form-subdivision"><label data-v-76509415="" data-v-76e7a15d="" class="osim-input ps-3 mb-2 input-group">
       <div data-v-76509415="" class="row"><span data-v-76509415="" class="form-label col-3">Title</span>
         <!--v-if-->
         <!-- for invalid-tooltip positioning -->
@@ -317,7 +317,7 @@ exports[`flawForm > mounts and renders 1`] = `
       </div>
     </label>
   </div>
-  <div data-v-76e7a15d="" class="col-6">
+  <div data-v-76e7a15d="" class="col-6 flaw-form-subdivision">
     <div data-v-d6c306ee="" data-v-76e7a15d="" class="osim-workflow-state-container mb-2">
       <div data-v-0e2ae48e="" data-v-d6c306ee="" class="osim-input ps-3 osim-workflow-state-display mb-2 osim-workflow-state-display mb-2" type="text">
         <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--> State <!--attrs: {{ $attrs }}--></span>

--- a/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
+++ b/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
@@ -13,7 +13,7 @@ exports[`flawCreateView > should render 1`] = `
             </div>
             <!--v-if-->
           </div>
-          <div data-v-76e7a15d="" id="" class="col-6"><label data-v-76509415="" data-v-76e7a15d="" class="osim-input ps-3 mb-2 input-group">
+          <div data-v-76e7a15d="" id="" class="col-6 flaw-form-subdivision"><label data-v-76509415="" data-v-76e7a15d="" class="osim-input ps-3 mb-2 input-group">
               <div data-v-76509415="" class="row"><span data-v-76509415="" class="form-label col-3">Title</span>
                 <!--v-if-->
                 <!-- for invalid-tooltip positioning -->
@@ -256,7 +256,7 @@ exports[`flawCreateView > should render 1`] = `
               </div>
             </label>
           </div>
-          <div data-v-76e7a15d="" class="col-6">
+          <div data-v-76e7a15d="" class="col-6 flaw-form-subdivision">
             <!--v-if--><label data-v-001a00e0="" data-v-76e7a15d="" class="osim-input mb-2 ps-3">
               <div data-v-001a00e0="" class="row"><span data-v-001a00e0="" class="form-label col-3">Incident State</span>
                 <div data-v-001a00e0="" class="col-9"><select data-v-001a00e0="" class="form-select" value="">


### PR DESCRIPTION
# OSIDB-4079 Limit flaw form width

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Fix to prevent flaw form UI rebasing screen bounds when using large input values.

## Changes:

- Limit max width in affect section cells
- Limit max width in flaw form subdivisions (right/left divs)
- Update snapshots

## Demo:
![Screenshot From 2025-03-12 09-50-21](https://github.com/user-attachments/assets/42e97191-ad97-457b-a79f-e37ae6f92a8f)

![Screenshot From 2025-03-12 09-26-31](https://github.com/user-attachments/assets/9e7978fe-da20-444b-bc66-64f50c6e2f09)

![image](https://github.com/user-attachments/assets/e99974c1-1f59-4776-8df6-723a4c679a52)

## Considerations:

- There was already ellipsis for overflow being applied but the width needed to be capped.

Closes OSIDB-4079
