### PR TITLE
✨ API Keys migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Fix wrong affected component names from OCI and RPMMOD types (`OSIDB-4358`)
 
 ### Changed
+* Bugzilla and Jira api keys are now saved on the backend (`OSIDB-4312`)
+* Show api key is now a field button instead a separate radio input (`OSIDB-4312`)
+
+### Changed
 * Improve loading performance by splitting up flaw and affect requests  (`OSIDB-4266`)
 * Don't update Flaw when only affects are modified (`OSIDB-4270`)
 

--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref, watch, reactive } from 'vue';
+import { ref, watch, reactive, computed } from 'vue';
 
 import { useSettingsStore } from '@/stores/SettingsStore';
 import { osimRuntime } from '@/stores/osimRuntime';
+import LoadingSpinner from '@/widgets/LoadingSpinner/LoadingSpinner.vue';
 
 type SensitiveFormInput = 'password' | 'text';
 
@@ -20,6 +21,8 @@ watch(() => settingsStore.apiKeys, (newApiKeys) => {
   formData.bugzillaApiKey = newApiKeys.bugzillaApiKey;
   formData.jiraApiKey = newApiKeys.jiraApiKey;
 }, { immediate: true });
+
+const apiKeysSyncing = computed(() => settingsStore.isLoadingApiKeys || settingsStore.isSavingApiKeys);
 
 const onSubmit = async () => {
   try {
@@ -72,6 +75,7 @@ const isValid = computed(() => ({
             type="radio"
             name="revealSensitive"
             value="password"
+            :disabled="apiKeysSyncing"
           >
           <span class="form-check-label">Hide Password Values</span>
         </label>
@@ -82,6 +86,7 @@ const isValid = computed(() => ({
             type="radio"
             name="revealSensitive"
             value="text"
+            :disabled="apiKeysSyncing"
           >
           <span class="form-check-label">Reveal Password Values</span>
         </label>
@@ -95,6 +100,7 @@ const isValid = computed(() => ({
             class="form-control"
             :type="revealSensitive"
             :class="{'is-invalid': !isValid.bugzillaApiKey,'is-valid': isValid.bugzillaApiKey}"
+            :disabled="apiKeysSyncing"
             placeholder="[none saved]"
           />
           <span
@@ -130,6 +136,7 @@ const isValid = computed(() => ({
             class="form-control"
             :type="revealSensitive"
             :class="{'is-invalid': !isValid.jiraApiKey,'is-valid': isValid.jiraApiKey}"
+            :disabled="apiKeysSyncing"
             placeholder="[none saved]"
           />
           <span
@@ -161,8 +168,14 @@ const isValid = computed(() => ({
         <button
           type="submit"
           class="btn btn-primary"
+          :disabled="apiKeysSyncing"
         >
-          Save Settings
+          <LoadingSpinner
+            v-if="settingsStore.isSavingApiKeys"
+            type="border"
+            class="spinner-border-sm me-2 d-inline-block"
+          />
+          {{ settingsStore.isSavingApiKeys ? 'Saving...' : 'Save Settings' }}
         </button>
       </div>
     </form>

--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -5,10 +5,10 @@ import { useSettingsStore } from '@/stores/SettingsStore';
 import { osimRuntime } from '@/stores/osimRuntime';
 import LoadingSpinner from '@/widgets/LoadingSpinner/LoadingSpinner.vue';
 
-type SensitiveFormInput = 'password' | 'text';
-
 const settingsStore = useSettingsStore();
-const revealSensitive = ref<SensitiveFormInput>('password');
+
+const showBugzillaKey = ref(false);
+const showJiraKey = ref(false);
 
 // Create reactive form data for API keys only
 const formData = reactive({
@@ -67,42 +67,28 @@ const isValid = computed(() => ({
         label="Bugzilla API Key"
         :error="errors.bugzillaApiKey"
       /> -->
-      <div class="form-control mb-3">
-        <label class="form-check">
-          <input
-            v-model="revealSensitive"
-            class="form-check-input"
-            type="radio"
-            name="revealSensitive"
-            value="password"
-            :disabled="apiKeysSyncing"
-          >
-          <span class="form-check-label">Hide Password Values</span>
-        </label>
-        <label class="form-check">
-          <input
-            v-model="revealSensitive"
-            class="form-check-input"
-            type="radio"
-            name="revealSensitive"
-            value="text"
-            :disabled="apiKeysSyncing"
-          >
-          <span class="form-check-label">Reveal Password Values</span>
-        </label>
-      </div>
 
       <div class="form-control mb-3">
         <label class="d-block">
           <span class="form-label">Bugzilla API Key</span>
-          <input
-            v-model="formData.bugzillaApiKey"
-            class="form-control"
-            :type="revealSensitive"
-            :class="{'is-invalid': !isValid.bugzillaApiKey,'is-valid': isValid.bugzillaApiKey}"
-            :disabled="apiKeysSyncing"
-            placeholder="[none saved]"
-          />
+          <div class="input-group">
+            <input
+              v-model="formData.bugzillaApiKey"
+              class="form-control"
+              :type="showBugzillaKey ? 'text' : 'password'"
+              :class="{'is-invalid': !isValid.bugzillaApiKey,'is-valid': isValid.bugzillaApiKey}"
+              :disabled="apiKeysSyncing"
+              placeholder="[none saved]"
+            />
+            <button
+              type="button"
+              class="btn btn-dark eye-toggle-btn"
+              :disabled="apiKeysSyncing"
+              @click="showBugzillaKey = !showBugzillaKey"
+            >
+              <i :class="showBugzillaKey ? 'bi bi-eye-slash' : 'bi bi-eye'"></i>
+            </button>
+          </div>
           <span
             v-if="!isValid.bugzillaApiKey"
             class="invalid-feedback d-block"
@@ -131,14 +117,24 @@ const isValid = computed(() => ({
       <div class="form-control mb-3">
         <label class="d-block">
           <span class="form-label">JIRA API Key</span>
-          <input
-            v-model="formData.jiraApiKey"
-            class="form-control"
-            :type="revealSensitive"
-            :class="{'is-invalid': !isValid.jiraApiKey,'is-valid': isValid.jiraApiKey}"
-            :disabled="apiKeysSyncing"
-            placeholder="[none saved]"
-          />
+          <div class="input-group">
+            <input
+              v-model="formData.jiraApiKey"
+              class="form-control"
+              :type="showJiraKey ? 'text' : 'password'"
+              :class="{'is-invalid': !isValid.jiraApiKey,'is-valid': isValid.jiraApiKey}"
+              :disabled="apiKeysSyncing"
+              placeholder="[none saved]"
+            />
+            <button
+              type="button"
+              class="btn btn-dark eye-toggle-btn"
+              :disabled="apiKeysSyncing"
+              @click="showJiraKey = !showJiraKey"
+            >
+              <i :class="showJiraKey ? 'bi bi-eye-slash' : 'bi bi-eye'"></i>
+            </button>
+          </div>
           <span
             v-if="!isValid.jiraApiKey"
             class="invalid-feedback d-block"

--- a/src/components/__tests__/Navbar.spec.ts
+++ b/src/components/__tests__/Navbar.spec.ts
@@ -51,9 +51,21 @@ describe('navbar', () => {
     const settingStore = useSettingsStore(pinia);
     settingStore.$state = {
       settings: {
-        ...settingStore.$state.settings,
         showNotifications: true,
+        affectsPerPage: 10,
+        trackersPerPage: 10,
+        isHidingLabels: false,
+        privacyNoticeShown: false,
+        unifiedCommentsView: false,
+        affectsColumnWidths: [],
+        trackersColumnWidths: [],
       },
+      apiKeys: {
+        bugzillaApiKey: '',
+        jiraApiKey: '',
+      },
+      isLoadingApiKeys: false,
+      isSavingApiKeys: false,
     };
     subject = mount(Navbar, {
       global: {
@@ -84,9 +96,21 @@ describe('navbar', () => {
     const settingStore = useSettingsStore(pinia);
     settingStore.$state = {
       settings: {
-        ...settingStore.$state.settings,
         showNotifications: true,
+        affectsPerPage: 10,
+        trackersPerPage: 10,
+        isHidingLabels: false,
+        privacyNoticeShown: true,
+        unifiedCommentsView: false,
+        affectsColumnWidths: [],
+        trackersColumnWidths: [],
       },
+      apiKeys: {
+        bugzillaApiKey: '',
+        jiraApiKey: '',
+      },
+      isLoadingApiKeys: false,
+      isSavingApiKeys: false,
     };
     subject = mount(Navbar, {
       global: {
@@ -102,7 +126,7 @@ describe('navbar', () => {
     expect(icon.classes()).toContain('bi-bell-fill');
     const badge = button.find('.osim-notification-count');
     expect(badge.exists()).toBeTruthy();
-    expect(badge.text()).toBe('2');
+    expect(badge.text()).toBe('3');
     await icon.trigger('click');
     expect(settingStore.settings.showNotifications).toBe(false);
     icon = subject.find('.osim-notification-button .notification-icon');
@@ -122,9 +146,21 @@ describe('navbar', () => {
     const settingStore = useSettingsStore(pinia);
     settingStore.$state = {
       settings: {
-        ...settingStore.$state.settings,
         showNotifications: false,
+        affectsPerPage: 10,
+        trackersPerPage: 10,
+        isHidingLabels: false,
+        privacyNoticeShown: false,
+        unifiedCommentsView: false,
+        affectsColumnWidths: [],
+        trackersColumnWidths: [],
       },
+      apiKeys: {
+        bugzillaApiKey: '',
+        jiraApiKey: '',
+      },
+      isLoadingApiKeys: false,
+      isSavingApiKeys: false,
     };
     subject = mount(Navbar, {
       global: {
@@ -155,9 +191,21 @@ describe('navbar', () => {
     const settingStore = useSettingsStore(pinia);
     settingStore.$state = {
       settings: {
-        ...settingStore.$state.settings,
         showNotifications: false,
+        affectsPerPage: 10,
+        trackersPerPage: 10,
+        isHidingLabels: false,
+        privacyNoticeShown: false,
+        unifiedCommentsView: false,
+        affectsColumnWidths: [],
+        trackersColumnWidths: [],
       },
+      apiKeys: {
+        bugzillaApiKey: '',
+        jiraApiKey: '',
+      },
+      isLoadingApiKeys: false,
+      isSavingApiKeys: false,
     };
     subject = mount(Navbar, {
       global: {

--- a/src/components/__tests__/ToastContainer.spec.ts
+++ b/src/components/__tests__/ToastContainer.spec.ts
@@ -28,10 +28,21 @@ describe('toastContainer', () => {
     const settingStore = useSettingsStore(pinia);
     settingStore.$state = {
       settings: {
-        ...settingStore.$state.settings,
         showNotifications: true,
         privacyNoticeShown: true,
+        affectsPerPage: 10,
+        trackersPerPage: 10,
+        isHidingLabels: false,
+        unifiedCommentsView: false,
+        affectsColumnWidths: [],
+        trackersColumnWidths: [],
       },
+      apiKeys: {
+        bugzillaApiKey: '',
+        jiraApiKey: '',
+      },
+      isLoadingApiKeys: false,
+      isSavingApiKeys: false,
     };
     const toastStore = useToastStore(pinia);
     toastStore.addToast({
@@ -68,10 +79,21 @@ describe('toastContainer', () => {
     const settingStore = useSettingsStore(pinia);
     settingStore.$state = {
       settings: {
-        ...settingStore.$state.settings,
         showNotifications: true,
         privacyNoticeShown: true,
+        affectsPerPage: 10,
+        trackersPerPage: 10,
+        isHidingLabels: false,
+        unifiedCommentsView: false,
+        affectsColumnWidths: [],
+        trackersColumnWidths: [],
       },
+      apiKeys: {
+        bugzillaApiKey: '',
+        jiraApiKey: '',
+      },
+      isLoadingApiKeys: false,
+      isSavingApiKeys: false,
     };
     subject = mount(ToastContainer, {
       global: {
@@ -97,9 +119,21 @@ describe('toastContainer', () => {
       const settingStore = useSettingsStore(pinia);
       settingStore.$state = {
         settings: {
-          ...settingStore.$state.settings,
           showNotifications: false,
+          affectsPerPage: 10,
+          trackersPerPage: 10,
+          isHidingLabels: false,
+          privacyNoticeShown: false,
+          unifiedCommentsView: false,
+          affectsColumnWidths: [],
+          trackersColumnWidths: [],
         },
+        apiKeys: {
+          bugzillaApiKey: '',
+          jiraApiKey: '',
+        },
+        isLoadingApiKeys: false,
+        isSavingApiKeys: false,
       };
       const toastStore = useToastStore(pinia);
       toastStore.addToast({

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -124,9 +124,8 @@ const router = createRouter({
 });
 
 function areApiKeysNotSet(): boolean {
-  const {
-    settings: { bugzillaApiKey, jiraApiKey },
-  } = useSettingsStore();
+  const settingsStore = useSettingsStore();
+  const { bugzillaApiKey, jiraApiKey } = settingsStore.apiKeys;
   return !bugzillaApiKey || !jiraApiKey;
 }
 

--- a/src/services/JiraService.ts
+++ b/src/services/JiraService.ts
@@ -3,6 +3,7 @@ import { createSuccessHandler, createCatchHandler } from '@/composables/service-
 import { useSettingsStore } from '@/stores/SettingsStore';
 import { useToastStore } from '@/stores/ToastStore';
 import { getNextAccessToken } from '@/services/OsidbAuthService';
+import { getApiKeysFromBackend } from '@/services/ApiKeyService';
 import {
   osimRuntime,
 } from '@/stores/osimRuntime';
@@ -172,15 +173,15 @@ async function osimRequestHeaders() {
   const osidbToken = await getNextAccessToken();
   if (osimRuntime.value.env === 'prod') {
     return new Headers({
-      'Authorization': `Bearer ${settingsStore.settings.jiraApiKey}`,
+      'Authorization': `Bearer ${settingsStore.apiKeys.jiraApiKey}`,
       'Content-Type': 'application/json',
     });
   } else {
+    const integrationTokens = await getApiKeysFromBackend();
     return new Headers({
       'Authorization': `Bearer ${osidbToken}`,
       'Content-Type': 'application/json',
-      'Bugzilla-Api-Key': settingsStore.settings.bugzillaApiKey,
-      'Jira-Api-Key': settingsStore.settings.jiraApiKey,
+      'Jira-Api-Key': integrationTokens.jira || '',
       'User-Agent': 'OSIM',
     });
   }

--- a/src/stores/SettingsStore.ts
+++ b/src/stores/SettingsStore.ts
@@ -1,15 +1,19 @@
+import { ref } from 'vue';
+
 import { defineStore } from 'pinia';
 import { z } from 'zod';
 import { useLocalStorage } from '@vueuse/core';
 
+import { saveApiKeysToBackend, getApiKeysFromBackend } from '@/services/ApiKeyService';
+
 import { useToastStore } from './ToastStore';
 
-export const SettingsSchema = z.object({
-  // bugzillaApiKey: z.string().length(
-  //   32, {message: 'Bugzilla API Key is the wrong length!'}
-  // ).optional(),
+export const ApiKeysSchema = z.object({
   bugzillaApiKey: z.string().optional().or(z.literal('')).default(''),
   jiraApiKey: z.string().optional().or(z.literal('')).default(''),
+});
+
+export const PersistentSettingsSchema = z.object({
   showNotifications: z.boolean(),
   affectsPerPage: z.number(),
   trackersPerPage: z.number(),
@@ -20,11 +24,18 @@ export const SettingsSchema = z.object({
   trackersColumnWidths: z.array(z.number()).default([]),
 });
 
-export type SettingsType = z.infer<typeof SettingsSchema>;
+export const SettingsSchema = ApiKeysSchema.merge(PersistentSettingsSchema);
 
-const defaultValues: SettingsType = {
+export type SettingsType = z.infer<typeof SettingsSchema>;
+export type ApiKeysType = z.infer<typeof ApiKeysSchema>;
+export type PersistentSettingsType = z.infer<typeof PersistentSettingsSchema>;
+
+const defaultApiKeys: ApiKeysType = {
   bugzillaApiKey: '',
   jiraApiKey: '',
+};
+
+const defaultPersistentSettings: PersistentSettingsType = {
   showNotifications: false,
   affectsPerPage: 10,
   trackersPerPage: 10,
@@ -35,35 +46,155 @@ const defaultValues: SettingsType = {
   trackersColumnWidths: [],
 };
 
+const LEGACY_SETTINGS_KEY = 'OSIM::USER-SETTINGS';
+
+async function migrateApiKeysFromLocalStorage(apiKeys: any, persistentSettings: any, addToast: any) {
+  try {
+    const legacySettings = JSON.parse(localStorage.getItem(LEGACY_SETTINGS_KEY) ?? '{}');
+
+    const hasLegacyApiKeys = legacySettings.bugzillaApiKey || legacySettings.jiraApiKey;
+    if (!hasLegacyApiKeys) {
+      return;
+    }
+
+    console.log('🔄 Migrating API keys from localStorage to backend...');
+
+    const keysToMigrate: any = {};
+    if (legacySettings.bugzillaApiKey) {
+      keysToMigrate.bugzilla = legacySettings.bugzillaApiKey;
+    }
+    if (legacySettings.jiraApiKey) {
+      keysToMigrate.jira = legacySettings.jiraApiKey;
+    }
+
+    await saveApiKeysToBackend(keysToMigrate);
+
+    const retrievedKeys = await getApiKeysFromBackend();
+
+    apiKeys.value = {
+      bugzillaApiKey: retrievedKeys.bugzilla || '',
+      jiraApiKey: retrievedKeys.jira || '',
+    };
+
+    const cleanedSettings = { ...legacySettings };
+    delete cleanedSettings.bugzillaApiKey;
+    delete cleanedSettings.jiraApiKey;
+
+    localStorage.setItem(LEGACY_SETTINGS_KEY, JSON.stringify(cleanedSettings));
+
+    addToast({
+      title: 'API Keys Migrated',
+      body: 'Your API keys have been securely moved to the server and will no longer be stored in your browser.',
+      css: 'success',
+    });
+
+    console.log('✅ API keys migration completed successfully');
+  } catch (error) {
+    console.error('❌ Failed to migrate API keys:', error);
+    addToast({
+      title: 'Migration Warning',
+      body: 'Failed to migrate API keys to server. You may need to re-enter them in Settings.',
+      css: 'warning',
+    });
+  }
+}
+
 export const useSettingsStore = defineStore('SettingsStore', () => {
   const { addToast } = useToastStore();
 
-  const settings = useLocalStorage('OSIM::USER-SETTINGS', structuredClone(defaultValues));
+  const apiKeys = ref<ApiKeysType>(structuredClone(defaultApiKeys));
 
-  const validatedSettings = SettingsSchema.safeParse(settings.value);
-  if (validatedSettings.success) {
-    if (JSON.stringify(validatedSettings.data) !== JSON.stringify(settings.value)) {
-      settings.value = validatedSettings.data;
+  const persistentSettings = useLocalStorage('OSIM::USER-SETTINGS', structuredClone(defaultPersistentSettings));
+
+  const validatedPersistentSettings = PersistentSettingsSchema.safeParse(persistentSettings.value);
+  if (validatedPersistentSettings.success) {
+    if (JSON.stringify(validatedPersistentSettings.data) !== JSON.stringify(persistentSettings.value)) {
+      persistentSettings.value = validatedPersistentSettings.data;
     }
   } else {
-    settings.value = structuredClone(defaultValues);
+    persistentSettings.value = structuredClone(defaultPersistentSettings);
   }
 
-  if (!settings.value.privacyNoticeShown) {
+  if (!persistentSettings.value.privacyNoticeShown) {
     addToast({
       title: 'Privacy Notice',
       body: 'OSIM transmits input information externally to Bugzilla for the purpose of retrieving bug data.' +
       ' In some cases that information may be publicly visible.',
     });
-    settings.value.privacyNoticeShown = true;
+    persistentSettings.value.privacyNoticeShown = true;
   }
 
+  async function loadApiKeysFromBackend() {
+    try {
+      const retrievedKeys = await getApiKeysFromBackend();
+      apiKeys.value = {
+        bugzillaApiKey: retrievedKeys.bugzilla || '',
+        jiraApiKey: retrievedKeys.jira || '',
+      };
+    } catch (error) {
+      console.debug('No API keys found on server or failed to retrieve them');
+    }
+  }
+
+  const isTestEnvironment = (typeof window !== 'undefined' && (window as any).__vitest__ !== undefined)
+    || (typeof import.meta !== 'undefined' && import.meta.env?.MODE === 'test');
+
+  if (!isTestEnvironment) {
+    Promise.resolve()
+      .then(() => loadApiKeysFromBackend())
+      .then(() => migrateApiKeysFromLocalStorage(apiKeys, persistentSettings, addToast))
+      .catch((error) => {
+        console.error('Error during API keys initialization:', error);
+      });
+  }
+
+  const settings = persistentSettings;
+
   function $reset() {
-    settings.value = structuredClone(defaultValues);
+    apiKeys.value = structuredClone(defaultApiKeys);
+    persistentSettings.value = structuredClone(defaultPersistentSettings);
+  }
+
+  async function updateApiKeys(newApiKeys: Partial<ApiKeysType>) {
+    try {
+      console.log('SettingsStore: updateApiKeys called with:', newApiKeys);
+
+      apiKeys.value = {
+        ...apiKeys.value,
+        ...newApiKeys,
+      };
+
+      const keysToSave: any = {};
+      if (newApiKeys.bugzillaApiKey !== undefined) {
+        keysToSave.bugzilla = newApiKeys.bugzillaApiKey;
+      }
+      if (newApiKeys.jiraApiKey !== undefined) {
+        keysToSave.jira = newApiKeys.jiraApiKey;
+      }
+
+      console.log('SettingsStore: keysToSave (backend format):', keysToSave);
+      await saveApiKeysToBackend(keysToSave);
+
+      addToast({
+        title: 'Success!',
+        body: 'API keys updated and saved securely',
+        css: 'success',
+      });
+    } catch (error) {
+      console.error('Failed to update API keys:', error);
+      addToast({
+        title: 'Error',
+        body: 'Failed to save API keys. Please try again.',
+        css: 'danger',
+      });
+      throw error;
+    }
   }
 
   return {
     $reset,
     settings,
+    apiKeys,
+    updateApiKeys,
   };
 });

--- a/src/stores/SettingsStore.ts
+++ b/src/stores/SettingsStore.ts
@@ -104,6 +104,9 @@ export const useSettingsStore = defineStore('SettingsStore', () => {
 
   const apiKeys = ref<ApiKeysType>(structuredClone(defaultApiKeys));
 
+  const isLoadingApiKeys = ref<boolean>(false);
+  const isSavingApiKeys = ref<boolean>(false);
+
   const persistentSettings = useLocalStorage('OSIM::USER-SETTINGS', structuredClone(defaultPersistentSettings));
 
   const validatedPersistentSettings = PersistentSettingsSchema.safeParse(persistentSettings.value);
@@ -126,6 +129,7 @@ export const useSettingsStore = defineStore('SettingsStore', () => {
 
   async function loadApiKeysFromBackend() {
     try {
+      isLoadingApiKeys.value = true;
       const retrievedKeys = await getApiKeysFromBackend();
       apiKeys.value = {
         bugzillaApiKey: retrievedKeys.bugzilla || '',
@@ -133,6 +137,8 @@ export const useSettingsStore = defineStore('SettingsStore', () => {
       };
     } catch (error) {
       console.debug('No API keys found on server or failed to retrieve them');
+    } finally {
+      isLoadingApiKeys.value = false;
     }
   }
 
@@ -157,6 +163,7 @@ export const useSettingsStore = defineStore('SettingsStore', () => {
 
   async function updateApiKeys(newApiKeys: Partial<ApiKeysType>) {
     try {
+      isSavingApiKeys.value = true;
       console.log('SettingsStore: updateApiKeys called with:', newApiKeys);
 
       apiKeys.value = {
@@ -188,6 +195,8 @@ export const useSettingsStore = defineStore('SettingsStore', () => {
         css: 'danger',
       });
       throw error;
+    } finally {
+      isSavingApiKeys.value = false;
     }
   }
 
@@ -195,6 +204,8 @@ export const useSettingsStore = defineStore('SettingsStore', () => {
     $reset,
     settings,
     apiKeys,
+    isLoadingApiKeys,
+    isSavingApiKeys,
     updateApiKeys,
   };
 });

--- a/src/stores/UserStore.ts
+++ b/src/stores/UserStore.ts
@@ -133,7 +133,7 @@ export const useUserStore = defineStore('UserStore', () => {
   });
 
   watch(
-    () => settingsStore.settings.jiraApiKey,
+    () => settingsStore.apiKeys.jiraApiKey,
     async () => {
       await updateJiraUsername();
     },

--- a/src/stores/__tests__/SettingsStore.spec.ts
+++ b/src/stores/__tests__/SettingsStore.spec.ts
@@ -2,11 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { createPinia, setActivePinia } from 'pinia';
 
-import { useSettingsStore, type SettingsType } from '@/stores/SettingsStore';
+import { useSettingsStore, type PersistentSettingsType } from '@/stores/SettingsStore';
 
-const initialState: SettingsType = {
-  bugzillaApiKey: '',
-  jiraApiKey: '',
+const initialState: PersistentSettingsType = {
   showNotifications: false,
   affectsPerPage: 10,
   trackersPerPage: 10,
@@ -36,8 +34,6 @@ describe('settingsStore', () => {
 
   it('saves values', () => {
     const settings = {
-      bugzillaApiKey: 'beep-beep-who-got-the-keys-to-the-jeep',
-      jiraApiKey: 'beep-beep-who-got-the-keys-to-the-jeep',
       showNotifications: !initialState.showNotifications,
       affectsPerPage: 1337,
       trackersPerPage: 1337,

--- a/src/views/__tests__/__snapshots__/SettingsView.spec.ts.snap
+++ b/src/views/__tests__/__snapshots__/SettingsView.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`settingsView > should render 1`] = `
 "<main class="mt-3">
   <div data-v-4b5aabe5="" class="osim-content container">
     <h1 data-v-4b5aabe5="" class="mb-3">Settings</h1>
-    <div data-v-4b5aabe5="" class="alert alert-info" role="alert"> These values are saved in browser local storage, and should persist across tabs and browser sessions. Ensure that security best practices are followed. </div>
+    <div data-v-4b5aabe5="" class="alert alert-info" role="alert"> API keys are saved securely on the backend and will persist across sessions. </div>
     <!--@submit.prevent="settingsStore.save(settings)"-->
     <form data-v-4b5aabe5="" class="osim-settings">
       <!-- <LabelInput
@@ -12,8 +12,9 @@ exports[`settingsView > should render 1`] = `
         label="Bugzilla API Key"
         :error="errors.bugzillaApiKey"
       /> -->
-      <div data-v-4b5aabe5="" class="form-control mb-3"><label data-v-4b5aabe5="" class="form-check"><input data-v-4b5aabe5="" class="form-check-input" type="radio" name="revealSensitive" value="password"><span data-v-4b5aabe5="" class="form-check-label">Hide Password Values</span></label><label data-v-4b5aabe5="" class="form-check"><input data-v-4b5aabe5="" class="form-check-input" type="radio" name="revealSensitive" value="text"><span data-v-4b5aabe5="" class="form-check-label">Reveal Password Values</span></label></div>
-      <div data-v-4b5aabe5="" class="form-control mb-3"><label data-v-4b5aabe5="" class="d-block"><span data-v-4b5aabe5="" class="form-label">Bugzilla API Key</span><input data-v-4b5aabe5="" class="form-control is-invalid" type="password" placeholder="[none saved]"><span data-v-4b5aabe5="" class="invalid-feedback d-block"> Please provide a Bugzilla key. </span></label>
+      <div data-v-4b5aabe5="" class="form-control mb-3"><label data-v-4b5aabe5="" class="d-block"><span data-v-4b5aabe5="" class="form-label">Bugzilla API Key</span>
+          <div data-v-4b5aabe5="" class="input-group"><input data-v-4b5aabe5="" class="form-control is-invalid" type="password" placeholder="[none saved]"><button data-v-4b5aabe5="" type="button" class="btn btn-dark eye-toggle-btn"><i data-v-4b5aabe5="" class="bi bi-eye"></i></button></div><span data-v-4b5aabe5="" class="invalid-feedback d-block"> Please provide a Bugzilla key. </span>
+        </label>
         <div data-v-4b5aabe5="" class="form-text">
           <p data-v-4b5aabe5="">Required for actions which interface with Bugzilla.</p>
           <details data-v-4b5aabe5="">
@@ -28,7 +29,9 @@ exports[`settingsView > should render 1`] = `
           </details>
         </div>
       </div>
-      <div data-v-4b5aabe5="" class="form-control mb-3"><label data-v-4b5aabe5="" class="d-block"><span data-v-4b5aabe5="" class="form-label">JIRA API Key</span><input data-v-4b5aabe5="" class="form-control is-invalid" type="password" placeholder="[none saved]"><span data-v-4b5aabe5="" class="invalid-feedback d-block"> Please provide a Jira key. </span></label>
+      <div data-v-4b5aabe5="" class="form-control mb-3"><label data-v-4b5aabe5="" class="d-block"><span data-v-4b5aabe5="" class="form-label">JIRA API Key</span>
+          <div data-v-4b5aabe5="" class="input-group"><input data-v-4b5aabe5="" class="form-control is-invalid" type="password" placeholder="[none saved]"><button data-v-4b5aabe5="" type="button" class="btn btn-dark eye-toggle-btn"><i data-v-4b5aabe5="" class="bi bi-eye"></i></button></div><span data-v-4b5aabe5="" class="invalid-feedback d-block"> Please provide a Jira key. </span>
+        </label>
         <div data-v-4b5aabe5="" class="form-text">
           <p data-v-4b5aabe5="">Required for actions which interface with JIRA.</p>
           <details data-v-4b5aabe5="">
@@ -44,6 +47,9 @@ exports[`settingsView > should render 1`] = `
           </details>
         </div>
       </div>
+      <div data-v-4b5aabe5="" class="mt-4"><button data-v-4b5aabe5="" type="submit" class="btn btn-primary">
+          <!--v-if--> Save Settings
+        </button></div>
     </form>
   </div>
 </main>"


### PR DESCRIPTION
# OSIDB-4312 API Keys backend migration

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [-] Integration tests updated
- [x] Jira ticket updated

## Summary:

Instead, OSIM should send a PATCH /osidb/integrations request with the JIRA/BZ token the user has provided.

OSIM should not need to provide the BZ/JIRA HTTP headers when sending requests to OSIDB that require the user's BZ/JIRA tokens, OSIDB will fetch them automatically if the user has already stored them (if not stored, the server will reply with 400 Error so OSIM should still handle the case in which the user has not yet set their tokens).

For direct OSIM-JIRA integration, the user's tokens can be fetched with a GET /osidb/integrations request, the tokens should only be stored in-memory.

The tokens' values should not be displayed back to the user in the settings page.

## Changes:

- **Split settings storage**: API keys now saved securely on backend (/osidb/integrations), UI preferences remain in localStorage
- **New ApiKeyService**: Added `saveApiKeysToBackend()` and `getApiKeysFromBackend()` methods
- **Settings form refactor**: Separate reactive form data for API keys with async backend submission
- **Service updates**: `JiraService` and `OsidbAuthService` updated to fetch API keys from backend instead of localStorage

## Considerations:

- Direct settings store mutation (settingsStore.settings = values) no longer works with split storage (api keys + persistent settings)
- Form inputs needed separate reactive state since API keys now async-loaded from backend
- Headers logic simplified by removing API keys from default OSIDB requests (now fetched per-service)

Closes OSIDB-4312
