### PR TITLE
✨ CVE Page link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * Fixed inconsistent local storage cached values (`OSIDB-4129`)
+* Added CVE ID link on flaw form (`OSIDB-3118`) 
 
 ## [2025.3.2]
 ### Added

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -220,7 +220,21 @@ const createdDate = computed(() => {
                   type="text"
                   label="CVE ID"
                   :error="errors.cve_id"
-                />
+                >
+                  <template #label>
+                    <a
+                      v-if="!isEmbargoed && flaw.cve_id"
+                      :href="`https://access.redhat.com/security/cve/${flaw.cve_id}`"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      CVE ID <i class="bi-box-arrow-up-right ms-2" />
+                    </a>
+                    <span v-else>
+                      CVE ID
+                    </span>
+                  </template>
+                </LabelEditable>
               </div>
               <div
                 v-if="!(flaw.cve_id || '').includes('CVE') && mode === 'edit'"
@@ -348,7 +362,6 @@ const createdDate = computed(() => {
                   <option v-for="state in descriptionRequiredStates" :key="state" :value="state">{{ state }}</option>
                 </select>
               </span>
-
             </template>
           </LabelTextarea>
           <LabelTextarea

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -101,7 +101,7 @@ exports[`flawForm > mounts and renders 1`] = `
     </label>
     <div data-v-76e7a15d="" class="row">
       <div data-v-76e7a15d="" class="col"><label data-v-76509415="" data-v-76e7a15d="" class="osim-input ps-3 mb-2 input-group">
-          <div data-v-76509415="" class="row"><span data-v-76509415="" class="form-label col-3">CVE ID</span>
+          <div data-v-76509415="" class="row"><span data-v-76509415="" class="form-label col-3"><a data-v-76e7a15d="" href="https://access.redhat.com/security/cve/CVE-2024-1234" target="_blank" rel="noopener noreferrer"> CVE ID <i data-v-76e7a15d="" class="bi-box-arrow-up-right ms-2"></i></a></span>
             <!--v-if-->
             <!-- for invalid-tooltip positioning -->
             <div data-v-76509415="" class="position-relative col-9 osim-editable-field osim-text">

--- a/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
+++ b/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
@@ -40,7 +40,7 @@ exports[`flawCreateView > should render 1`] = `
             </label>
             <div data-v-76e7a15d="" class="row">
               <div data-v-76e7a15d="" class="col"><label data-v-76509415="" data-v-76e7a15d="" class="osim-input ps-3 mb-2 input-group">
-                  <div data-v-76509415="" class="row"><span data-v-76509415="" class="form-label col-3">CVE ID</span>
+                  <div data-v-76509415="" class="row"><span data-v-76509415="" class="form-label col-3"><span data-v-76e7a15d=""> CVE ID </span></span>
                     <!--v-if-->
                     <!-- for invalid-tooltip positioning -->
                     <div data-v-76509415="" class="position-relative col-9 osim-editable-field osim-text">


### PR DESCRIPTION
# OSIDB-3118 CVE Page Link

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Adds a link to CVE Page for flaws that have CVE ID present and are not embargoed.

## Changes:

- Adds the link in CVE ID input field label (conditional)
- Updates snapshots

## Demo

https://github.com/user-attachments/assets/847b1e39-0cf3-4c66-9928-25a7761ea37e

Closes OSIDB-3118
