### PR TITLE
✨ Display CVE ID on page title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OSIM Changelog
 
+## [Unreleased]
+### Added
+* Show CVE ID on page title (`OSIDB-3715`)
+
 ## [2025.4.0]
 ### Added
 * Validate Discouraged an Prohibited CWE usage (`OSIDB-4127`)

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -88,6 +88,9 @@ const { draftFlaw } = useDraftFlawStore();
 let initialFlaw: ZodFlawType;
 
 onMounted(() => {
+  if (props.flaw.cve_id) {
+    document.title = document.title.replace('Flaw Details', props.flaw.cve_id);
+  }
   initialFlaw = deepCopyFromRaw(props.flaw) as ZodFlawType;
   isEmbargoed.value = initialFlaw?.embargoed;
   if (draftFlaw) {


### PR DESCRIPTION
# OSIDB-3715 Display CVE ID on page title

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Adds the CVE ID in the browser title if the user is on flaw details of a flaw that has it.

## Changes:

- Replaces the substring of "Flaw Details" with the CVE ID in the page's title

## Demo
![image](https://github.com/user-attachments/assets/5520ad27-a082-4744-9ea9-2c3d8c8927a5)

## Considerations:

- Considered a concatenation but the result string for the title was quite long
- Considered an integration test would be more appropriate.

Closes OSIDB-3715
