### PR TITLE
🚩 Disable CWE AI Suggestions

### DIFF
--- a/build/entrypoint.d/20-osim-runtime-json.sh
+++ b/build/entrypoint.d/20-osim-runtime-json.sh
@@ -25,6 +25,9 @@ if [ -f "/osim_build.json" ]; then
     IFS= read -r -d '' OSIM_VERSION <"/osim_build.json" || :
 fi
 
+# Feature flags
+OSIM_FLAG_AI_CWE_SUGGESTIONS="${OSIM_FLAG_AI_CWE_SUGGESTIONS:-false}"
+
 IFS= read -r -d '' OSIM_RUNTIME <<EOF || :
 {
   "env": "${OSIM_ENV}",
@@ -38,7 +41,10 @@ IFS= read -r -d '' OSIM_RUNTIME <<EOF || :
     "mitre": "${OSIM_BACKENDS_MITRE}"
   },
   "osimVersion": ${OSIM_VERSION},
-  "readOnly": ${OSIM_READONLY_MODE}
+  "readOnly": ${OSIM_READONLY_MODE},
+  "flags": {
+    "aiCweSuggestions": ${OSIM_FLAG_AI_CWE_SUGGESTIONS}
+  }
 }
 EOF
 

--- a/src/components/CweSelector/CweSelector.vue
+++ b/src/components/CweSelector/CweSelector.vue
@@ -8,6 +8,7 @@ import EditableTextWithSuggestions from '@/widgets/EditableTextWithSuggestions/E
 import LabelDiv from '@/widgets/LabelDiv/LabelDiv.vue';
 import type { CWEMemberType } from '@/types/mitreCwe';
 import { loadCweData } from '@/services/CweService';
+import { osimRuntime } from '@/stores/osimRuntime';
 
 const props = withDefaults(defineProps<{
   aegisContext?: AegisSuggestionContextRefs | null;
@@ -112,6 +113,7 @@ const getUsageClass = (usage: string) => {
   <LabelDiv :label :loading="isSuggesting" class="mb-2">
     <template #labelSlot>
       <i
+        v-if="osimRuntime.flags?.aiCweSuggestions === true"
         class="bi-stars label-icon"
         :class="{ disabled: !canSuggest, applied: hasAppliedSuggestion }"
         :title="suggestionTooltip"

--- a/src/components/__tests__/__snapshots__/CweSelector.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/CweSelector.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`cweSelector.vue > renders correctly 1`] = `
 "<div data-v-0e2ae48e="" data-v-478878c2="" class="osim-input ps-3 mb-2">
-  <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--><i data-v-478878c2="" class="bi-stars label-icon disabled" title="Suggest CWE via AEGIS-AI"></i><!--v-if-->  <!--attrs: {{ $attrs }}--></span>
+  <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if-->  <!--attrs: {{ $attrs }}--></span>
     <div data-v-0e2ae48e="" class="col-9">
       <div data-v-478878c2="" tabindex="0">
         <!-- for invalid-tooltip positioning -->

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -204,7 +204,7 @@ exports[`flawForm > mounts and renders 1`] = `
       <!--v-if-->
     </div>
     <div data-v-0e2ae48e="" data-v-478878c2="" data-v-76e7a15d="" class="osim-input ps-3 mb-2">
-      <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--><i data-v-478878c2="" class="bi-stars label-icon" title="Suggest CWE via AEGIS-AI"></i><!--v-if--> CWE ID <!--attrs: {{ $attrs }}--></span>
+      <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--> CWE ID <!--attrs: {{ $attrs }}--></span>
         <div data-v-0e2ae48e="" class="col-9">
           <div data-v-478878c2="" tabindex="0">
             <!-- for invalid-tooltip positioning -->

--- a/src/types/zodOsim.ts
+++ b/src/types/zodOsim.ts
@@ -25,6 +25,7 @@ export const OsimRuntime = z.object({
   }),
   error: z.string().default(''),
   readOnly: z.boolean().default(false),
+  flags: z.record(z.union([z.boolean(), z.string()])).optional(),
 });
 export type OsimRuntimeType = z.infer<typeof OsimRuntime>;
 

--- a/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
+++ b/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
@@ -165,7 +165,7 @@ exports[`flawCreateView > should render 1`] = `
               <!--v-if-->
             </div>
             <div data-v-0e2ae48e="" data-v-478878c2="" data-v-76e7a15d="" class="osim-input ps-3 mb-2">
-              <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--><i data-v-478878c2="" class="bi-stars label-icon disabled" title="Suggest CWE via AEGIS-AI"></i><!--v-if--> CWE ID <!--attrs: {{ $attrs }}--></span>
+              <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--> CWE ID <!--attrs: {{ $attrs }}--></span>
                 <div data-v-0e2ae48e="" class="col-9">
                   <div data-v-478878c2="" tabindex="0">
                     <!-- for invalid-tooltip positioning -->


### PR DESCRIPTION
Disabling CWE Aegis-AI suggestions for simplifying incoming OSIM releases.

Once Aegis backend is released to prod, we just need to remove the flag and release our side.

## Considerations:
Would be nice to have an actual flag system that allow us to enable/disable features without requiring releases (As @MrMarble suggested a while ago)