### PR TITLE
[OSIDB-4322] Change source in integration tests

### DIFF
--- a/features/pages/flaw_detail_page.py
+++ b/features/pages/flaw_detail_page.py
@@ -351,7 +351,7 @@ class FlawDetailPage(BasePage):
         if "" in all_values:
             all_values.remove("")
         if all_values:
-            updated_value = all_values[-1]
+            updated_value = "REDHAT" if "REDHAT" in all_values else all_values[0]
             field_select.select_element_by_text(updated_value)
         else:
             updated_value = current_value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-selenium
+selenium==4.31.0
 behave
 requests
 selenium-page-factory


### PR DESCRIPTION
[OSIDB-4322] Change source in integration tests

## Checklist:

- [x] Commits consolidated
- [-] Changelog updated
- [-] Test cases added/updated
- [x] Integration tests updated
- [x] Jira ticket updated

## Summary:

`all_values[-1]` corresponded to "**XEN**" source which is hidden in the DOM and a recent Selenium version made this fail the test
## Considerations:

Closes OSIDB-4322