### PR TITLE
🐛 Fix limited affects fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # OSIM Changelog
 ## [Unreleased]
 ### Fixed
+* Fix only showing 100 affects in flaw view (`OSIDB-4393`)
 * Fix incorrect "unset api keys" notification (`OSIDB-4390`)
 
 ## [2025.7.0]

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -24,6 +24,7 @@ import { useFlawModel } from '@/composables/useFlawModel';
 import { useFlaw } from '@/composables/useFlaw';
 import { useFetchFlaw } from '@/composables/useFetchFlaw';
 
+import LoadingSpinner from '@/widgets/LoadingSpinner/LoadingSpinner.vue';
 import LabelTextarea from '@/widgets/LabelTextarea/LabelTextarea.vue';
 import LabelStatic from '@/widgets/LabelStatic/LabelStatic.vue';
 import LabelSelect from '@/widgets/LabelSelect/LabelSelect.vue';
@@ -411,9 +412,10 @@ const createdDate = computed(() => {
         </div>
         <div class="osim-flaw-form-section">
           <div v-if="isFetchingAffects">
-            <div class="spinner-border" role="status">
-              <span class="visually-hidden">Fetching affects...</span>
-            </div>
+            <LoadingSpinner
+              type="border"
+              class="spinner-border-sm me-1"
+            />
             <span class="ms-1">Fetching affects...</span>
           </div>
           <FlawAffects


### PR DESCRIPTION
# OSIDB-4393 Fix limited affects fetch
## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [-] Integration tests updated
- [x] Jira ticket updated

## Summary:

Fix the affects fetch which is currently limited to 100 by OSIDB default's limit.


## Changes:

Modifies `getAffects` to fetch affects in batches of 100 until `count` is  reached.

## Considerations:

Quick change was just rising the limit on fetch affect request, but I considered this "batched" request more efficient.

Closes OSIDB-4393
