### PR TITLE
🐛 Fix PURL parsing component for OCI and RPMMOD types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 * Fix performance issues with affects updates (`OSIDB-4273`)
+* Fix wrong affected component names from OCI and RPMMOD types (`OSIDB-4358`)
 
 ### Changed
 * Improve loading performance by splitting up flaw and affect requests  (`OSIDB-4266`)

--- a/src/components/FlawAffects/FlawAffectsTableRow.vue
+++ b/src/components/FlawAffects/FlawAffectsTableRow.vue
@@ -60,7 +60,20 @@ const handleKeystroke = (event: KeyboardEvent, affect: ZodAffectType) => {
 
 function componentFromPurl(purl: string) {
   try {
-    return PackageURL.fromString(purl)?.name ?? null;
+    const packageUrl = PackageURL.fromString(purl);
+
+    if (packageUrl?.type === 'oci') {
+      const repositoryUrl = packageUrl.qualifiers?.repository_url;
+      const prefix = repositoryUrl?.split('/')[1];
+      if (!prefix) {
+        throw new Error('Invalid repository_url in OCI PURL');
+      }
+      return `${prefix}/${packageUrl.name}`;
+    } else if (packageUrl?.qualifiers?.rpmmod) {
+      return `${packageUrl.qualifiers.rpmmod}/${packageUrl.name}`;
+    } else {
+      return packageUrl?.name ?? null;
+    }
   } catch (error) {
     return null;
   }


### PR DESCRIPTION
# OSIDB-4358 Fix PURL parsing component for OCI and RPMMOD types

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [-] Integration tests updated
- [x] Jira ticket updated

## Summary:

OSIM generates affected component when PURL is provided in an affect to give users the value in advance (OSIDB also performs a parsing in the backend).
The parsing in OSIM side was not being equivalent to the one in OSIDB for some cases (OCI and RPMMOD type PURL), cause it needs special handling to add a namespace prior to the component name.

## Changes:

- Handle OCI and RPMMOD PURL type cases in parsing function

## Considerations:

- This is taken as an immediate action to fix the bug, long term solution should go around OSIDB-4361
(handling parsing locally in each client)

Closes OSIDB-4358
