### PR TITLE
👔 Collapse Contributors table by default unless any labels are new or…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 * Move labels table after trackers (`OSIDB-4082`)
 * CWE suggestions using AegisAI (`AEGIS-69`)
+* Only expand Contributors table when a label is new or assigned (`OSIDB-4083`). 
 
 ## [2025.8.0]
 ### Added

--- a/src/components/FlawLabels/FlawLabelsTable.vue
+++ b/src/components/FlawLabels/FlawLabelsTable.vue
@@ -10,7 +10,7 @@ import { FlawLabelTypeEnum, type ZodFlawLabelType } from '@/types/zodFlaw';
 
 import FlawLabelTableEditingRow from './FlawLabelTableEditingRow.vue';
 
-const modelValue = defineModel<ZodFlawLabelType[]>({ required: true });
+const labelsFromProps = defineModel<ZodFlawLabelType[]>({ required: true });
 
 const {
   deletedLabels,
@@ -21,7 +21,7 @@ const {
   loadContextLabels,
   newLabels,
   updatedLabels,
-} = useFlawLabels(modelValue);
+} = useFlawLabels(labelsFromProps);
 
 const isCreatingLabel = ref(false);
 const isUpdatingLabel = ref<string>();
@@ -31,7 +31,9 @@ const availableLabels = computed(() =>
     !Object.values(labels.value).some(({ label }) => label === contextLabel),
   ),
 );
-const [isExpanded, toggleExpanded] = useToggle(true);
+
+const isExpandedDefault = labelsFromProps.value.some(label => label.contributor || label.state === 'NEW');
+const [isExpanded, toggleExpanded] = useToggle(isExpandedDefault);
 
 function handleNewLabel(label: ZodFlawLabelType) {
   newLabels.value.add(label.label);

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -859,9 +859,9 @@ This module has no trackers associated"><i data-v-2d3c4208="" class="bi bi-excla
     </div>
   </div>
   <div data-v-76e7a15d="" class="osim-flaw-form-section">
-    <div data-v-4715e8e2="" data-v-5d530569="" data-v-76e7a15d="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
+    <div data-v-4715e8e2="" data-v-5d530569="" data-v-76e7a15d="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-plus-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
       <div data-v-4715e8e2="" class="ps-3 border-start">
-        <div data-v-4715e8e2="" class="">
+        <div data-v-4715e8e2="" class="visually-hidden">
           <div data-v-5d530569="">
             <p data-v-5d530569="">No available labels</p>
           </div>


### PR DESCRIPTION
# OSIDB-4083 Change Collapse Contributors table default

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ :frowning: ] Integration tests updated
- [x] Jira ticket updated

## Summary:

Collapse Contributors table by default under some conditions

## Changes:
 Collapse Contributors table by default unless any labels are new or have assigned contributors
## Considerations:

[Replace with any additional considerations, notes, or instructions for reviewers.]

Closes OSIDB-4083