### PR TITLE
[OSIDB-4272] Error propagation

### DIFF
--- a/src/components/CweSelector/CweSelector.vue
+++ b/src/components/CweSelector/CweSelector.vue
@@ -7,7 +7,7 @@ import type { CWEMemberType } from '@/types/mitreCwe';
 import { loadCweData } from '@/services/CweService';
 
 withDefaults(defineProps<{
-  error?: string;
+  error?: null | string;
   label?: string;
 }>(), {
   label: '',

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -8,6 +8,8 @@ import { IssuerEnum } from '@/generated-client';
 import { CVSS_V3 } from '@/constants';
 import type { ZodAffectType, ZodAffectCVSSType, ZodFlawCommentType } from '@/types';
 
+import type { DeepMapValues } from './typeHelpers';
+
 export function unwrap(value: any): any {
   const unwrapped = toRaw(unref(value));
   return isUnwrappable(unwrapped) ? unwrap(unwrapped) : unwrapped;
@@ -45,7 +47,11 @@ const isNonEmptyArray = (value: any) => R.is(Array, value) && value.length > 0;
 const isNonArrayObject = (value: any) => R.is(Object, value) && !R.is(Array, value);
 const isDeepMappable = (value: DeepMappable) => isNonEmptyArray(value) || isNonArrayObject(value);
 
-export const deepMap = (transform: (arg: any) => any, object: DeepMappable): any =>
+type deepMapOverload = {
+  <T extends object, K>(transform: (arg: any) => K, object: T): DeepMapValues<T, K>;
+  <T, K>(transform: (arg: any) => K, object: T[]): K[];
+};
+export const deepMap: deepMapOverload = (transform: (arg: any) => any, object: DeepMappable): any =>
   R.map(
     (val: any) => isDeepMappable(val)
       ? deepMap(transform, val)

--- a/src/utils/typeHelpers.ts
+++ b/src/utils/typeHelpers.ts
@@ -3,3 +3,15 @@ export type ValueOf<T> = T[keyof T];
 export type Nullable<T> = null | T | undefined;
 
 export type NonNullable<T> = T extends null | undefined ? never : T;
+
+export type DeepMapValues<T, V> = T extends Array<infer U>
+  ? DeepMapValues<U, V>[]
+  : T extends object
+    ? { [K in keyof T]: DeepMapValues<T[K], V> }
+    : V;
+
+export type DeepNullable<T> = T extends Array<infer U>
+  ? DeepNullable<U>[] | null
+  : T extends object
+    ? { [K in keyof T]: DeepNullable<T[K]> }
+    : null | T;

--- a/src/widgets/LabelTagsInput/LabelTagsInput.vue
+++ b/src/widgets/LabelTagsInput/LabelTagsInput.vue
@@ -2,7 +2,7 @@
 import TagsInput from '@/widgets/TagsInput/TagsInput.vue';
 
 withDefaults(defineProps<{
-  error?: string | string[];
+  error?: (null | string)[] | null | string;
   label?: string;
 }>(), {
   label: '',

--- a/src/widgets/LabelTextarea/LabelTextarea.vue
+++ b/src/widgets/LabelTextarea/LabelTextarea.vue
@@ -4,7 +4,7 @@ import type { TextareaHTMLAttributes } from 'vue';
 
 withDefaults(defineProps<{
   disabled?: boolean;
-  error?: string;
+  error?: null | string;
   label: string;
   loading?: boolean;
   modelValue: null | string | undefined;

--- a/src/widgets/TagsInput/TagsInput.vue
+++ b/src/widgets/TagsInput/TagsInput.vue
@@ -4,7 +4,7 @@ import { ref, computed } from 'vue';
 import { useDraggable } from '@/composables/useDraggable';
 
 const props = withDefaults(defineProps<{
-  error?: string | string[];
+  error?: (null | string)[] | null | string;
   readOnly?: boolean;
 }>(), {
   error: '',


### PR DESCRIPTION
# [OSIDB-4272] Error propagation

## Checklist:

- [x] Commits consolidated
- [-] Changelog updated
- [x] Test cases added/updated
- [-] Integration tests updated
- [x] Jira ticket updated

## Summary:

`errors` is a computed property that is updated every time the flaw changes, this means that the whole `FlawForm` is re-rendered, this introduces some performance issues in Flaws with a lot of affects. I've changed the `composed` to diff the errors and if nothing changed return the previous value which is already cached by Vue, reducing re-renders.

## Changes:

- Added `DeepMapValues` and `DeepNullable` type helpers
- Improved type definitions for `deepMap` helper
- Fixed flaw error propagation
- Fixed type errors that happened after tightening the definitions for the `error` prop 

## Considerations:

Closes OSIDB-4272