### PR TITLE
[OSIDB-4290] Correctly display line breaks in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Add Aegis-AI regulatory notifications (`AEGIS-62`)
 * Show time in Flaw index/list view (`OSIDB-4407`)
 
+### Fixed
+* Correctly display line breaks in comments (`OSIDB-4290`)
+
 ### Changed
 * Move labels table after trackers (`OSIDB-4082`)
 * Reduce network calls in post-save Flaw refresh (`OSIDB-4267`)

--- a/src/components/FlawComments/FlawComments.vue
+++ b/src/components/FlawComments/FlawComments.vue
@@ -178,7 +178,7 @@ const tabsTooltips = computed(() => {
     }
   }
 
-  .osim-flaw-comment {
+  :deep(.osim-flaw-comment) {
     white-space: pre-wrap;
   }
 }


### PR DESCRIPTION
# [OSIDB-4290] Correctly display line breaks in comments

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [-] Integration tests updated
- [x] Jira ticket updated

## Summary:

The `white-space: pre-warp` style was not being applied after the refactor of the comment section since it was targeting a child component. Added a `:deep` pseudo selector to fix the issue

|Before|After|
|---|---|
|![](https://github.com/user-attachments/assets/68e47848-66d2-4248-a0fe-dfd6afa6b945)|![](https://github.com/user-attachments/assets/2a2117d0-d33d-4336-b784-9a17c8bf0d60)|

Closes OSIDB-4290
