### PR TITLE
🐛 API Keys not loaded on new user session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 * Correctly display line breaks in comments (`OSIDB-4290`)
 * Fix UI layout issues for smaller resolutions (`OSIDB-4411`)
+* Fix API Keys not loaded on new user session (`OSIDB-4416`)
 
 ### Changed
 * Move labels table after trackers (`OSIDB-4082`)

--- a/src/components/__tests__/Navbar.spec.ts
+++ b/src/components/__tests__/Navbar.spec.ts
@@ -67,6 +67,7 @@ describe('navbar', () => {
       },
       isLoadingApiKeys: false,
       isSavingApiKeys: false,
+      isApiKeysInitialized: false,
     };
     subject = mount(Navbar, {
       global: {
@@ -113,6 +114,7 @@ describe('navbar', () => {
       },
       isLoadingApiKeys: false,
       isSavingApiKeys: false,
+      isApiKeysInitialized: false,
     };
     subject = mount(Navbar, {
       global: {
@@ -164,6 +166,7 @@ describe('navbar', () => {
       },
       isLoadingApiKeys: false,
       isSavingApiKeys: false,
+      isApiKeysInitialized: false,
     };
     subject = mount(Navbar, {
       global: {
@@ -210,6 +213,7 @@ describe('navbar', () => {
       },
       isLoadingApiKeys: false,
       isSavingApiKeys: false,
+      isApiKeysInitialized: false,
     };
     subject = mount(Navbar, {
       global: {

--- a/src/components/__tests__/ToastContainer.spec.ts
+++ b/src/components/__tests__/ToastContainer.spec.ts
@@ -44,6 +44,7 @@ describe('toastContainer', () => {
       },
       isLoadingApiKeys: false,
       isSavingApiKeys: false,
+      isApiKeysInitialized: false,
     };
     const toastStore = useToastStore(pinia);
     toastStore.addToast({
@@ -96,6 +97,7 @@ describe('toastContainer', () => {
       },
       isLoadingApiKeys: false,
       isSavingApiKeys: false,
+      isApiKeysInitialized: false,
     };
     subject = mount(ToastContainer, {
       global: {
@@ -137,6 +139,7 @@ describe('toastContainer', () => {
         },
         isLoadingApiKeys: false,
         isSavingApiKeys: false,
+        isApiKeysInitialized: false,
       };
       const toastStore = useToastStore(pinia);
       toastStore.addToast({


### PR DESCRIPTION
# OSIDB-4416 API Keys not loaded on new user session

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [-] Integration tests updated
- [x] Jira ticket updated

## Summary:

The problem: API keys didn’t load on fresh sessions due to non-reactive auth gating (isLoggedin was being changed to true after api keys initialization).
The solution: Wait for reactive isAuthenticated (via `waitUntilAuthenticated`), then load/migrate keys once.

## Changes:

- Add `waitUntilAuthenticated` in UserStore using VueUse `until`.
- `SettingsStore.initializeApiKeys` awaits auth, then loads/migrates keys.
- Removed non-reactive `isLoggedIn` gating

## Considerations:

- Tested in dev and working

Closes OSIDB-4416
