### PR TITLE
✨ Comments section display modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 ### Added
+* Add an unified view for all comment types  (`OSIDB-3467`)
+* Support changing between display modes in comment section  (`OSIDB-3467`)
 * Add searchbox filter on trackers table (`OSIDB-4062`)
 * Show CVE ID on page title (`OSIDB-3715`)
 

--- a/src/components/FlawComments/CommentList.vue
+++ b/src/components/FlawComments/CommentList.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { DateTime } from 'luxon';
+import sanitizeHtml from 'sanitize-html';
+
+import { CommentTypeDisplay } from '@/composables/useFlawCommentsModel';
+
+import { type ZodFlawCommentType } from '@/types/zodFlaw';
+import { CommentType } from '@/types';
+import { jiraUserUrl } from '@/services/JiraService';
+import { commentTooltips } from '@/constants';
+import { osimRuntime } from '@/stores/osimRuntime';
+
+defineProps<{
+  commentList: ZodFlawCommentType[];
+}>();
+
+const parseCommentDisplayText = (text: string) => parseJiraTags(linkify(sanitizeHtml(text)));
+
+function linkify(text: string) {
+  const bugzillaLink = `${osimRuntime.value.backends.bugzilla}/show_bug.cgi?id=`;
+
+  const bugzillaRegex = /\[bug (\d+)\]/g;
+  const jiraRegex = /\[([^|]+)\|([^\]]+)\]/g;
+
+  return text
+    .replace(bugzillaRegex, `<a target="_blank" href="${bugzillaLink}$1">[bug $1]</a>`)
+    .replace(jiraRegex, '<a target="_blank" href="$2">$2</a>');
+}
+
+function parseJiraTags(text: string) {
+  const jiraUserLink = `${osimRuntime.value.backends.jiraDisplay}/ViewProfile.jspa?name=`;
+  const jiraTagRegex = /\[~([^[\]]+)\]/g;
+
+  return text
+    .replace(jiraTagRegex, (match, p1) => `<a target="_blank" href="${jiraUserLink}${p1}">${p1}</a>`);
+}
+
+function getCommentTooltip(type: CommentType | undefined) {
+  if (!type) {
+    return '';
+  }
+
+  return commentTooltips[type];
+}
+</script>
+
+<template>
+  <ul class="comments list-unstyled">
+    <li
+      v-for="(comment, commentIndex) in commentList"
+      :key="commentIndex"
+      class="p-4 mt-3 rounded-2"
+      :class="{
+        'bg-light-green': comment.type === CommentType.Public,
+        'bg-light-info': comment.type === CommentType.Private,
+        'bg-light-orange': comment.type === CommentType.Internal,
+        'bg-light-yellow': comment.type === CommentType.System,
+      }"
+    >
+      <div class="d-flex border-bottom pb-3 align-items-center">
+        <i class="bi bi-caret-right-fill me-2"></i>
+        <a
+          v-if="comment.type === CommentType.Internal"
+          :href="jiraUserUrl(comment.creator || '')"
+          target="_blank"
+        >
+          {{ comment.creator }}
+        </a>
+        <span v-else>{{ comment.creator }}</span>
+        - {{ DateTime.fromISO(comment.created_dt ?? '',{ setZone: true })
+          .toFormat('yyyy-MM-dd hh:mm a ZZZZ') }}
+        <span
+          class="badge rounded-pill float-end ms-auto"
+          style="font-size: 14px; cursor: help; user-select: none;"
+          :title="getCommentTooltip(comment.type)"
+          :class="{
+            'bg-success': comment.type === CommentType.Public,
+            'bg-info': comment.type === CommentType.Private,
+            'bg-danger': comment.type === CommentType.Internal,
+            'bg-warning text-black': comment.type === CommentType.System,
+          }"
+        >
+          {{ CommentTypeDisplay(comment.type) }}
+        </span>
+      </div>
+      <!--eslint-disable-next-line vue/no-v-html -->
+      <p class="osim-flaw-comment" v-html="parseCommentDisplayText(comment.text ?? '')" />
+    </li>
+  </ul>
+</template>

--- a/src/components/FlawComments/CommentList.vue
+++ b/src/components/FlawComments/CommentList.vue
@@ -5,9 +5,8 @@ import sanitizeHtml from 'sanitize-html';
 import { CommentTypeDisplay } from '@/composables/useFlawCommentsModel';
 
 import { type ZodFlawCommentType } from '@/types/zodFlaw';
-import { CommentType } from '@/types';
+import { CommentType, commentTooltips } from '@/constants';
 import { jiraUserUrl } from '@/services/JiraService';
