### PR TITLE
🐛 Fix incorrect unset API keys toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # OSIM Changelog
+## [Unreleased]
+### Fixed
+* Fix incorrect "unset api keys" notification (`OSIDB-4390`)
 
 ## [2025.7.0]
 ### Fixed

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -59,7 +59,6 @@ export const routes = [
     meta: {
       title: 'Flaw Details',
     },
-    beforeEnter: apiKeysGuard(),
   },
   {
     path: '/search',
@@ -102,11 +101,6 @@ export const routes = [
     meta: {
       title: 'Settings',
     },
-    beforeEnter() {
-      if (areApiKeysNotSet() && osimRuntime.value.readOnly) {
-        notifyApiKeyUnset();
-      }
-    },
   },
   {
     path: '/:pathMatch(.*)*',
@@ -143,11 +137,8 @@ function apiKeysGuard(shouldRedirectToSettings = false) {
       return;
     }
 
-    if (noKeysAreSet) {
-      notifyApiKeyUnset();
-    }
-
     if (noKeysAreSet && shouldRedirectToSettings) {
+      notifyApiKeyUnset();
       next('/settings');
       return;
     }


### PR DESCRIPTION
# OSIDB-4390 Fix incorrect unset API keys toast
## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [-] Integration tests updated
- [x] Jira ticket updated

## Summary:

Prevents incorrect "unset API keys" notifications from showing before actually trying to fetch them.

## Changes:

- Removed API key checks from router guards
- Centralized notification logic moved to `SettingsStore` initialization
- Only shows "unset keys" warning when actually needed (keys missing + not read-only mode)
- Eliminates false notifications during normal app navigation

Closes OSIDB-4390
