### PR TITLE
Show creation times along with creation dates in Flaw view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 * Support extending session (reauthenticating) (`OSIDB-4275`)
 * Add Aegis-AI regulatory notifications (`AEGIS-62`)
+* Show time in Flaw index/list view (`OSIDB-4407`)
 
 ### Changed
 * Move labels table after trackers (`OSIDB-4082`)

--- a/src/components/IssueQueue/IssueQueue.vue
+++ b/src/components/IssueQueue/IssueQueue.vue
@@ -113,7 +113,7 @@ function relevantFields(issue: ZodFlawType) {
     unembargo_dt: issue.unembargo_dt,
     embargoed: issue.embargoed,
     owner: issue.owner,
-    formattedDate: DateTime.fromISO(issue.created_dt!).toUTC().toFormat('yyyy-MM-dd'),
+    formattedDate: DateTime.fromISO(issue.created_dt!).toUTC().toFormat('yyyy-MM-dd HH:mm'),
     labels: issue.labels,
   };
 }

--- a/src/components/__tests__/IssueQueue.spec.ts
+++ b/src/components/__tests__/IssueQueue.spec.ts
@@ -193,7 +193,7 @@ describe('issueQueue', () => {
 
     const dateEl = wrapper.findAll('td')[2];
     expect(dateEl.exists()).toBeTruthy();
-    expect(dateEl.text()).toBe('2021-07-29');
+    expect(dateEl.text()).toBe('2021-07-29 22:50');
   });
 
   it('should render flaw labels', () => {

--- a/src/components/__tests__/__snapshots__/IssueQueue.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/IssueQueue.spec.ts.snap
@@ -25,7 +25,7 @@ exports[`issueQueue > should not render flaw labels that are already assigned 1`
         <tr data-v-15d9c71d="" class="osim-issue-queue-item osim-shaded">
           <td data-v-15d9c71d="" class="osim-issue-title pb-0"><a data-v-15d9c71d="" href="/flaws/CVE-2903-0092" class="">CVE-2903-0092</a></td>
           <td data-v-15d9c71d="" class="pb-0">MODERATE</td>
-          <td data-v-15d9c71d="" class="pb-0">2021-07-29</td>
+          <td data-v-15d9c71d="" class="pb-0">2021-07-29 14:50</td>
           <td data-v-15d9c71d="" class="pb-0">title</td>
           <td data-v-15d9c71d="" class="pb-0">NEW</td>
           <td data-v-15d9c71d="" class="pb-0">test@redhat.com</td>
@@ -76,7 +76,7 @@ exports[`issueQueue > should not render flaw labels when isHidingLabels is true 
         <tr data-v-15d9c71d="" class="osim-issue-queue-item osim-shaded">
           <td data-v-15d9c71d="" class="osim-issue-title"><a data-v-15d9c71d="" href="/flaws/CVE-2903-0092" class="">CVE-2903-0092</a></td>
           <td data-v-15d9c71d="" class="">MODERATE</td>
-          <td data-v-15d9c71d="" class="">2021-07-29</td>
+          <td data-v-15d9c71d="" class="">2021-07-29 14:50</td>
           <td data-v-15d9c71d="" class="">title</td>
           <td data-v-15d9c71d="" class="">NEW</td>
           <td data-v-15d9c71d="" class="">test@redhat.com</td>
@@ -118,7 +118,7 @@ exports[`issueQueue > should render flaw labels 1`] = `
         <tr data-v-15d9c71d="" class="osim-issue-queue-item osim-shaded">
           <td data-v-15d9c71d="" class="osim-issue-title pb-0"><a data-v-15d9c71d="" href="/flaws/CVE-2903-0092" class="">CVE-2903-0092</a></td>
           <td data-v-15d9c71d="" class="pb-0">MODERATE</td>
-          <td data-v-15d9c71d="" class="pb-0">2021-07-29</td>
+          <td data-v-15d9c71d="" class="pb-0">2021-07-29 14:50</td>
           <td data-v-15d9c71d="" class="pb-0">title</td>
           <td data-v-15d9c71d="" class="pb-0">NEW</td>
           <td data-v-15d9c71d="" class="pb-0">test@redhat.com</td>


### PR DESCRIPTION
# OSIDB-4407 Show creation times along with creation dates in Flaw view

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated
- [x] Jira ticket updated

## Summary:

Add times to dates in the Flaw index view.

Closes OSIDB-4407