### PR TITLE
✨ Reauthentication banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # OSIM Changelog
 ## [Unreleased]
+### Added
+* Support extending session (reauthenticating) (`OSIDB-4275`)
+
 ### Changed
 * Move labels table after trackers (`OSIDB-4082`)
 
 ## [2025.8.0]
+### Added
+* Add expiring session banner (`OSIDB-4275`)
+
 ### Fixed
 * Fix only showing 100 affects in flaw view (`OSIDB-4393`)
 * Fix incorrect "unset api keys" notification (`OSIDB-4390`)
@@ -16,8 +22,6 @@
 ### Changed
 * Bugzilla and Jira api keys are now saved on the backend (`OSIDB-4312`)
 * Show api key is now a field button instead a separate radio input (`OSIDB-4312`)
-
-### Changed
 * Improve loading performance by splitting up flaw and affect requests  (`OSIDB-4266`)
 * Don't update Flaw when only affects are modified (`OSIDB-4270`)
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,7 @@ import { useElementBounding } from '@vueuse/core';
 import ToastContainer from '@/components/ToastContainer/ToastContainer.vue';
 import ChangeLog from '@/components/ChangeLog/ChangeLog.vue';
 import Navbar from '@/components/Navbar/Navbar.vue';
+import SessionWarningBanner from '@/components/SessionWarningBanner/SessionWarningBanner.vue';
 
 import {
   osidbHealth,
@@ -63,6 +64,7 @@ onBeforeUnmount(() => {
 
 <template>
   <template v-if="osimRuntimeStatus === OsimRuntimeStatus.READY">
+    <SessionWarningBanner />
     <header>
       <Navbar v-if="!$route.meta.hideNavbar" />
     </header>

--- a/src/components/SessionWarningBanner/SessionWarningBanner.vue
+++ b/src/components/SessionWarningBanner/SessionWarningBanner.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+
+import { useSessionWarning } from '@/composables/useSessionWarning';
+
+import { useToastStore } from '@/stores/ToastStore';
+import { osimRuntime } from '@/stores/osimRuntime';
+
+const {
+  isAccessTokenExpiringInOneHour,
+  isReauthenticating,
+  reauthenticate,
+  timeUntilExpiration,
+} = useSessionWarning();
+
+const toastStore = useToastStore();
+const isDismissed = ref(false);
+
+const authMethod = computed(() => osimRuntime.value.backends.osidbAuth);
+
+const shouldShowBanner = computed(() => {
+  return isAccessTokenExpiringInOneHour.value && !isDismissed.value && authMethod.value === 'kerberos';
+});
+
+const timeRemainingText = computed(() => {
+  const time = timeUntilExpiration.value;
+  if (!time) return '';
+
+  const hours = Math.floor(time.hours || 0);
+  const minutes = Math.floor(time.minutes || 0);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+});
+
+const bannerMessage = computed(() => {
+  return `Your session will expire in ${timeRemainingText.value}. Click "Extend Session" to continue working.`;
+});
+
+const buttonText = computed(() => {
+  return isReauthenticating.value ? 'Extending...' : 'Extend Session';
+});
+
+async function handleReauthenticate() {
+  try {
+    await reauthenticate();
+    toastStore.addToast({
+      title: 'Session Extended',
+      body: 'Your session has been successfully extended.',
+      css: 'success',
+    });
+    if (!isAccessTokenExpiringInOneHour.value) {
+      isDismissed.value = false;
+    }
+  } catch (error) {
+    toastStore.addToast({
+      title: 'Session Extension Failed',
+      body: 'Unable to extend your session. Please log in again.',
+      css: 'danger',
+    });
+  }
+}
+
+function dismissBanner() {
+  isDismissed.value = true;
+}
+
+watch(isAccessTokenExpiringInOneHour, (newValue: boolean) => {
+  if (newValue) {
+    isDismissed.value = false;
+  }
+});
+</script>
+
+<template>
+  <Transition name="banner-slide">
+    <div v-if="shouldShowBanner" class="session-warning-banner">
+      <div class="container-fluid">
+        <div class="alert alert-warning mb-0 d-flex align-items-center justify-content-between" role="alert">
+          <div class="d-flex align-items-center">
+            <i class="bi bi-exclamation-triangle-fill me-2"></i>
+            <div>
+              <strong>Session Expiring Soon</strong>
+              <span class="ms-2">{{ bannerMessage }}</span>
+            </div>
+          </div>
+          <div class="d-flex align-items-center gap-2">
+            <button
+              type="button"
+              class="btn btn-warning btn-sm"
+              :disabled="isReauthenticating"
+              @click="handleReauthenticate"
+            >
+              <span
+                v-if="isReauthenticating"
+                class="spinner-border spinner-border-sm me-1"
+                role="status"
+              >
+                <span class="visually-hidden">Loading...</span>
+              </span>
+              {{ buttonText }}
+            </button>
+            <button
+              type="button"
+              class="btn-close"
+              :disabled="isReauthenticating"
+              @click="dismissBanner"
+            >
+              <span class="visually-hidden">Close</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.session-warning-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1100;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+}
+
+.banner-slide-enter-active,
+.banner-slide-leave-active {
+  transition: transform 0.3s ease-in-out;
+}
+
+.banner-slide-enter-from,
+.banner-slide-leave-to {
+  transform: translateY(-100%);
+}
+
+/* Add spacing to body when banner is shown */
+:global(body:has(.session-warning-banner)) {
+  padding-top: 60px;
+}
+
+/* Fallback for browsers that don't support :has() */
+.session-warning-banner ~ * {
+  margin-top: 60px;
+}
+</style>

--- a/src/components/__tests__/SessionWarningBanner.spec.ts
+++ b/src/components/__tests__/SessionWarningBanner.spec.ts
@@ -1,0 +1,154 @@
+import { ref } from 'vue';
+
+import { mount, VueWrapper } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import SessionWarningBanner from '@/components/SessionWarningBanner/SessionWarningBanner.vue';
+
+import { useToastStore } from '@/stores/ToastStore';
+
+const mockIsAccessTokenExpiringInOneHour = ref(false);
+const mockIsReauthenticating = ref(false);
+const mockTimeUntilExpiration = ref({ hours: 0, minutes: 45 });
+const mockReauthenticate = vi.fn();
+
+vi.mock('@/composables/useSessionWarning', () => ({
+  useSessionWarning: () => ({
+    isAccessTokenExpiringInOneHour: mockIsAccessTokenExpiringInOneHour,
+    isReauthenticating: mockIsReauthenticating,
+    reauthenticate: mockReauthenticate,
+    timeUntilExpiration: mockTimeUntilExpiration,
+  }),
+}));
+
+vi.mock('@/stores/osimRuntime', () => ({
+  osimRuntime: {
+    value: {
+      backends: {
+        osidbAuth: 'kerberos',
+      },
+    },
+  },
+}));
+
+describe('sessionWarningBanner', () => {
+  let wrapper: VueWrapper<any>;
+  let toastStore: any;
+
+  const mountComponent = () => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      stubActions: false,
+    });
+    toastStore = useToastStore(pinia);
+
+    return mount(SessionWarningBanner, {
+      global: {
+        plugins: [pinia],
+      },
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAccessTokenExpiringInOneHour.value = false;
+    mockIsReauthenticating.value = false;
+    mockTimeUntilExpiration.value = { hours: 0, minutes: 45 };
+    mockReauthenticate.mockReset();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should not show banner when token is not expiring', () => {
+    mockIsAccessTokenExpiringInOneHour.value = false;
+    wrapper = mountComponent();
+
+    expect(wrapper.find('.session-warning-banner').exists()).toBe(false);
+  });
+
+  it('should show banner when token is expiring and auth method is kerberos', () => {
+    mockIsAccessTokenExpiringInOneHour.value = true;
+    wrapper = mountComponent();
+
+    expect(wrapper.find('.session-warning-banner').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Session Expiring Soon');
+    expect(wrapper.text()).toContain('Your session will expire in 45m');
+  });
+
+  it('should hide banner when dismissed', async () => {
+    mockIsAccessTokenExpiringInOneHour.value = true;
+    wrapper = mountComponent();
+
+    const closeButton = wrapper.find('.btn-close');
+    await closeButton.trigger('click');
+
+    expect(wrapper.find('.session-warning-banner').exists()).toBe(false);
+  });
+
+  it('should call reauthenticate when extend button is clicked', async () => {
+    mockIsAccessTokenExpiringInOneHour.value = true;
+    wrapper = mountComponent();
+
+    const extendButton = wrapper.find('.btn-warning');
+    await extendButton.trigger('click');
+
+    expect(mockReauthenticate).toHaveBeenCalled();
+  });
+
+  it('should show loading state during reauthentication', () => {
+    mockIsAccessTokenExpiringInOneHour.value = true;
+    mockIsReauthenticating.value = true;
+    wrapper = mountComponent();
+
+    const extendButton = wrapper.find('.btn-warning');
+    expect(extendButton.text()).toContain('Extending...');
+    expect(extendButton.attributes('disabled')).toBeDefined();
+    expect(wrapper.find('.spinner-border').exists()).toBe(true);
+  });
+
+  it('should show success toast on successful reauthentication', async () => {
+    mockIsAccessTokenExpiringInOneHour.value = true;
+    mockReauthenticate.mockResolvedValue(undefined);
+    wrapper = mountComponent();
+
+    const extendButton = wrapper.find('.btn-warning');
+    await extendButton.trigger('click');
+
+    expect(toastStore.addToast).toHaveBeenCalledWith({
+      title: 'Session Extended',
+      body: 'Your session has been successfully extended.',
+      css: 'success',
+    });
+  });
+
+  it('should show error toast on failed reauthentication', async () => {
+    mockIsAccessTokenExpiringInOneHour.value = true;
+    const error = new Error('Reauthentication failed');
+    mockReauthenticate.mockRejectedValue(error);
+    wrapper = mountComponent();
+
+    const extendButton = wrapper.find('.btn-warning');
+    await extendButton.trigger('click');
+
+    expect(toastStore.addToast).toHaveBeenCalledWith({
+      title: 'Session Extension Failed',
+      body: 'Unable to extend your session. Please log in again.',
+      css: 'danger',
+    });
+  });
+
+  it('should disable buttons during reauthentication', () => {
+    mockIsAccessTokenExpiringInOneHour.value = true;
+    mockIsReauthenticating.value = true;
+    wrapper = mountComponent();
+
+    const extendButton = wrapper.find('.btn-warning');
+    const closeButton = wrapper.find('.btn-close');
+
+    expect(extendButton.attributes('disabled')).toBeDefined();
+    expect(closeButton.attributes('disabled')).toBeDefined();
+  });
+});

--- a/src/components/__tests__/__snapshots__/App.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/App.spec.ts.snap
@@ -3,7 +3,8 @@
 exports[`app > renders the App component when OSIDB is NOT READY 1`] = `"<div class="osim-backend-error">OSIDB is not ready</div>"`;
 
 exports[`app > renders the App component when OSIDB is READY 1`] = `
-"<header>
+"<session-warning-banner-stub></session-warning-banner-stub>
+<header>
   <navbar-stub></navbar-stub>
 </header>
 <div class="osim-content-layered">

--- a/src/composables/__tests__/useSessionWarning.spec.ts
+++ b/src/composables/__tests__/useSessionWarning.spec.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { DateTime } from 'luxon';
+
+import { encodeJWT } from '@/__tests__/helpers';
+import { useUserStore } from '@/stores/UserStore';
+
+import { useSessionWarning } from '../useSessionWarning';
+
+// Mock osimRuntime before importing anything else
+vi.mock('@/stores/osimRuntime', () => ({
+  osimRuntime: {
+    value: {
+      backends: {
+        osidbAuth: 'kerberos',
+      },
+    },
+  },
+}));
+
+// Mock UserStore with proper reactive session
+const mockSessionData = {
+  refresh: '',
+  env: '',
+  whoami: null,
+  jiraUsername: '',
+};
+
+// Create a shared login spy that can be accessed in tests
+const mockLogin = vi.fn().mockResolvedValue(true);
+
+vi.mock('@/stores/UserStore', () => ({
+  useUserStore: vi.fn(() => ({
+    get refreshToken() { return mockSessionData.refresh; },
+    set refreshToken(value: string) { mockSessionData.refresh = value; },
+    login: mockLogin,
+    logout: vi.fn(),
+  })),
+}));
+
+describe('useSessionWarning', () => {
+  let _userStore: any;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers({
+      now: new Date('2024-01-01T12:00:00Z'),
+    });
+
+    // Reset mock data
+    mockSessionData.refresh = '';
+    mockSessionData.env = '';
+    mockSessionData.whoami = null;
+    mockSessionData.jiraUsername = '';
+
+    _userStore = useUserStore();
+    vi.clearAllMocks();
+    mockLogin.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('should detect when refresh token expires in less than 1 hour', () => {
+    const { isAccessTokenExpiringInOneHour } = useSessionWarning();
+
+    // Create refresh token that expires in 30 minutes
+    mockSessionData.refresh = encodeJWT({
+      exp: Math.floor(DateTime.now().plus({ minutes: 30 }).toSeconds()),
+      iat: Math.floor(DateTime.now().toSeconds()),
+    });
+
+    expect(isAccessTokenExpiringInOneHour.value).toBe(true);
+  });
+
+  it('should not detect expiration when refresh token expires in more than 1 hour', () => {
+    const { isAccessTokenExpiringInOneHour } = useSessionWarning();
+
+    // Create refresh token that expires in 2 hours
+    mockSessionData.refresh = encodeJWT({
+      exp: Math.floor(DateTime.now().plus({ hours: 2 }).toSeconds()),
+      iat: Math.floor(DateTime.now().toSeconds()),
+    });
+
+    expect(isAccessTokenExpiringInOneHour.value).toBe(false);
+  });
+
+  it('should not detect expiration when refresh token is already expired', () => {
+    const { isAccessTokenExpiringInOneHour } = useSessionWarning();
+
+    // Create refresh token that expired 1 hour ago
+    mockSessionData.refresh = encodeJWT({
+      exp: Math.floor(DateTime.now().minus({ hours: 1 }).toSeconds()),
+      iat: Math.floor(DateTime.now().minus({ hours: 2 }).toSeconds()),
+    });
+
+    expect(isAccessTokenExpiringInOneHour.value).toBe(false);
+  });
+
+  it('should return correct time until refresh token expiration', () => {
+    const { timeUntilExpiration } = useSessionWarning();
+
+    // Create refresh token that expires in 45 minutes
+    mockSessionData.refresh = encodeJWT({
+      exp: Math.floor(DateTime.now().plus({ minutes: 45 }).toSeconds()),
+      iat: Math.floor(DateTime.now().toSeconds()),
+    });
+
+    const timeRemaining = timeUntilExpiration.value;
+    expect(timeRemaining).toBeDefined();
+    expect(timeRemaining?.hours).toBe(0);
+    expect(Math.floor(timeRemaining?.minutes || 0)).toBe(45);
+  });
+
+  it('should return null for time remaining when no refresh token', () => {
+    const { timeUntilExpiration } = useSessionWarning();
+
+    mockSessionData.refresh = '';
+
+    expect(timeUntilExpiration.value).toBeNull();
+  });
+
+  it('should handle invalid refresh tokens gracefully', () => {
+    const { isAccessTokenExpiringInOneHour, timeUntilExpiration } = useSessionWarning();
+
+    mockSessionData.refresh = 'invalid-token';
+
+    expect(isAccessTokenExpiringInOneHour.value).toBe(false);
+    expect(timeUntilExpiration.value).toBeNull();
+  });
+
+  it('should call reauthenticate function correctly', async () => {
+    const { isReauthenticating, reauthenticate } = useSessionWarning();
+
+    expect(isReauthenticating.value).toBe(false);
+
+    const promise = reauthenticate();
+    expect(isReauthenticating.value).toBe(true);
+
+    await promise;
+    expect(isReauthenticating.value).toBe(false);
+    expect(mockLogin).toHaveBeenCalled();
+  });
+});

--- a/src/composables/useSessionWarning.ts
+++ b/src/composables/useSessionWarning.ts
@@ -1,0 +1,73 @@
+import { computed, ref } from 'vue';
+
+import jwtDecode from 'jwt-decode';
+import type { JwtPayload } from 'jwt-decode';
+import { DateTime } from 'luxon';
+
+import { useUserStore } from '@/stores/UserStore';
+
+export function useSessionWarning() {
+  const userStore = useUserStore();
+  const isReauthenticating = ref(false);
+
+  const isRefreshTokenExpiringInOneHour = computed(() => {
+    try {
+      const refreshToken = userStore.refreshToken;
+      if (!refreshToken) return false;
+
+      const decoded = jwtDecode<JwtPayload>(refreshToken);
+      const exp = decoded?.exp;
+
+      if (!exp) return false;
+
+      const expirationTime = DateTime.fromSeconds(exp);
+      const oneHourFromNow = DateTime.now().plus({ hours: 1 });
+
+      return expirationTime <= oneHourFromNow && expirationTime > DateTime.now();
+    } catch (e) {
+      return false;
+    }
+  });
+
+  const timeUntilExpiration = computed(() => {
+    try {
+      const refreshToken = userStore.refreshToken;
+      if (!refreshToken) return null;
+
+      const decoded = jwtDecode<JwtPayload>(refreshToken);
+      const exp = decoded?.exp;
+
+      if (!exp) return null;
+
+      const expirationTime = DateTime.fromSeconds(exp);
+      const now = DateTime.now();
+
+      if (expirationTime <= now) return null;
+
+      return expirationTime.diff(now, ['hours', 'minutes']).toObject();
+    } catch (e) {
+      return null;
+    }
+  });
+
+  async function reauthenticate() {
+    if (isReauthenticating.value) return;
+
+    try {
+      isReauthenticating.value = true;
+      await userStore.login();
+    } catch (error) {
+      userStore.logout();
+      throw error;
+    } finally {
+      isReauthenticating.value = false;
+    }
+  }
+
+  return {
+    isAccessTokenExpiringInOneHour: isRefreshTokenExpiringInOneHour,
+    timeUntilExpiration,
+    isReauthenticating,
+    reauthenticate,
+  };
+}

--- a/src/services/OsidbAuthService.ts
+++ b/src/services/OsidbAuthService.ts
@@ -129,19 +129,17 @@ function queryStringFromParams(params: Record<string, any>) {
   return queryString ? `?${queryString}` : '';
 }
 
-export async function getNextAccessToken() {
+export async function getNextAccessToken(forceRefresh: boolean = false) {
+  // Moving this to module scope results in "cannot access before initialization" -
+  // probably a vite or typescript bug
+  const url = `${osimRuntime.value.backends.osidb}/auth/token/refresh`;
   const userStore = useUserStore();
-
-  // If we have a valid access token, return it
-  if (userStore.accessToken && !userStore.isAccessTokenExpired()) {
+  let response;
+  if (!forceRefresh && userStore.accessToken && !userStore.isAccessTokenExpired()) {
     return userStore.accessToken;
   }
 
-  const url = `${osimRuntime.value.backends.osidb}/auth/token/refresh`;
-
   try {
-    let response: Response;
-
     if (osimRuntime.value.env === 'dev') {
       // For local development: Use POST with refresh token from localStorage
       const refreshToken = userStore.getDevRefreshToken();


### PR DESCRIPTION
# OSIDB-4275 Reauthentication banner

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [-] Integration tests updated
- [x] Jira ticket updated

## Summary:

Adds a banner that shows up when the user's refresh token is about to expire (less than 1h left).
Supports extending user session (renewing refresh token by reauthenticating) from a button in the warning banner.

## Changes:

- Banner template
- Reauthentication logic
- Make refresh token available in memory
- Update tests

## Considerations:
The `UserStore` changes in this branch are to make the refresh token available in memory to be able to check the expiring time and properly showing the banner.

Closes OSIDB-4275