-import { commentTooltips } from '@/constants';
 import { osimRuntime } from '@/stores/osimRuntime';
 
 defineProps<{

--- a/src/components/FlawComments/CommentsToolbar.vue
+++ b/src/components/FlawComments/CommentsToolbar.vue
@@ -78,7 +78,7 @@ const { settings } = storeToRefs(useSettingsStore());
     <div class="form-check form-switch ms-auto" style="font-size: 18px">
       <input
         id="singleViewSwitch"
-        v-model="settings['singleCommentsView']"
+        v-model="settings['unifiedCommentsView']"
         class="form-check-input"
         type="checkbox"
       >

--- a/src/components/FlawComments/CommentsToolbar.vue
+++ b/src/components/FlawComments/CommentsToolbar.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
+import { storeToRefs } from 'pinia';
+
 import { jiraTaskUrl } from '@/services/JiraService';
+import { useSettingsStore } from '@/stores/SettingsStore';
 import { CommentType } from '@/types';
 
 defineProps<{
@@ -12,13 +15,13 @@ defineProps<{
   showBugzillaLink: boolean;
   showJiraLink: boolean;
   taskKey: null | string | undefined;
-  unifiedView: boolean;
 }>();
 
 const emit = defineEmits<{
   startNewComment: [type: CommentType];
-  toggleView: [];
 }>();
+
+const { settings } = storeToRefs(useSettingsStore());
 </script>
 
 <template>
@@ -74,11 +77,9 @@ const emit = defineEmits<{
     </div>
     <div class="form-check form-switch ms-auto" style="font-size: 18px">
       <input
-        id="singleViewSwitch"
+        v-model="settings['singleCommentsView']"
         class="form-check-input"
         type="checkbox"
-        :value="unifiedView"
-        @click="emit('toggleView')"
       >
       <label class="form-check-label" for="singleViewSwitch" style="user-select: none;">Unified view</label>
     </div>

--- a/src/components/FlawComments/CommentsToolbar.vue
+++ b/src/components/FlawComments/CommentsToolbar.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { jiraTaskUrl } from '@/services/JiraService';
+import { CommentType } from '@/types';
+
+defineProps<{
+  bugzillaLink: string;
+  internalCommentsAvailable: boolean;
+  isAddingNewComment: boolean;
+  isSaving: boolean;
+  newCommentAllowed: boolean;
+  newCommentType: CommentType;
+  showBugzillaLink: boolean;
+  showJiraLink: boolean;
+  taskKey: null | string | undefined;
+  unifiedView: boolean;
+}>();
+
+const emit = defineEmits<{
+  startNewComment: [type: CommentType];
+  toggleView: [];
+}>();
+</script>
+
+<template>
+  <div class="d-flex mb-4 sticky-top p-3 ps-0 border-bottom align-items-center" style="background-color: white;">
+    <div class="d-flex gap-2">
+      <button
+        type="button"
+        class="btn btn-secondary"
+        :disabled="!newCommentAllowed || isSaving || (isAddingNewComment && newCommentType === CommentType.Public)"
+        @click="emit('startNewComment', CommentType.Public)"
+      >
+        Add Public Comment
+      </button>
+      <button
+        type="button"
+        class="btn btn-secondary"
+        :disabled="!newCommentAllowed || isSaving || (isAddingNewComment && newCommentType === CommentType.Private)"
+        @click="emit('startNewComment', CommentType.Private)"
+      >
+        Add Private Comment
+      </button>
+      <button
+        type="button"
+        class="btn btn-secondary"
+        :disabled="
+          !internalCommentsAvailable
+            || !newCommentAllowed
+            || isSaving
+            || (isAddingNewComment && newCommentType === CommentType.Internal)
+        "
+        @click="emit('startNewComment', CommentType.Internal)"
+      >
+        Add Internal Comment
+      </button>
+      <a
+        v-if="showBugzillaLink"
+        :href="bugzillaLink"
+        target="_blank"
+        class="btn tab-btn border border-secondary"
+        :disabled="isSaving"
+      >
+        View in Bugzilla
+      </a>
+      <a
+        v-if="showJiraLink"
+        :href="taskKey ? jiraTaskUrl(taskKey) : '#'"
+        target="_blank"
+        class="btn tab-btn border border-secondary"
+        :disabled="isSaving"
+      >
+        View in Jira
+      </a>
+    </div>
+    <div class="form-check form-switch ms-auto" style="font-size: 18px">
+      <input
+        id="singleViewSwitch"
+        class="form-check-input"
+        type="checkbox"
+        :value="unifiedView"
+        @click="emit('toggleView')"
+      >
+      <label class="form-check-label" for="singleViewSwitch" style="user-select: none;">Unified view</label>
+    </div>
+  </div>
+</template>

--- a/src/components/FlawComments/CommentsToolbar.vue
+++ b/src/components/FlawComments/CommentsToolbar.vue
@@ -3,7 +3,7 @@ import { storeToRefs } from 'pinia';
 
 import { jiraTaskUrl } from '@/services/JiraService';
 import { useSettingsStore } from '@/stores/SettingsStore';
-import { CommentType } from '@/types';
+import { CommentType } from '@/constants';
 
 defineProps<{
   bugzillaLink: string;
@@ -77,6 +77,7 @@ const { settings } = storeToRefs(useSettingsStore());
     </div>
     <div class="form-check form-switch ms-auto" style="font-size: 18px">
       <input
+        id="singleViewSwitch"
         v-model="settings['singleCommentsView']"
         class="form-check-input"
         type="checkbox"

--- a/src/components/FlawComments/FlawComments.vue
+++ b/src/components/FlawComments/FlawComments.vue
@@ -88,6 +88,16 @@ const showBugzillaLink = computed(() =>
 const showJiraLink = computed(() =>
   props.internalCommentsAvailable && props.commentsByType[CommentType.Internal].length > 0,
 );
+
+const tabsTooltips = computed(() => {
+  const defaultTooltips = Object.values(commentTooltips);
+  if (props.internalCommentsAvailable) {
+    return defaultTooltips;
+  } else {
+    defaultTooltips[CommentType.Internal] = 'Internal comments not available';
+    return defaultTooltips;
+  }
+});
 </script>
 
 <template>
@@ -121,7 +131,8 @@ const showJiraLink = computed(() =>
       v-if="!settings['unifiedCommentsView']"
       :labels="commentLabels"
       :default="0"
-      :tooltips="Object.values(commentTooltips)"
+      :disabled="!internalCommentsAvailable ? [2] : []"
+      :tooltips="tabsTooltips"
       @tab-change="handleTabChange"
     >
       <template #tab-content>
@@ -134,9 +145,6 @@ const showJiraLink = computed(() =>
             >
               <span class="visually-hidden">Loading...</span>
             </span>
-            <div v-else-if="!internalCommentsAvailable && selectedTab === CommentType.Internal">
-              Internal comments not available
-            </div>
             <div v-else-if="commentsByType[selectedTab]?.length === 0">
               No {{ CommentType[selectedTab].toLowerCase() }} comments
             </div>

--- a/src/components/FlawComments/FlawComments.vue
+++ b/src/components/FlawComments/FlawComments.vue
@@ -1,32 +1,22 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 
-import { isDefined, watchDebounced } from '@vueuse/core';
-import sanitizeHtml from 'sanitize-html';
-import { DateTime } from 'luxon';
+import CommentList from '@/components/FlawComments/CommentList.vue';
+import CommentsToolbar from '@/components/FlawComments/CommentsToolbar.vue';
+import NewCommentForm from '@/components/FlawComments/NewCommentForm.vue';
 
-import { createCatchHandler } from '@/composables/service-helpers';
-
-import LabelTextarea from '@/widgets/LabelTextarea/LabelTextarea.vue';
 import Tabs from '@/widgets/Tabs/Tabs.vue';
-import DropDown from '@/widgets/DropDown/DropDown.vue';
-import JiraUser from '@/widgets/JiraUser/JiraUser.vue';
 import { useUserStore } from '@/stores/UserStore';
-import { osimRuntime } from '@/stores/osimRuntime';
-import type { ZodJiraUserAssignableType } from '@/types/zodJira';
-import { searchJiraUsers, jiraTaskUrl, jiraUserUrl } from '@/services/JiraService';
 import { type ZodFlawCommentType } from '@/types/zodFlaw';
-import { CommentType } from '@/constants';
+import { CommentType, commentTooltips } from '@/constants';
+import { orderCommentsByDate } from '@/utils/helpers';
 
 const props = defineProps<{
   bugzillaLink: string;
-  internalComments: ZodFlawCommentType[];
+  commentsByType: Record<CommentType, ZodFlawCommentType[]>;
   internalCommentsAvailable: boolean;
   isLoadingInternalComments: boolean;
   isSaving: boolean;
-  privateComments: ZodFlawCommentType[];
-  publicComments: ZodFlawCommentType[];
-  systemComments: ZodFlawCommentType[];
   taskKey: null | string | undefined;
 }>();
 
@@ -37,7 +27,7 @@ const emit = defineEmits<{
 
 const userStore = useUserStore();
 
-const newComment = ref('');
+const newCommentType = ref<CommentType>(CommentType.Public);
 const isAddingNewComment = ref(false);
 
 const commentLabels = computed(() => {
@@ -46,212 +36,94 @@ const commentLabels = computed(() => {
     .map(key => `${key} Comments`);
 });
 
-const commentTooltips: Record<CommentType, string> = {
-  [CommentType.Public]: 'Bugzilla Public - This comments are visible to everyone.',
-  [CommentType.Private]: 'Bugzilla Private - This comments are visible to Red Hat associates.',
-  [CommentType.Internal]: 'Jira Internal - This comments are visible to team members with required permissions.',
-  [CommentType.System]: 'Bugzilla System - This are auto-generated private comments.',
-};
-
 const selectedTab = ref(CommentType.Public);
 const handleTabChange = (index: number) => {
   selectedTab.value = index;
 };
 
-const displayedComments = computed(() => {
-  switch (selectedTab.value) {
-    case CommentType.Public:
-      return props.publicComments;
-    case CommentType.Private:
-      return props.privateComments;
-    case CommentType.Internal:
-      return props.internalComments;
-    case CommentType.System:
-      return props.systemComments;
-    default:
-      return [];
-  }
-});
+const unifiedView = ref(false);
+const unifiedComments = computed(
+  () => orderCommentsByDate(Object.values(props.commentsByType).flat()),
+);
 
 onMounted(async () => {
   emit('loadInternalComments');
 });
 
-async function handleCommentSave() {
+function startNewComment(type: CommentType) {
+  isAddingNewComment.value = true;
+  newCommentType.value = type;
+}
+
+async function handleCommentSave(newComment: string) {
   emit(
     'comment:addFlawComment',
-    newComment.value,
+    newComment,
     userStore.userName,
-    CommentType[selectedTab.value],
+    CommentType[newCommentType.value],
   );
-  newComment.value = '';
   isAddingNewComment.value = false;
 }
 
-const parseCommentDisplayText = (text: string) => parseJiraTags(linkify(sanitizeHtml(text)));
+const newCommentAllowed = computed(() =>
+  (
+    (
+      (
+        selectedTab.value !== CommentType.System
+        && (props.internalCommentsAvailable || selectedTab.value !== CommentType.Internal)
+      )
+      || (unifiedView.value))
+  ),
+);
 
-function linkify(text: string) {
-  const bugzillaLink = `${osimRuntime.value.backends.bugzilla}/show_bug.cgi?id=`;
+const showBugzillaLink = computed(() =>
+  props.commentsByType[CommentType.Private].length > 0
+  || props.commentsByType[CommentType.Public].length > 0
+  || props.commentsByType[CommentType.System].length > 0,
+);
 
-  const bugzillaRegex = /\[bug (\d+)\]/g;
-  const jiraRegex = /\[([^|]+)\|([^\]]+)\]/g;
-
-  return text
-    .replace(bugzillaRegex, `<a target="_blank" href="${bugzillaLink}$1">[bug $1]</a>`)
-    .replace(jiraRegex, '<a target="_blank" href="$2">$2</a>');
-}
-
-function parseJiraTags(text: string) {
-  const jiraUserLink = `${osimRuntime.value.backends.jiraDisplay}/ViewProfile.jspa?name=`;
-  const jiraTagRegex = /\[~([^[\]]+)\]/g;
-
-  return text
-    .replace(jiraTagRegex, (match, p1) => `<a target="_blank" href="${jiraUserLink}${p1}">${p1}</a>`);
-}
-
-const isInternalComment = computed(() => selectedTab.value === CommentType.Internal);
-const refTextArea = ref<InstanceType<typeof LabelTextarea> | null>(null);
-const suggestions = ref<ZodJiraUserAssignableType[]>([]);
-const isLoadingSuggestions = ref(false);
-const caretPos = ref(['0px', '0px']);
-
-watchDebounced(newComment, async () => {
-  if (!isDefined(newComment)
-    || newComment.value === ''
-    || !refTextArea.value?.elTextArea?.value
-    || !isInternalComment.value
-    || !props.taskKey) {
-    return;
-  }
-
-  const lastWord = getLastWord();
-  if (!lastWord?.startsWith('@') || lastWord.length < 2) {
-    return;
-  }
-  isLoadingSuggestions.value = true;
-  const users = await searchJiraUsers(lastWord.slice(1), props.taskKey)
-    .catch(createCatchHandler('Failed to load jira users', false))
-    .finally(() => {
-      isLoadingSuggestions.value = false;
-      nextTick(() => refTextArea.value?.elTextArea?.focus());
-    });
-
-  if (!users?.data?.users) {
-    return;
-  }
-  calculateDropdownPosition(lastWord);
-  nextTick(() => {
-    suggestions.value = users.data?.users;
-  });
-}, { debounce: 500 });
-
-const calculateDropdownPosition = (lastWord: string) => {
-  const elTextArea = refTextArea.value!.elTextArea;
-  const selectionStart = elTextArea?.selectionStart ?? 0;
-
-  const textAreaRect = elTextArea!.getBoundingClientRect();
-  const textAreaStyle = getComputedStyle(elTextArea!);
-  const paddingLeft = Number.parseInt(textAreaStyle.getPropertyValue('padding-left').replace('px', ''));
-  const paddingTop = Number.parseInt(textAreaStyle.getPropertyValue('padding-top').replace('px', ''));
-  const lineHeight = Number.parseInt(textAreaStyle.getPropertyValue('line-height').replace('px', ''));
-
-  const textAreaOffset = (textAreaRect.top ?? 0) - (elTextArea!.parentElement?.getBoundingClientRect()?.top ?? 0);
-  const horizontalPos = selectionStart - newComment.value.slice(0, selectionStart).lastIndexOf('\n') - lastWord.length;
-  const verticalPos = elTextArea!.value.slice(0, selectionStart).split('\n').length ?? 0;
-
-  caretPos.value[0] = `calc(${paddingLeft}px + ${horizontalPos}ch)`;
-  caretPos.value[1] = (textAreaOffset + paddingTop + Math.min(lineHeight * verticalPos, textAreaRect.height)) + 'px';
-};
-
-const handleSuggestionClick = (user: any) => {
-  const lastWord = getLastWord();
-  if (!lastWord) {
-    return;
-  }
-
-  const username = `[~${user.name}]`;
-  const contentBefore = newComment.value.slice(0, newComment.value.lastIndexOf(lastWord));
-  const contentAfter = newComment.value.slice(newComment.value.lastIndexOf(lastWord) + lastWord.length);
-
-  newComment.value = contentBefore + username + contentAfter;
-
-  suggestions.value = [];
-  refTextArea.value?.elTextArea?.focus();
-};
-
-const getLastWord = () => {
-  const elTextArea = refTextArea.value?.elTextArea;
-  const selectionStart = elTextArea?.selectionStart ?? 0;
-
-  return newComment.value?.slice(0, selectionStart).split('\n')?.pop()?.split(' ')?.pop();
-};
-
-const clearSuggestions = (event: FocusEvent | KeyboardEvent | MouseEvent) => {
-  if (event instanceof KeyboardEvent
-    && ['ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'Enter', 'Escape', 'Tab']
-      .includes(event.key)) {
-    suggestions.value = [];
-    return;
-  }
-
-  if (event instanceof MouseEvent) {
-    suggestions.value = [];
-    return;
-  }
-
-  if (event instanceof FocusEvent
-    && event.relatedTarget !== event.currentTarget
-    && !(event.currentTarget as Node)?.contains(event.relatedTarget as Node)
-  ) {
-    suggestions.value = [];
-  }
-};
+const showJiraLink = computed(() =>
+  props.internalCommentsAvailable && props.commentsByType[CommentType.Internal].length > 0,
+);
 </script>
 
 <template>
-  <section class="osim-comments my-2">
-    <h4 class="mb-4">Comments</h4>
+  <section class="osim-comments">
+    <h4>Comments</h4>
+    <CommentsToolbar
+      :newCommentAllowed
+      :showBugzillaLink
+      :bugzillaLink
+      :showJiraLink
+      :isSaving
+      :taskKey
+      :unifiedView
+      :isAddingNewComment
+      :newCommentType
+      :internalCommentsAvailable
+      @toggleView="unifiedView = !unifiedView"
+      @startNewComment="(type) => startNewComment(type)"
+    />
+    <div v-if="!internalCommentsAvailable && settings['unifiedCommentsView']" class="alert alert-danger">
+      Internal comments not available
+    </div>
+    <NewCommentForm
+      :unifiedView
+      :taskKey
+      :isAddingNewComment
+      :isSaving
+      :newCommentType
+      :internalCommentsAvailable
+      @saveComment="(newComment) => handleCommentSave(newComment)"
+      @cancelComment="() => isAddingNewComment = false"
+    />
     <Tabs
+      v-if="!unifiedView"
       :labels="commentLabels"
       :default="0"
       :tooltips="Object.values(commentTooltips)"
       @tab-change="handleTabChange"
     >
-      <template #header-actions>
-        <div class="tab-actions">
-          <button
-            v-if="(
-              !isAddingNewComment
-              && selectedTab !== CommentType.System)
-              && (internalCommentsAvailable || selectedTab !== CommentType.Internal
-              )"
-            type="button"
-            class="btn btn-secondary tab-btn"
-            :disabled="isSaving"
-            @click="isAddingNewComment = true"
-          >
-            Add {{ CommentType[selectedTab] }} Comment
-          </button>
-          <a
-            v-if="(selectedTab === CommentType.Public || selectedTab === CommentType.Private)"
-            :href="bugzillaLink"
-            target="_blank"
-            class="btn btn-secondary tab-btn"
-            :disabled="isSaving"
-          >
-            View on Bugzilla
-          </a>
-          <a
-            v-if="(selectedTab === CommentType.Internal && internalCommentsAvailable)"
-            :href="taskKey ? jiraTaskUrl(taskKey) : '#'"
-            target="_blank"
-            class="btn btn-secondary tab-btn"
-            :disabled="isSaving"
-          >
-            View on Jira
-          </a>
-        </div>
-      </template>
       <template #tab-content>
         <div class="tab-content">
           <div class="info-message ms-3 mb-4">
@@ -265,110 +137,22 @@ const clearSuggestions = (event: FocusEvent | KeyboardEvent | MouseEvent) => {
             <div v-else-if="!internalCommentsAvailable && selectedTab === CommentType.Internal">
               Internal comments not available
             </div>
-            <div v-else-if="displayedComments?.length === 0">
+            <div v-else-if="commentsByType[selectedTab]?.length === 0">
               No {{ CommentType[selectedTab].toLowerCase() }} comments
             </div>
           </div>
-          <div
-            v-if="(
-              isAddingNewComment
-              && selectedTab !== CommentType.System)
-              && (internalCommentsAvailable
-                || selectedTab !== CommentType.Internal
-              )"
-            class="position-relative"
-            tabindex="-1"
-            @blur.capture="clearSuggestions"
-          >
-            <div v-if="selectedTab === CommentType.Public" class="alert alert-warning">
-              Any information provided in this comment will be publicly visible on Bugzilla.
-            </div>
-            <template v-if="!isInternalComment">
-              <LabelTextarea v-model="newComment" :label="`New ${CommentType[selectedTab]} Comment`" />
-            </template>
-            <template v-if="isInternalComment">
-              <LabelTextarea
-                ref="refTextArea"
-                v-model="newComment"
-                :label="`New ${CommentType[selectedTab]} Comment`"
-                :disabled="isLoadingSuggestions"
-                :loading="isLoadingSuggestions"
-                @keydown="clearSuggestions"
-                @click="clearSuggestions"
-              />
-              <DropDown
-                v-if="suggestions.length > 0"
-                :style="{ width: 'auto', left: caretPos[0], top: caretPos[1], right: 'auto' }"
-              >
-                <div
-                  v-for="user in suggestions"
-                  :key="user.name"
-                  class="item"
-                  @click="handleSuggestionClick(user)"
-                >
-                  <JiraUser v-bind="user" :query="getLastWord()?.slice(1)" />
-                </div>
-              </DropDown>
-            </template>
-            <button type="button" class="btn btn-primary col" @click="handleCommentSave">
-              Save {{ CommentType[selectedTab] }} Comment
-            </button>
-            <button type="button" class="btn ms-3 btn-secondary col" @click="isAddingNewComment = false">
-              Cancel
-            </button>
-          </div>
-          <ul class="comments list-unstyled">
-            <li
-              v-for="(comment, commentIndex) in displayedComments"
-              :key="commentIndex"
-              class="bg-light p-4 mt-3 rounded-2"
-            >
-              <p class="border-bottom pb-3">
-                <i class="bi bi-caret-right-fill me-2"></i>
-                <a
-                  v-if="selectedTab === CommentType.Internal"
-                  :href="jiraUserUrl(comment.creator || '')"
-                  target="_blank"
-                >
-                  {{ comment.creator }}
-                </a>
-                <span v-else>{{ comment.creator }}</span>
-                - {{ DateTime.fromISO(comment.created_dt ?? '',{ setZone: true })
-                  .toFormat('yyyy-MM-dd hh:mm a ZZZZ') }}
-                <span
-                  class="badge rounded-pill float-end cursor-pointer"
-                  :class="{
-                    'bg-success': selectedTab === CommentType.Public,
-                    'bg-info': selectedTab === CommentType.Private,
-                    'bg-danger': selectedTab === CommentType.Internal,
-                    'bg-warning text-black': selectedTab === CommentType.System,
-                  }"
-                >
-                  {{ CommentType[selectedTab] }}
-                </span>
-              </p>
-              <!--eslint-disable-next-line vue/no-v-html -->
-              <p class="osim-flaw-comment" v-html="parseCommentDisplayText(comment.text ?? '')" />
-            </li>
-          </ul>
+          <CommentList :commentList="commentsByType[selectedTab]" />
         </div>
       </template>
     </Tabs>
+    <div v-else style="min-height: 250px;">
+      <CommentList :commentList="unifiedComments" />
+      <span v-if="unifiedComments.length <= 0" class="p-3">No comments</span>
+    </div>
   </section>
 </template>
 
 <style scoped lang="scss">
-.tab-actions {
-  margin-left: auto;
-
-  .tab-btn {
-    margin-left: 3px;
-    margin-top: 3px;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
-  }
-}
-
 .tab-content {
   min-height: 250px;
   margin-top: 25px;

--- a/src/components/FlawComments/FlawComments.vue
+++ b/src/components/FlawComments/FlawComments.vue
@@ -75,7 +75,7 @@ const newCommentAllowed = computed(() =>
         selectedTab.value !== CommentType.System
         && (props.internalCommentsAvailable || selectedTab.value !== CommentType.Internal)
       )
-      || (settings.value['singleCommentsView']))
+      || (settings.value['unifiedCommentsView']))
   ),
 );
 
@@ -118,7 +118,7 @@ const showJiraLink = computed(() =>
       @cancelComment="() => isAddingNewComment = false"
     />
     <Tabs
-      v-if="!settings['singleCommentsView']"
+      v-if="!settings['unifiedCommentsView']"
       :labels="commentLabels"
       :default="0"
       :tooltips="Object.values(commentTooltips)"

--- a/src/components/FlawComments/NewCommentForm.vue
+++ b/src/components/FlawComments/NewCommentForm.vue
@@ -10,7 +10,7 @@ import type { ZodJiraUserAssignableType } from '@/types/zodJira';
 import { searchJiraUsers } from '@/services/JiraService';
 import DropDown from '@/widgets/DropDown/DropDown.vue';
 import JiraUser from '@/widgets/JiraUser/JiraUser.vue';
-import { CommentType } from '@/types';
+import { CommentType } from '@/constants';
 
 const props = defineProps<{
   internalCommentsAvailable: boolean;

--- a/src/components/FlawComments/NewCommentForm.vue
+++ b/src/components/FlawComments/NewCommentForm.vue
@@ -1,0 +1,178 @@
+<script setup lang="ts">
+import { nextTick, computed, ref } from 'vue';
+
+import { isDefined, watchDebounced } from '@vueuse/core';
+
+import { createCatchHandler } from '@/composables/service-helpers';
+
+import LabelTextarea from '@/widgets/LabelTextarea/LabelTextarea.vue';
+import type { ZodJiraUserAssignableType } from '@/types/zodJira';
+import { searchJiraUsers } from '@/services/JiraService';
+import DropDown from '@/widgets/DropDown/DropDown.vue';
+import JiraUser from '@/widgets/JiraUser/JiraUser.vue';
+import { CommentType } from '@/types';
+
+const props = defineProps<{
+  internalCommentsAvailable: boolean;
+  isAddingNewComment: boolean;
+  isSaving: boolean;
+  newCommentType: CommentType;
+  taskKey: null | string | undefined;
+  unifiedView: boolean;
+}>();
+
+const emit = defineEmits<{
+  cancelComment: [];
+  saveComment: [newComment: string];
+}>();
+
+const newComment = ref('');
+const refTextArea = ref<InstanceType<typeof LabelTextarea> | null>(null);
+const suggestions = ref<ZodJiraUserAssignableType[]>([]);
+const isLoadingSuggestions = ref(false);
+const caretPos = ref(['0px', '0px']);
+
+const isInternalComment = computed(() => props.newCommentType === CommentType.Internal);
+
+watchDebounced(newComment, async () => {
+  if (!isDefined(newComment)
+    || newComment.value === ''
+    || !refTextArea.value?.elTextArea?.value
+    || !isInternalComment.value
+    || !props.taskKey) {
+    return;
+  }
+
+  const lastWord = getLastWord();
+  if (!lastWord?.startsWith('@') || lastWord.length < 2) {
+    return;
+  }
+  isLoadingSuggestions.value = true;
+  const users = await searchJiraUsers(lastWord.slice(1), props.taskKey)
+    .catch(createCatchHandler('Failed to load jira users', false))
+    .finally(() => {
+      isLoadingSuggestions.value = false;
+      nextTick(() => refTextArea.value?.elTextArea?.focus());
+    });
+
+  if (!users?.data?.users) {
+    return;
+  }
+  calculateDropdownPosition(lastWord);
+  nextTick(() => {
+    suggestions.value = users.data?.users;
+  });
+}, { debounce: 500 });
+
+const calculateDropdownPosition = (lastWord: string) => {
+  const elTextArea = refTextArea.value!.elTextArea;
+  const selectionStart = elTextArea?.selectionStart ?? 0;
+
+  const textAreaRect = elTextArea!.getBoundingClientRect();
+  const textAreaStyle = getComputedStyle(elTextArea!);
+  const paddingLeft = Number.parseInt(textAreaStyle.getPropertyValue('padding-left').replace('px', ''));
+  const paddingTop = Number.parseInt(textAreaStyle.getPropertyValue('padding-top').replace('px', ''));
+  const lineHeight = Number.parseInt(textAreaStyle.getPropertyValue('line-height').replace('px', ''));
+
+  const textAreaOffset = (textAreaRect.top ?? 0) - (elTextArea!.parentElement?.getBoundingClientRect()?.top ?? 0);
+  const horizontalPos = selectionStart - newComment.value.slice(0, selectionStart).lastIndexOf('\n') - lastWord.length;
+  const verticalPos = elTextArea!.value.slice(0, selectionStart).split('\n').length ?? 0;
+
+  caretPos.value[0] = `calc(${paddingLeft}px + ${horizontalPos}ch)`;
+  caretPos.value[1] = (textAreaOffset + paddingTop + Math.min(lineHeight * verticalPos, textAreaRect.height)) + 'px';
+};
+
+const handleSuggestionClick = (user: any) => {
+  const lastWord = getLastWord();
+  if (!lastWord) {
+    return;
+  }
+
+  const username = `[~${user.name}]`;
+  const contentBefore = newComment.value.slice(0, newComment.value.lastIndexOf(lastWord));
+  const contentAfter = newComment.value.slice(newComment.value.lastIndexOf(lastWord) + lastWord.length);
+
+  newComment.value = contentBefore + username + contentAfter;
+
+  suggestions.value = [];
+  refTextArea.value?.elTextArea?.focus();
+};
+
+const getLastWord = () => {
+  const elTextArea = refTextArea.value?.elTextArea;
+  const selectionStart = elTextArea?.selectionStart ?? 0;
+
+  return newComment.value?.slice(0, selectionStart).split('\n')?.pop()?.split(' ')?.pop();
+};
+
+const clearSuggestions = (event: FocusEvent | KeyboardEvent | MouseEvent) => {
+  if (event instanceof KeyboardEvent
+    && ['ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'Enter', 'Escape', 'Tab']
+      .includes(event.key)) {
+    suggestions.value = [];
+    return;
+  }
+
+  if (event instanceof MouseEvent) {
+    suggestions.value = [];
+    return;
+  }
+
+  if (event instanceof FocusEvent
+    && event.relatedTarget !== event.currentTarget
+    && !(event.currentTarget as Node)?.contains(event.relatedTarget as Node)
+  ) {
+    suggestions.value = [];
+  }
+};
+
+function commentTypeString(type: CommentType | undefined): string {
+  return type !== undefined ? CommentType[type] : '';
+}
+</script>
+
+<template>
+  <div
+    v-if="(isAddingNewComment && !isSaving)"
+    class="position-relative mb-4 pb-2"
+    tabindex="-1"
+    @blur.capture="clearSuggestions"
+  >
+    <div v-if="newCommentType === CommentType.Public" class="alert alert-warning">
+      Any information provided in this comment will be publicly visible on Bugzilla.
+    </div>
+    <template v-if="!isInternalComment">
+      <LabelTextarea v-model="newComment" :label="`New ${commentTypeString(newCommentType)} Comment`" />
+    </template>
+    <template v-if="isInternalComment && internalCommentsAvailable">
+      <LabelTextarea
+        ref="refTextArea"
+        v-model="newComment"
+        :label="`New ${commentTypeString(newCommentType)} Comment`"
+        :disabled="isLoadingSuggestions"
+        :loading="isLoadingSuggestions"
+        @keydown="clearSuggestions"
+        @click="clearSuggestions"
+      />
+      <DropDown
+        v-if="suggestions.length > 0"
+        :style="{ width: 'auto', left: caretPos[0], top: caretPos[1], right: 'auto' }"
+      >
+        <div
+          v-for="user in suggestions"
+          :key="user.name"
+          class="item"
+          @click="handleSuggestionClick(user)"
+        >
+          <JiraUser v-bind="user" :query="getLastWord()?.slice(1)" />
+        </div>
+      </DropDown>
+    </template>
+    <button type="button" class="btn btn-primary col" @click="emit('saveComment', newComment); newComment = ''">
+      Save {{ commentTypeString(newCommentType) }} Comment
+    </button>
+    <button type="button" class="btn ms-3 btn-secondary col" @click="emit('cancelComment')">
+      Cancel
+    </button>
+  </div>
+</template>

--- a/src/components/FlawComments/NewCommentForm.vue
+++ b/src/components/FlawComments/NewCommentForm.vue
@@ -18,7 +18,6 @@ const props = defineProps<{
   isSaving: boolean;
   newCommentType: CommentType;
   taskKey: null | string | undefined;
-  unifiedView: boolean;
 }>();
 
 const emit = defineEmits<{

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -60,6 +60,7 @@ const {
   bugzillaLink,
   cancelAddAcknowledgment,
   cancelAddReference,
+  commentsByType,
   createFlaw,
   deleteAcknowledgment,
   deleteReference,
@@ -69,7 +70,6 @@ const {
   flawReferences,
   flawRhCvss3,
   highlightedNvdCvss3String,
-  internalComments,
   internalCommentsAvailable,
   isLoadingInternalComments,
   isSaving,
@@ -77,14 +77,11 @@ const {
   loadInternalComments,
   nvdCvss3String,
   osimLink,
-  privateComments,
-  publicComments,
   rhCvss3String,
   saveAcknowledgments,
   saveReferences,
   shouldCreateJiraTask,
   shouldDisplayEmailNistForm,
-  systemComments,
   toggleShouldCreateJiraTask,
   updateFlaw,
 } = useFlawModel(props.flaw, onSaveSuccess);
@@ -427,12 +424,9 @@ const createdDate = computed(() => {
         </div>
         <div v-if="mode === 'edit'" class="border-top osim-flaw-form-section">
           <FlawComments
-            :publicComments
-            :privateComments
-            :internalComments
+            :commentsByType
             :internalCommentsAvailable
             :isLoadingInternalComments
-            :systemComments
             :taskKey="flaw.task_key || ''"
             :bugzillaLink
             :isSaving

--- a/src/components/__tests__/FlawComments.spec.ts
+++ b/src/components/__tests__/FlawComments.spec.ts
@@ -280,7 +280,7 @@ describe('flawComments', () => {
 
   it('should not render tabs if unified view is set', async () => {
     const store = useSettingsStore();
-    store.settings.singleCommentsView = true;
+    store.settings.unifiedCommentsView = true;
     await flushPromises();
 
     const tabs = subject.find('.nav-tabs');

--- a/src/components/__tests__/FlawComments.spec.ts
+++ b/src/components/__tests__/FlawComments.spec.ts
@@ -5,7 +5,9 @@ import FlawComments from '@/components/FlawComments/FlawComments.vue';
 
 import { type ZodFlawCommentType } from '@/types/zodFlaw';
 import { searchJiraUsers } from '@/services/JiraService';
+import { useSettingsStore } from '@/stores/SettingsStore';
 import { mountWithConfig } from '@/__tests__/helpers';
+import { CommentType } from '@/constants';
 
 vi.mock('@/services/JiraService', () => ({
   searchJiraUsers: vi.fn(() => Promise.resolve([])),
@@ -21,12 +23,14 @@ describe('flawComments', () => {
     vi.useFakeTimers();
     subject = mountWithConfig(FlawComments, {
       props: {
-        publicComments: [],
-        privateComments: [],
-        internalComments: [],
+        commentsByType: {
+          [CommentType.Public]: [],
+          [CommentType.Private]: [],
+          [CommentType.Internal]: [],
+          [CommentType.System]: [],
+        } as Record<CommentType, ZodFlawCommentType[]>,
         internalCommentsAvailable: true,
         isLoadingInternalComments: false,
-        systemComments: [],
         taskKey: 'sampleKey',
         bugzillaLink: 'sampleBzLink',
         isSaving: false,
@@ -68,15 +72,13 @@ describe('flawComments', () => {
   });
 
   it('show a functional add comment button', async () => {
-    let addCommentButton = subject.find('.tab-actions button');
+    const addCommentButton = subject.find('button');
     expect(addCommentButton.exists()).toBeTruthy();
     expect(addCommentButton.text()).toBe('Add Public Comment');
     // Check that it is functional
     await addCommentButton.trigger('click');
-    const newCommentInput = subject.find('.tab-content > div > .osim-input');
+    const newCommentInput = subject.find('textarea');
     expect(newCommentInput.exists()).toBeTruthy();
-    addCommentButton = subject.find('.tab-actions button');
-    expect(addCommentButton.exists()).toBeFalsy();
   });
 
   it('show message if no comments', () => {
@@ -89,15 +91,17 @@ describe('flawComments', () => {
   it('correctly display public comments', () => {
     subject = mount(FlawComments, {
       props: {
-        publicComments: [
-          { creator: 'noonerelevant', text: 'First public comment', created_dt: '2021-07-29T14:50:50Z' },
-          { creator: 'onelessrelevant', text: 'Second public comment', created_dt: '2023-09-20T14:50:50Z' },
-        ] as ZodFlawCommentType[],
-        privateComments: [],
-        internalComments: [],
+        commentsByType: {
+          [CommentType.Public]: [
+            { creator: 'noonerelevant', text: 'First public comment', created_dt: '2023-09-20T14:50:50Z' },
+            { creator: 'onelessrelevant', text: 'Second public comment', created_dt: '2021-07-29T14:50:50Z' },
+          ] as ZodFlawCommentType[],
+          [CommentType.Private]: [],
+          [CommentType.Internal]: [],
+          [CommentType.System]: [],
+        },
         internalCommentsAvailable: false,
         isLoadingInternalComments: false,
-        systemComments: [],
         taskKey: 'sampleKey',
         bugzillaLink: 'sampleBzLink',
         isSaving: false,
@@ -107,29 +111,31 @@ describe('flawComments', () => {
     const commentElements = subject.findAll('ul.comments li');
     expect(commentElements.length).toBe(2);
     // First public comment checks
-    const firstHeader = commentElements[0].findAll('p')[0];
-    const firstBody = commentElements[0].findAll('p')[1];
-    expect(firstHeader.text()).toBe('noonerelevant - 2021-07-29 02:50 PM UTC Public');
+    const firstHeader = commentElements[0].find('div');
+    const firstBody = commentElements[0].find('p');
+    expect(firstHeader.text()).toBe('noonerelevant - 2023-09-20 02:50 PM UTC');
     expect(firstBody.text()).toBe('First public comment');
-    // Seccond public comment checks
-    const secondHeader = commentElements[1].findAll('p')[0];
-    const secondBody = commentElements[1].findAll('p')[1];
-    expect(secondHeader.text()).toBe('onelessrelevant - 2023-09-20 02:50 PM UTC Public');
+    // Second public comment checks
+    const secondHeader = commentElements[1].findAll('div')[0];
+    const secondBody = commentElements[1].findAll('p')[0];
+    expect(secondHeader.text()).toBe('onelessrelevant - 2021-07-29 02:50 PM UTC');
     expect(secondBody.text()).toBe('Second public comment');
   });
 
   it('correctly display private comments', async () => {
     subject = mount(FlawComments, {
       props: {
-        publicComments: [],
-        privateComments: [
-          { creator: 'noonerelevant', text: 'First private comment', created_dt: '2021-07-29T15:50:50Z' },
-          { creator: 'onelessrelevant', text: 'Second private comment', created_dt: '2023-09-20T15:50:50Z' },
-        ] as ZodFlawCommentType[],
-        internalComments: [],
+        commentsByType: {
+          [CommentType.Public]: [],
+          [CommentType.Private]: [
+            { creator: 'noonerelevant', text: 'First private comment', created_dt: '2021-07-29T15:50:50Z' },
+            { creator: 'onelessrelevant', text: 'Second private comment', created_dt: '2023-09-20T15:50:50Z' },
+          ] as ZodFlawCommentType[],
+          [CommentType.Internal]: [],
+          [CommentType.System]: [],
+        },
         internalCommentsAvailable: false,
         isLoadingInternalComments: false,
-        systemComments: [],
         taskKey: 'sampleKey',
         bugzillaLink: 'sampleBzLink',
         isSaving: false,
@@ -141,27 +147,44 @@ describe('flawComments', () => {
     expect(subject.html()).toMatchSnapshot();
   });
 
-  it('show Jira link button on internal comments', async () => {
-    const navLinks = subject.findAll('.nav-link');
-    await navLinks[2].trigger('click');
-    const actionButtons = subject.findAll('.tab-actions > *');
-    expect(actionButtons.length).toBe(2);
-    expect(actionButtons[0].text()).toBe('Add Internal Comment');
-    expect(actionButtons[1].text()).toContain('Jira');
+  it('show Jira link button', async () => {
+    subject = mount(FlawComments, {
+      props: {
+        commentsByType: {
+          [CommentType.Public]: [],
+          [CommentType.Private]: [],
+          [CommentType.Internal]: [
+            { creator: 'noonerelevant', text: 'First internal comment', created_dt: '2023-09-20T16:50:50Z' },
+            { creator: 'onelessrelevant', text: 'Second internal comment', created_dt: '2021-07-29T16:50:50Z' },
+          ] as ZodFlawCommentType[],
+          [CommentType.System]: [],
+        },
+        internalCommentsAvailable: true,
+        isLoadingInternalComments: false,
+        taskKey: 'sampleKey',
+        bugzillaLink: 'sampleBzLink',
+        isSaving: false,
+      },
+    });
+    const jiraLinkBtn = subject.findAll('a')[0];
+    expect(jiraLinkBtn.text()).toBe('View in Jira');
+    expect(jiraLinkBtn.exists()).toBeTruthy();
   });
 
   it('correctly display internal comments', async () => {
     subject = mount(FlawComments, {
       props: {
-        publicComments: [],
-        privateComments: [],
-        internalComments: [
-          { creator: 'noonerelevant', text: 'First internal comment', created_dt: '2021-07-29T16:50:50Z' },
-          { creator: 'onelessrelevant', text: 'Second internal comment', created_dt: '2023-09-20T16:50:50Z' },
-        ] as ZodFlawCommentType[],
+        commentsByType: {
+          [CommentType.Public]: [],
+          [CommentType.Private]: [],
+          [CommentType.Internal]: [
+            { creator: 'noonerelevant', text: 'First internal comment', created_dt: '2023-09-20T16:50:50Z' },
+            { creator: 'onelessrelevant', text: 'Second internal comment', created_dt: '2021-07-29T16:50:50Z' },
+          ] as ZodFlawCommentType[],
+          [CommentType.System]: [],
+        },
         internalCommentsAvailable: true,
         isLoadingInternalComments: false,
-        systemComments: [],
         taskKey: 'sampleKey',
         bugzillaLink: 'sampleBzLink',
         isSaving: false,
@@ -172,14 +195,14 @@ describe('flawComments', () => {
     const commentElements = subject.findAll('ul.comments li');
     expect(commentElements.length).toBe(2);
     // First internal comment checks
-    const firstHeader = commentElements[0].findAll('p')[0];
-    const firstBody = commentElements[0].findAll('p')[1];
-    expect(firstHeader.text()).toBe('noonerelevant - 2021-07-29 04:50 PM UTC Internal');
+    const firstHeader = commentElements[0].findAll('div')[0];
+    const firstBody = commentElements[0].findAll('p')[0];
+    expect(firstHeader.text()).toBe('noonerelevant - 2023-09-20 04:50 PM UTC');
     expect(firstBody.text()).toBe('First internal comment');
     // Seccond internal comment checks
-    const secondHeader = commentElements[1].findAll('p')[0];
-    const secondBody = commentElements[1].findAll('p')[1];
-    expect(secondHeader.text()).toBe('onelessrelevant - 2023-09-20 04:50 PM UTC Internal');
+    const secondHeader = commentElements[1].findAll('div')[0];
+    const secondBody = commentElements[1].findAll('p')[0];
+    expect(secondHeader.text()).toBe('onelessrelevant - 2021-07-29 04:50 PM UTC');
     expect(secondBody.text()).toBe('Second internal comment');
   });
 
@@ -202,15 +225,18 @@ describe('flawComments', () => {
   it('correctly display system comments', async () => {
     subject = mount(FlawComments, {
       props: {
-        publicComments: [],
-        privateComments: [],
-        internalComments: [],
+        commentsByType: {
+          [CommentType.Public]: [],
+          [CommentType.Private]: [],
+          [CommentType.Internal]: [],
+          [CommentType.System]: [
+            { creator: SYSTEM_EMAIL, text: 'First system comment', created_dt: '2023-09-20T17:50:50Z' },
+            { creator: SYSTEM_EMAIL, text: 'Second system comment', created_dt: '2021-07-29T17:50:50Z' },
+          ] as ZodFlawCommentType[],
+        },
+
         internalCommentsAvailable: false,
         isLoadingInternalComments: false,
-        systemComments: [
-          { creator: SYSTEM_EMAIL, text: 'First system comment', created_dt: '2021-07-29T17:50:50Z' },
-          { creator: SYSTEM_EMAIL, text: 'Second system comment', created_dt: '2023-09-20T17:50:50Z' },
-        ] as ZodFlawCommentType[],
         taskKey: 'sampleKey',
         bugzillaLink: 'sampleBzLink',
         isSaving: false,
@@ -222,14 +248,14 @@ describe('flawComments', () => {
     const commentElements = subject.findAll('ul.comments li');
     expect(commentElements.length).toBe(2);
     // First system comment checks
-    const firstHeader = commentElements[0].findAll('p')[0];
-    const firstBody = commentElements[0].findAll('p')[1];
-    expect(firstHeader.text()).toBe(`${SYSTEM_EMAIL} - 2021-07-29 05:50 PM UTC System`);
+    const firstHeader = commentElements[0].findAll('div')[0];
+    const firstBody = commentElements[0].findAll('p')[0];
+    expect(firstHeader.text()).toBe(`${SYSTEM_EMAIL} - 2023-09-20 05:50 PM UTC`);
     expect(firstBody.text()).toBe('First system comment');
     // Seccond system comment checks
-    const secondHeader = commentElements[1].findAll('p')[0];
-    const secondBody = commentElements[1].findAll('p')[1];
-    expect(secondHeader.text()).toBe(`${SYSTEM_EMAIL} - 2023-09-20 05:50 PM UTC System`);
+    const secondHeader = commentElements[1].findAll('div')[0];
+    const secondBody = commentElements[1].findAll('p')[0];
+    expect(secondHeader.text()).toBe(`${SYSTEM_EMAIL} - 2021-07-29 05:50 PM UTC`);
     expect(secondBody.text()).toBe('Second system comment');
   });
 
@@ -240,17 +266,24 @@ describe('flawComments', () => {
       },
     });
 
-    const navLinks = subject.findAll('.nav-link');
+    const navLinks = subject.findAll('button');
     await navLinks[2].trigger('click');
-    const addCommentButton = subject.find('.tab-actions button');
-    await addCommentButton.trigger('click');
 
-    const newCommentInput = subject.find('.tab-content textarea ');
+    const newCommentInput = subject.find('textarea');
     await newCommentInput.setValue('test @user');
 
     vi.runAllTimers();
     await flushPromises();
 
     expect(searchJiraUsers).toHaveBeenCalledWith('user', 'sampleKey');
+  });
+
+  it('should not render tabs if unified view is set', async () => {
+    const store = useSettingsStore();
+    store.settings.singleCommentsView = true;
+    await flushPromises();
+
+    const tabs = subject.find('.nav-tabs');
+    expect(tabs.exists()).toBeFalsy();
   });
 });

--- a/src/components/__tests__/__snapshots__/FlawComments.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawComments.spec.ts.snap
@@ -1,33 +1,37 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`flawComments > correctly display private comments 1`] = `
-"<section data-v-0b679fcf="" class="osim-comments my-2">
-  <h4 data-v-0b679fcf="" class="mb-4">Comments</h4>
+"<section data-v-0b679fcf="" class="osim-comments">
+  <h4 data-v-0b679fcf="">Comments</h4>
+  <div data-v-0b679fcf="" class="d-flex mb-4 sticky-top p-3 ps-0 border-bottom align-items-center" style="background-color: white;">
+    <div class="d-flex gap-2"><button type="button" class="btn btn-secondary"> Add Public Comment </button><button type="button" class="btn btn-secondary"> Add Private Comment </button><button type="button" class="btn btn-secondary" disabled=""> Add Internal Comment </button><a href="sampleBzLink" target="_blank" class="btn tab-btn border border-secondary" disabled="false"> View in Bugzilla </a>
+      <!--v-if-->
+    </div>
+    <div class="form-check form-switch ms-auto" style="font-size: 18px;"><input id="singleViewSwitch" class="form-check-input" type="checkbox"><label class="form-check-label" for="singleViewSwitch" style="user-select: none;">Unified view</label></div>
+  </div>
+  <!--v-if-->
+  <!--v-if-->
   <div data-v-8b945130="" data-v-0b679fcf="">
     <ul data-v-8b945130="" class="nav nav-tabs">
-      <li data-v-8b945130="" class="nav-item"><button data-v-8b945130="" type="button" class="nav-link" title="Bugzilla Public - This comments are visible to everyone.">Public Comments</button></li>
-      <li data-v-8b945130="" class="nav-item"><button data-v-8b945130="" type="button" class="nav-link active" title="Bugzilla Private - This comments are visible to Red Hat associates.">Private Comments</button></li>
-      <li data-v-8b945130="" class="nav-item"><button data-v-8b945130="" type="button" class="nav-link" title="Jira Internal - This comments are visible to team members with required permissions.">Internal Comments</button></li>
-      <li data-v-8b945130="" class="nav-item"><button data-v-8b945130="" type="button" class="nav-link" title="Bugzilla System - This are auto-generated private comments.">System Comments</button></li>
-      <div data-v-0b679fcf="" class="tab-actions"><button data-v-0b679fcf="" type="button" class="btn btn-secondary tab-btn"> Add Private Comment </button><a data-v-0b679fcf="" href="sampleBzLink" target="_blank" class="btn btn-secondary tab-btn" disabled="false"> View on Bugzilla </a>
-        <!--v-if-->
-      </div>
+      <li data-v-8b945130="" title="Bugzilla Public - These comments are visible to everyone." class="nav-item"><button data-v-8b945130="" type="button" class="nav-link">Public Comments</button></li>
+      <li data-v-8b945130="" title="Bugzilla Private - These comments are visible to Red Hat associates." class="nav-item"><button data-v-8b945130="" type="button" class="nav-link active">Private Comments</button></li>
+      <li data-v-8b945130="" title="Internal comments not available" class="nav-item"><button data-v-8b945130="" type="button" class="nav-link" disabled="">Internal Comments</button></li>
+      <li data-v-8b945130="" title="Bugzilla System - These are auto-generated private comments." class="nav-item"><button data-v-8b945130="" type="button" class="nav-link">System Comments</button></li>
     </ul>
     <div data-v-0b679fcf="" class="tab-content">
       <div data-v-0b679fcf="" class="info-message ms-3 mb-4">
         <!--v-if-->
       </div>
-      <!--v-if-->
       <ul data-v-0b679fcf="" class="comments list-unstyled">
-        <li data-v-0b679fcf="" class="bg-light p-4 mt-3 rounded-2">
-          <p data-v-0b679fcf="" class="border-bottom pb-3"><i data-v-0b679fcf="" class="bi bi-caret-right-fill me-2"></i><span data-v-0b679fcf="">noonerelevant</span> - 2021-07-29 03:50 PM UTC <span data-v-0b679fcf="" class="badge rounded-pill float-end cursor-pointer bg-info">Private</span></p>
+        <li class="p-4 mt-3 rounded-2">
+          <div class="d-flex border-bottom pb-3 align-items-center"><i class="bi bi-caret-right-fill me-2"></i><span>noonerelevant</span> - 2021-07-29 03:50 PM UTC <span class="badge rounded-pill float-end ms-auto" style="font-size: 14px; cursor: help; user-select: none;" title=""></span></div>
           <!--eslint-disable-next-line vue/no-v-html -->
-          <p data-v-0b679fcf="" class="osim-flaw-comment">First private comment</p>
+          <p class="osim-flaw-comment">First private comment</p>
         </li>
-        <li data-v-0b679fcf="" class="bg-light p-4 mt-3 rounded-2">
-          <p data-v-0b679fcf="" class="border-bottom pb-3"><i data-v-0b679fcf="" class="bi bi-caret-right-fill me-2"></i><span data-v-0b679fcf="">onelessrelevant</span> - 2023-09-20 03:50 PM UTC <span data-v-0b679fcf="" class="badge rounded-pill float-end cursor-pointer bg-info">Private</span></p>
+        <li class="p-4 mt-3 rounded-2">
+          <div class="d-flex border-bottom pb-3 align-items-center"><i class="bi bi-caret-right-fill me-2"></i><span>onelessrelevant</span> - 2023-09-20 03:50 PM UTC <span class="badge rounded-pill float-end ms-auto" style="font-size: 14px; cursor: help; user-select: none;" title=""></span></div>
           <!--eslint-disable-next-line vue/no-v-html -->
-          <p data-v-0b679fcf="" class="osim-flaw-comment">Second private comment</p>
+          <p class="osim-flaw-comment">Second private comment</p>
         </li>
       </ul>
     </div>

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -864,28 +864,32 @@ This module has no trackers associated"><i data-v-2d3c4208="" class="bi bi-excla
     </div>
   </div>
   <div data-v-76e7a15d="" class="border-top osim-flaw-form-section">
-    <section data-v-0b679fcf="" data-v-76e7a15d="" class="osim-comments my-2">
-      <h4 data-v-0b679fcf="" class="mb-4">Comments</h4>
+    <section data-v-0b679fcf="" data-v-76e7a15d="" class="osim-comments">
+      <h4 data-v-0b679fcf="">Comments</h4>
+      <div data-v-0b679fcf="" class="d-flex mb-4 sticky-top p-3 ps-0 border-bottom align-items-center" style="background-color: white;">
+        <div class="d-flex gap-2"><button type="button" class="btn btn-secondary"> Add Public Comment </button><button type="button" class="btn btn-secondary"> Add Private Comment </button><button type="button" class="btn btn-secondary" disabled=""> Add Internal Comment </button><a href="/show_bug.cgi?id=1984541" target="_blank" class="btn tab-btn border border-secondary" disabled="false"> View in Bugzilla </a>
+          <!--v-if-->
+        </div>
+        <div class="form-check form-switch ms-auto" style="font-size: 18px;"><input id="singleViewSwitch" class="form-check-input" type="checkbox"><label class="form-check-label" for="singleViewSwitch" style="user-select: none;">Unified view</label></div>
+      </div>
+      <!--v-if-->
+      <!--v-if-->
       <div data-v-8b945130="" data-v-0b679fcf="">
         <ul data-v-8b945130="" class="nav nav-tabs">
-          <li data-v-8b945130="" class="nav-item"><button data-v-8b945130="" type="button" class="nav-link active" title="Bugzilla Public - This comments are visible to everyone.">Public Comments</button></li>
-          <li data-v-8b945130="" class="nav-item"><button data-v-8b945130="" type="button" class="nav-link" title="Bugzilla Private - This comments are visible to Red Hat associates.">Private Comments</button></li>
-          <li data-v-8b945130="" class="nav-item"><button data-v-8b945130="" type="button" class="nav-link" title="Jira Internal - This comments are visible to team members with required permissions.">Internal Comments</button></li>
-          <li data-v-8b945130="" class="nav-item"><button data-v-8b945130="" type="button" class="nav-link" title="Bugzilla System - This are auto-generated private comments.">System Comments</button></li>
-          <div data-v-0b679fcf="" class="tab-actions"><button data-v-0b679fcf="" type="button" class="btn btn-secondary tab-btn"> Add Public Comment </button><a data-v-0b679fcf="" href="/show_bug.cgi?id=1984541" target="_blank" class="btn btn-secondary tab-btn" disabled="false"> View on Bugzilla </a>
-            <!--v-if-->
-          </div>
+          <li data-v-8b945130="" title="Bugzilla Public - These comments are visible to everyone." class="nav-item"><button data-v-8b945130="" type="button" class="nav-link active">Public Comments</button></li>
+          <li data-v-8b945130="" title="Bugzilla Private - These comments are visible to Red Hat associates." class="nav-item"><button data-v-8b945130="" type="button" class="nav-link">Private Comments</button></li>
+          <li data-v-8b945130="" title="Internal comments not available" class="nav-item"><button data-v-8b945130="" type="button" class="nav-link" disabled="">Internal Comments</button></li>
+          <li data-v-8b945130="" title="Bugzilla System - These are auto-generated private comments." class="nav-item"><button data-v-8b945130="" type="button" class="nav-link">System Comments</button></li>
         </ul>
         <div data-v-0b679fcf="" class="tab-content">
           <div data-v-0b679fcf="" class="info-message ms-3 mb-4">
             <!--v-if-->
           </div>
-          <!--v-if-->
           <ul data-v-0b679fcf="" class="comments list-unstyled">
-            <li data-v-0b679fcf="" class="bg-light p-4 mt-3 rounded-2">
-              <p data-v-0b679fcf="" class="border-bottom pb-3"><i data-v-0b679fcf="" class="bi bi-caret-right-fill me-2"></i><span data-v-0b679fcf="">example@example.com</span> - 2021-09-13 09:09 AM UTC <span data-v-0b679fcf="" class="badge rounded-pill float-end cursor-pointer bg-success">Public</span></p>
+            <li class="p-4 mt-3 rounded-2 bg-light-green">
+              <div class="d-flex border-bottom pb-3 align-items-center"><i class="bi bi-caret-right-fill me-2"></i><span>example@example.com</span> - 2021-09-13 09:09 AM UTC <span class="badge rounded-pill float-end ms-auto bg-success" style="font-size: 14px; cursor: help; user-select: none;" title="">Public</span></div>
               <!--eslint-disable-next-line vue/no-v-html -->
-              <p data-v-0b679fcf="" class="osim-flaw-comment">Dictum maecenas congue quis quam phasellus aenean.</p>
+              <p class="osim-flaw-comment">Dictum maecenas congue quis quam phasellus aenean.</p>
             </li>
           </ul>
         </div>

--- a/src/composables/__tests__/useFlawCommentsModel.spec.ts
+++ b/src/composables/__tests__/useFlawCommentsModel.spec.ts
@@ -7,7 +7,7 @@ import { blankFlaw } from '@/composables/useFlaw';
 
 import { getJiraComments, postJiraComment } from '@/services/JiraService';
 import { postFlawComment } from '@/services/FlawService';
-import { SYSTEM_EMAIL } from '@/constants';
+import { CommentType, SYSTEM_EMAIL } from '@/constants';
 import type { ZodFlawCommentType, ZodFlawType } from '@/types/zodFlaw';
 
 vi.mock('@/services/JiraService');
@@ -46,21 +46,23 @@ describe('useFlawCommentsModel', () => {
     flaw.value.comments = [{ is_private: false } as ZodFlawCommentType];
     const { publicComments } = useFlawCommentsModel(flaw, isSaving, afterSaveSuccess);
 
-    expect(publicComments.value).toEqual([{ is_private: false }]);
+    expect(publicComments.value).toEqual([{ is_private: false, type: CommentType.Public }]);
   });
 
   it('should filter private comments correctly', () => {
     flaw.value.comments = [{ is_private: true, creator: 'user@example.com' } as ZodFlawCommentType];
     const { privateComments } = useFlawCommentsModel(flaw, isSaving, afterSaveSuccess);
 
-    expect(privateComments.value).toEqual([{ is_private: true, creator: 'user@example.com' }]);
+    expect(privateComments.value).toEqual(
+      [{ is_private: true, type: CommentType.Private, creator: 'user@example.com' }],
+    );
   });
 
   it('should filter system comments correctly', () => {
     flaw.value.comments = [{ creator: SYSTEM_EMAIL } as ZodFlawCommentType];
     const { systemComments } = useFlawCommentsModel(flaw, isSaving, afterSaveSuccess);
 
-    expect(systemComments.value).toEqual([{ creator: SYSTEM_EMAIL }]);
+    expect(systemComments.value).toEqual([{ creator: SYSTEM_EMAIL, type: CommentType.System }]);
   });
 
   it('should load internal comments when task_key is present', async () => {
@@ -79,7 +81,9 @@ describe('useFlawCommentsModel', () => {
     await flushPromises();
 
     expect(internalCommentsAvailable.value).toBe(true);
-    expect(internalComments.value).toEqual([{ creator: 'author', created_dt: 'date', text: 'body' }]);
+    expect(internalComments.value).toEqual(
+      [{ creator: 'author', created_dt: 'date', text: 'body', type: CommentType.Internal }],
+    );
     expect(isLoadingInternalComments.value).toBe(false);
   });
 

--- a/src/composables/useFlawCommentsModel.ts
+++ b/src/composables/useFlawCommentsModel.ts
@@ -3,7 +3,9 @@ import { computed, ref, type Ref } from 'vue';
 import { getJiraComments, postJiraComment } from '@/services/JiraService';
 import type { ZodFlawCommentType, ZodFlawType } from '@/types/zodFlaw';
 import { postFlawComment } from '@/services/FlawService';
-import { CommentType, SYSTEM_EMAIL } from '@/constants';
+import { SYSTEM_EMAIL } from '@/constants';
+import { CommentType } from '@/types';
+import { orderCommentsByDate } from '@/utils/helpers';
 
 type OsidbCommentFilter = Exclude<keyof typeof CommentType, 'Internal'>;
 type OsidbCommentFilterFunctions = Record<OsidbCommentFilter, (comment: ZodFlawCommentType) => boolean>;
@@ -14,14 +16,36 @@ const filterFunctions: OsidbCommentFilterFunctions = {
   System: (comment: any) => comment.creator === SYSTEM_EMAIL,
 };
 
+export function CommentTypeDisplay(type: CommentType | undefined) {
+  return type !== undefined ? CommentType[type] : '';
+}
+
 export function useFlawCommentsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<boolean>, afterSaveSuccess: () => void) {
   const internalCommentsAvailable = ref(false);
   const isLoadingInternalComments = ref(false);
   const internalComments = ref<ZodFlawCommentType[]>([]);
 
-  const publicComments = computed<ZodFlawCommentType[]>(() => flaw.value.comments.filter(filterFunctions.Public));
-  const privateComments = computed<ZodFlawCommentType[]>(() => flaw.value.comments.filter(filterFunctions.Private));
-  const systemComments = computed<ZodFlawCommentType[]>(() => flaw.value.comments.filter(filterFunctions.System));
+  const publicComments = computed<ZodFlawCommentType[]>(
+    () => orderCommentsByDate(
+      flaw.value.comments.filter(filterFunctions.Public)).map(c => ({ ...c, type: CommentType.Public })),
+  );
+  const privateComments = computed<ZodFlawCommentType[]>(
+    () => orderCommentsByDate(
+      flaw.value.comments.filter(filterFunctions.Private)).map(c => ({ ...c, type: CommentType.Private })),
+  );
+  const systemComments = computed<ZodFlawCommentType[]>(
+    () => orderCommentsByDate(
+      flaw.value.comments.filter(filterFunctions.System)).map(c => ({ ...c, type: CommentType.System })),
+  );
+
+  const commentsByType = computed<Record<CommentType, ZodFlawCommentType[]>>(() => {
+    return {
+      [CommentType.Public]: publicComments.value.map(c => ({ ...c, type: CommentType.Public })),
+      [CommentType.Private]: privateComments.value.map(c => ({ ...c, type: CommentType.Private })),
+      [CommentType.System]: systemComments.value.map(c => ({ ...c, type: CommentType.System })),
+      [CommentType.Internal]: internalComments.value.map(c => ({ ...c, type: CommentType.Internal })),
+    };
+  });
 
   function loadInternalComments() {
     isLoadingInternalComments.value = true;
@@ -99,6 +123,7 @@ export function useFlawCommentsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<boole
     internalComments,
     systemComments,
     addFlawComment,
+    commentsByType,
     loadInternalComments,
     isLoadingInternalComments,
     internalCommentsAvailable,

--- a/src/composables/useFlawCommentsModel.ts
+++ b/src/composables/useFlawCommentsModel.ts
@@ -3,8 +3,7 @@ import { computed, ref, type Ref } from 'vue';
 import { getJiraComments, postJiraComment } from '@/services/JiraService';
 import type { ZodFlawCommentType, ZodFlawType } from '@/types/zodFlaw';
 import { postFlawComment } from '@/services/FlawService';
-import { SYSTEM_EMAIL } from '@/constants';
-import { CommentType } from '@/types';
+import { SYSTEM_EMAIL, CommentType } from '@/constants';
 import { orderCommentsByDate } from '@/utils/helpers';
 
 type OsidbCommentFilter = Exclude<keyof typeof CommentType, 'Internal'>;

--- a/src/composables/useFlawCommentsModel.ts
+++ b/src/composables/useFlawCommentsModel.ts
@@ -27,23 +27,26 @@ export function useFlawCommentsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<boole
 
   const publicComments = computed<ZodFlawCommentType[]>(
     () => orderCommentsByDate(
-      flaw.value.comments.filter(filterFunctions.Public)).map(c => ({ ...c, type: CommentType.Public })),
+      flaw.value.comments.filter(filterFunctions.Public)).map(c => ({ ...c, type: CommentType.Public }),
+    ),
   );
   const privateComments = computed<ZodFlawCommentType[]>(
     () => orderCommentsByDate(
-      flaw.value.comments.filter(filterFunctions.Private)).map(c => ({ ...c, type: CommentType.Private })),
+      flaw.value.comments.filter(filterFunctions.Private)).map(c => ({ ...c, type: CommentType.Private }),
+    ),
   );
   const systemComments = computed<ZodFlawCommentType[]>(
     () => orderCommentsByDate(
-      flaw.value.comments.filter(filterFunctions.System)).map(c => ({ ...c, type: CommentType.System })),
+      flaw.value.comments.filter(filterFunctions.System)).map(c => ({ ...c, type: CommentType.System }),
+    ),
   );
 
   const commentsByType = computed<Record<CommentType, ZodFlawCommentType[]>>(() => {
     return {
-      [CommentType.Public]: publicComments.value.map(c => ({ ...c, type: CommentType.Public })),
-      [CommentType.Private]: privateComments.value.map(c => ({ ...c, type: CommentType.Private })),
-      [CommentType.System]: systemComments.value.map(c => ({ ...c, type: CommentType.System })),
-      [CommentType.Internal]: internalComments.value.map(c => ({ ...c, type: CommentType.Internal })),
+      [CommentType.Public]: publicComments.value,
+      [CommentType.Private]: privateComments.value,
+      [CommentType.System]: systemComments.value,
+      [CommentType.Internal]: internalComments.value,
     };
   });
 
@@ -62,7 +65,8 @@ export function useFlawCommentsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<boole
           internalCommentsAvailable.value = true;
         }
         if (res.data.comments.length >= 0) {
-          internalComments.value = parseJiraComments(res.data.comments);
+          internalComments.value = parseJiraComments(res.data.comments)
+            .map(c => ({ ...c, type: CommentType.Internal }));
         }
       })
       .catch((res) => {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,9 +1,4 @@
-export enum CommentType {
-  Public,
-  Private,
-  Internal,
-  System,
-}
+import { CommentType } from '@/types';
 
 export const SYSTEM_EMAIL = 'bugzilla@redhat.com';
 
@@ -42,3 +37,10 @@ export const allowedSources = [
   'UBUNTU',
   'UPSTREAM',
 ];
+
+export const commentTooltips: Record<CommentType, string> = {
+  [CommentType.Public]: 'Bugzilla Public - These comments are visible to everyone.',
+  [CommentType.Private]: 'Bugzilla Private - These comments are visible to Red Hat associates.',
+  [CommentType.Internal]: 'Jira Internal - These comments are visible to team members with required permissions.',
+  [CommentType.System]: 'Bugzilla System - These are auto-generated private comments.',
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,3 @@
-import { CommentType } from '@/types';
-
 export const SYSTEM_EMAIL = 'bugzilla@redhat.com';
 
 export const CVSS_V3 = 'V3';
@@ -37,6 +35,13 @@ export const allowedSources = [
   'UBUNTU',
   'UPSTREAM',
 ];
+
+export enum CommentType {
+  Public,
+  Private,
+  Internal,
+  System,
+}
 
 export const commentTooltips: Record<CommentType, string> = {
   [CommentType.Public]: 'Bugzilla Public - These comments are visible to everyone.',

--- a/src/stores/SettingsStore.ts
+++ b/src/stores/SettingsStore.ts
@@ -15,6 +15,7 @@ export const SettingsSchema = z.object({
   trackersPerPage: z.number(),
   isHidingLabels: z.boolean().optional().default(false),
   privacyNoticeShown: z.boolean().default(false),
+  singleCommentsView: z.boolean().default(false),
 });
 
 export type SettingsType = z.infer<typeof SettingsSchema>;
@@ -27,6 +28,7 @@ const defaultValues: SettingsType = {
   trackersPerPage: 10,
   isHidingLabels: false,
   privacyNoticeShown: false,
+  singleCommentsView: false,
 };
 
 export const useSettingsStore = defineStore('SettingsStore', () => {
@@ -50,12 +52,6 @@ export const useSettingsStore = defineStore('SettingsStore', () => {
       ' In some cases that information may be publicly visible.',
     });
     settings.value.privacyNoticeShown = true;
-  }
-
-  // This is to remove previous privacy notice shown flag
-  // Can be removed in future versions, when we are sure that all users have updated to the latest version
-  if (localStorage.getItem('privacyNoticeShown')) {
-    localStorage.removeItem('privacyNoticeShown');
   }
 
   function $reset() {

--- a/src/stores/SettingsStore.ts
+++ b/src/stores/SettingsStore.ts
@@ -15,7 +15,7 @@ export const SettingsSchema = z.object({
   trackersPerPage: z.number(),
   isHidingLabels: z.boolean().optional().default(false),
   privacyNoticeShown: z.boolean().default(false),
-  singleCommentsView: z.boolean().default(false),
+  unifiedCommentsView: z.boolean().default(false),
 });
 
 export type SettingsType = z.infer<typeof SettingsSchema>;
@@ -28,7 +28,7 @@ const defaultValues: SettingsType = {
   trackersPerPage: 10,
   isHidingLabels: false,
   privacyNoticeShown: false,
-  singleCommentsView: false,
+  unifiedCommentsView: false,
 };
 
 export const useSettingsStore = defineStore('SettingsStore', () => {

--- a/src/stores/__tests__/SettingsStore.spec.ts
+++ b/src/stores/__tests__/SettingsStore.spec.ts
@@ -12,7 +12,7 @@ const initialState: SettingsType = {
   trackersPerPage: 10,
   isHidingLabels: false,
   privacyNoticeShown: true,
-  singleCommentsView: false,
+  unifiedCommentsView: false,
 };
 
 // While not used in this file, store below depends on global pinia test instance
@@ -41,7 +41,7 @@ describe('settingsStore', () => {
       trackersPerPage: 1337,
       isHidingLabels: !initialState.isHidingLabels,
       privacyNoticeShown: false,
-      singleCommentsView: false,
+      unifiedCommentsView: false,
     };
 
     settingsStore.settings = settings;

--- a/src/stores/__tests__/SettingsStore.spec.ts
+++ b/src/stores/__tests__/SettingsStore.spec.ts
@@ -12,6 +12,7 @@ const initialState: SettingsType = {
   trackersPerPage: 10,
   isHidingLabels: false,
   privacyNoticeShown: true,
+  singleCommentsView: false,
 };
 
 // While not used in this file, store below depends on global pinia test instance
@@ -40,6 +41,7 @@ describe('settingsStore', () => {
       trackersPerPage: 1337,
       isHidingLabels: !initialState.isHidingLabels,
       privacyNoticeShown: false,
+      singleCommentsView: false,
     };
 
     settingsStore.settings = settings;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,10 +34,3 @@ export type {
 export type {
   ZodAlertType,
 } from '@/types/zodShared';
-
-export enum CommentType {
-  Public,
-  Private,
-  Internal,
-  System,
-}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,3 +34,10 @@ export type {
 export type {
   ZodAlertType,
 } from '@/types/zodShared';
+
+export enum CommentType {
+  Public,
+  Private,
+  Internal,
+  System,
+}

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -1,9 +1,10 @@
-import { z } from 'zod';
+import { nativeEnum, z } from 'zod';
 import { DateTime } from 'luxon';
 
 import { cveRegex } from '@/utils/helpers';
 import type { ValueOf } from '@/utils/typeHelpers';
 import { loadCweData } from '@/services/CweService';
+import { CommentType } from '@/constants';
 
 import {
   NistCvssValidationEnum,
@@ -131,6 +132,7 @@ export const ZodFlawCommentSchema = z.object({
   created_dt: zodOsimDateTime().nullish(),
   updated_dt: zodOsimDateTime().nullish(),
   alerts: z.array(ZodAlertSchema).default([]),
+  type: nativeEnum(CommentType).optional(),
 });
 
 export type ZodFlawHistoryItemType = z.infer<typeof ZodHistoryItemSchema>;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -6,7 +6,7 @@ import { watchOnce } from '@vueuse/core';
 
 import { IssuerEnum } from '@/generated-client';
 import { CVSS_V3 } from '@/constants';
-import type { ZodAffectType, ZodAffectCVSSType } from '@/types';
+import type { ZodAffectType, ZodAffectCVSSType, ZodFlawCommentType } from '@/types';
 
 export function unwrap(value: any): any {
   const unwrapped = toRaw(unref(value));
@@ -123,4 +123,18 @@ export function watchedRef<T>(initialValue?: T): [Ref<(T | undefined) | (undefin
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore - TODO: this throws an error on `yarn type-check` but IDE is happy with it
   return [refValue, hasChanged] as const;
+}
+
+export function orderCommentsByDate<T extends ZodFlawCommentType>(comments: T[]): T[] {
+  return comments.sort((a, b) => {
+    const dateA = DateTime.fromISO(a.created_dt ?? '');
+    const dateB = DateTime.fromISO(b.created_dt ?? '');
+    if (dateA < dateB) {
+      return 1;
+    }
+    if (dateA > dateB) {
+      return -1;
+    }
+    return 0;
+  });
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -125,6 +125,7 @@ export function watchedRef<T>(initialValue?: T): [Ref<(T | undefined) | (undefin
   return [refValue, hasChanged] as const;
 }
 
+// Note that Array .sort function will modify input array
 export function orderCommentsByDate<T extends ZodFlawCommentType>(comments: T[]): T[] {
   return comments.sort((a, b) => {
     const dateA = DateTime.fromISO(a.created_dt ?? '');

--- a/src/widgets/Tabs/Tabs.vue
+++ b/src/widgets/Tabs/Tabs.vue
@@ -24,13 +24,17 @@ const selectTab = (index: number) => {
 <template>
   <div>
     <ul class="nav nav-tabs">
-      <li v-for="(label,index) in labels" :key="index" class="nav-item">
+      <li
+        v-for="(label,index) in labels"
+        :key="index"
+        :title="tooltips[index]"
+        class="nav-item"
+      >
         <button
           type="button"
           class="nav-link"
           :class="{ 'active': activeTabIndex === index }"
           :disabled="disabled?.includes(index)"
-          :title="tooltips[index]"
           @click="selectTab(index)"
         >
           {{ label }}


### PR DESCRIPTION
# OSIDB-3467 Comments section display modes

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Jira ticket updated

## Summary:

Adding a new display mode to show all comment types under the same view. We are keeping previous display mode and allow users to choose their preference.

## Changes:

- Refactor `FlawComments` into smaller components for simplicity
- Relocate some comments constants/types to be globally available
- Add new single view for all comment types
- Support toggling between comments view modes
- Order comments by date descendant
- Use local storage for user display mode selection
- Make comments toolbar sticky
- Update tests

## Demo
- Working on it, (having problems with Jira stage account)

## Considerations:

- Comment toolbar sticky is mostly intended to allow users to use the view mode switch at any scroll point of the section 
- NTH - Custom comments order

Closes OSIDB-3467
