### PR TITLE
🐛 Move privacyNotice cookie to settings store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 * Validate Discouraged an Prohibited CWE usage (`OSIDB-4172`)
 
+### Fixed
+* Fixed inconsistent local storage cached values (`OSIDB-4129`)
+
 ## [2025.3.2]
 ### Added
 * Added colors to flaw list labels (`OSIDB-3992`)

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,11 +19,9 @@ import {
 import { footerHeight, footerTop } from '@/stores/responsive';
 
 import { updateCWEData } from './services/CweService';
-import { useToastStore } from './stores/ToastStore';
 
 setup();
 
-const { addToast } = useToastStore();
 watch(osimRuntimeStatus, () => {
   if (osimRuntimeStatus.value === OsimRuntimeStatus.READY) {
     updateRelativeOsimBuildDate();
@@ -47,15 +45,6 @@ onMounted(() => {
   const ms15Minutes = 15 * 60 * 60 * 1000;
   buildDateIntervalId = setInterval(updateRelativeOsimBuildDate, ms15Minutes);
   updateRelativeOsimBuildDate();
-
-  if (!localStorage.getItem('privacyNoticeShown')) {
-    addToast({
-      title: 'Privacy Notice',
-      body: 'OSIM transmits input information externally to Bugzilla for the purpose of retrieving bug data.' +
-      ' In some cases that information may be publicly visible.',
-    });
-    localStorage.setItem('privacyNoticeShown', 'true');
-  }
 });
 onBeforeUnmount(() => {
   clearInterval(buildDateIntervalId);

--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -12,7 +12,7 @@ const revealSensitive = ref<SensitiveFormInput>('password');
 const settings = ref(settingsStore.settings);
 
 const onSubmit = (values: SettingsType) => {
-  settingsStore.save(values);
+  settingsStore.settings = values;
 };
 
 const isValid = ref({

--- a/src/components/__tests__/ToastContainer.spec.ts
+++ b/src/components/__tests__/ToastContainer.spec.ts
@@ -30,6 +30,7 @@ describe('toastContainer', () => {
       settings: {
         ...settingStore.$state.settings,
         showNotifications: true,
+        privacyNoticeShown: true,
       },
     };
     const toastStore = useToastStore(pinia);
@@ -69,6 +70,7 @@ describe('toastContainer', () => {
       settings: {
         ...settingStore.$state.settings,
         showNotifications: true,
+        privacyNoticeShown: true,
       },
     };
     subject = mount(ToastContainer, {
@@ -113,6 +115,8 @@ describe('toastContainer', () => {
           ],
         },
       });
+
+      settingStore.settings.privacyNoticeShown = true;
       const toastElements = subject.findAllComponents(Toast);
       expect(toastElements.length).toBe(1);
       vi.advanceTimersByTime(12000);

--- a/src/components/__tests__/ToastContainer.spec.ts
+++ b/src/components/__tests__/ToastContainer.spec.ts
@@ -52,7 +52,7 @@ describe('toastContainer', () => {
       },
     });
     const toastElements = subject.findAllComponents(Toast);
-    expect(toastElements.length).toBe(2);
+    expect(toastElements.length).toBe(3);
     const clearAllButton = subject.find('.osim-toast-container-clear button');
     expect(clearAllButton.exists()).toBeTruthy();
     await clearAllButton.trigger('click');

--- a/src/stores/__tests__/SettingsStore.spec.ts
+++ b/src/stores/__tests__/SettingsStore.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { createPinia, setActivePinia } from 'pinia';
 
-import { useSettingsStore, type SettingsType } from '../SettingsStore';
+import { useSettingsStore, type SettingsType } from '@/stores/SettingsStore';
 
 const initialState: SettingsType = {
   bugzillaApiKey: '',
@@ -39,6 +39,7 @@ describe('settingsStore', () => {
       affectsPerPage: 1337,
       trackersPerPage: 1337,
       isHidingLabels: !initialState.isHidingLabels,
+      privacyNoticeShown: false,
     };
 
     settingsStore.settings = settings;

--- a/src/stores/__tests__/SettingsStore.spec.ts
+++ b/src/stores/__tests__/SettingsStore.spec.ts
@@ -11,6 +11,7 @@ const initialState: SettingsType = {
   affectsPerPage: 10,
   trackersPerPage: 10,
   isHidingLabels: false,
+  privacyNoticeShown: true,
 };
 
 // While not used in this file, store below depends on global pinia test instance
@@ -40,7 +41,7 @@ describe('settingsStore', () => {
       isHidingLabels: !initialState.isHidingLabels,
     };
 
-    settingsStore.save(settings);
+    settingsStore.settings = settings;
 
     expect(settingsStore.settings).toEqual(settings);
   });

--- a/src/stores/__tests__/ToastStore.spec.ts
+++ b/src/stores/__tests__/ToastStore.spec.ts
@@ -2,22 +2,15 @@ import { createPinia, setActivePinia } from 'pinia';
 
 import { useToastStore, type ToastNew } from '@/stores/ToastStore';
 
-import { useSettingsStore } from '../SettingsStore';
-
 describe('toastStore', () => {
   let toastStore: ReturnType<typeof useToastStore>;
-  let settingsStore: ReturnType<typeof useSettingsStore>;
 
   beforeEach(() => {
     setActivePinia(createPinia());
-    settingsStore = useSettingsStore();
     toastStore = useToastStore();
   });
 
   it('addToast', () => {
-    settingsStore.settings.privacyNoticeShown = true;
-    settingsStore.settings.showNotifications = true;
-
     const toast: ToastNew = { body: 'Test Toast' };
 
     toastStore.addToast(toast);

--- a/src/stores/__tests__/ToastStore.spec.ts
+++ b/src/stores/__tests__/ToastStore.spec.ts
@@ -15,6 +15,7 @@ describe('toastStore', () => {
   });
 
   it('addToast', () => {
+    settingsStore.settings.privacyNoticeShown = true;
     settingsStore.settings.showNotifications = true;
 
     const toast: ToastNew = { body: 'Test Toast' };


### PR DESCRIPTION
# OSIDB-4129 Move privacyNotice cookie to settings store

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Refactors the use of localsotrage for the privacyNotice cookie to use the setting store of the user to fix issues with cache variables (API keys values getting overrived)

## Changes:

- Move privacyNotice cookie into settingsStore
- Update tests

## Considerations:

- Couldn't replicate the issue so will need to get feedback from using on UAT

Closes OSIDB-4129
