### PR TITLE
[OSIDB-4470] Create `DropDown` widget

### DIFF
--- a/src/widgets/DropDownMenu/DropDownMenu.vue
+++ b/src/widgets/DropDownMenu/DropDownMenu.vue
@@ -1,0 +1,197 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, nextTick } from 'vue';
+
+interface Props {
+  offset?: number;
+  placement?: 'bottom-end' | 'bottom-start' | 'top-end' | 'top-start';
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  placement: 'bottom-start',
+  offset: 8,
+});
+
+const emit = defineEmits<{
+  close: [];
+  open: [];
+}>();
+
+const isOpen = ref(false);
+const triggerRef = ref<HTMLElement>();
+const dropdownRef = ref<HTMLElement>();
+const dropdownPosition = ref({ top: 0, left: 0 });
+
+const calculatePosition = async () => {
+  if (!triggerRef.value) return;
+
+  await nextTick();
+
+  const triggerRect = triggerRef.value.getBoundingClientRect();
+  const dropdownEl = dropdownRef.value;
+
+  if (!dropdownEl) return;
+
+  const dropdownRect = dropdownEl.getBoundingClientRect();
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  let top = 0;
+  let left = 0;
+
+  switch (props.placement) {
+    case 'bottom-start':
+      top = triggerRect.bottom + props.offset;
+      left = triggerRect.left;
+      break;
+    case 'bottom-end':
+      top = triggerRect.bottom + props.offset;
+      left = triggerRect.right - dropdownRect.width;
+      break;
+    case 'top-start':
+      top = triggerRect.top - dropdownRect.height - props.offset;
+      left = triggerRect.left;
+      break;
+    case 'top-end':
+      top = triggerRect.top - dropdownRect.height - props.offset;
+      left = triggerRect.right - dropdownRect.width;
+      break;
+  }
+
+  // Adjust if dropdown would go outside viewport
+  if (left + dropdownRect.width > viewportWidth) {
+    left = viewportWidth - dropdownRect.width - 8;
+  }
+  if (left < 8) {
+    left = 8;
+  }
+  if (top + dropdownRect.height > viewportHeight) {
+    top = triggerRect.top - dropdownRect.height - props.offset;
+  }
+  if (top < 8) {
+    top = triggerRect.bottom + props.offset;
+  }
+
+  dropdownPosition.value = { top, left };
+};
+
+const toggleDropdown = async () => {
+  if (isOpen.value) {
+    closeDropdown();
+  } else {
+    openDropdown();
+  }
+};
+
+const openDropdown = async () => {
+  isOpen.value = true;
+  emit('open');
+  await nextTick();
+  calculatePosition();
+};
+
+const closeDropdown = () => {
+  isOpen.value = false;
+  emit('close');
+};
+
+const handleResize = () => {
+  if (isOpen.value) {
+    calculatePosition();
+  }
+};
+
+const handleScroll = () => {
+  if (isOpen.value) {
+    calculatePosition();
+  }
+};
+
+onMounted(() => {
+  window.addEventListener('resize', handleResize);
+  window.addEventListener('scroll', handleScroll, true);
+});
+
+onUnmounted(() => {
+  window.removeEventListener('resize', handleResize);
+  window.removeEventListener('scroll', handleScroll, true);
+});
+
+defineExpose({
+  isOpen,
+  open: openDropdown,
+  close: closeDropdown,
+  toggle: toggleDropdown,
+});
+</script>
+
+<template>
+  <div ref="triggerRef" class="dropdown-container">
+    <div class="dropdown-trigger px-1" @click="toggleDropdown">
+      <slot name="trigger" :isOpen="isOpen" />
+    </div>
+
+    <Teleport to="#app">
+      <div
+        v-if="isOpen"
+        ref="dropdownRef"
+        class="dropdown-menu"
+        @click.stop
+      >
+        <slot name="content" :close="closeDropdown" />
+      </div>
+    </Teleport>
+
+    <div
+      v-if="isOpen"
+      class="dropdown-backdrop"
+      @click="closeDropdown"
+    ></div>
+  </div>
+</template>
+
+<style scoped>
+.dropdown-container {
+  position: relative;
+  display: inline-block;
+}
+
+.dropdown-trigger {
+  cursor: pointer;
+}
+
+.dropdown-menu {
+  top: calc(v-bind('dropdownPosition.top') * 1px);
+  position: fixed;
+  left: calc(v-bind('dropdownPosition.left') * 1px);
+  z-index: 9999;
+  display: flex;
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 10%),
+    0 4px 6px -2px rgb(0 0 0 / 5%);
+  max-width: 400px;
+  animation: fade-in 0.15s ease-out;
+  padding: var(--bs-dropdown-padding-y) var(--bs-dropdown-padding-x);
+}
+
+.dropdown-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+  cursor: default;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/src/widgets/DropDownMenu/__tests__/DropDownMenu.spec.ts
+++ b/src/widgets/DropDownMenu/__tests__/DropDownMenu.spec.ts
@@ -1,0 +1,266 @@
+import { nextTick } from 'vue';
+
+import { mount } from '@vue/test-utils';
+
+import DropDownMenu from '@/widgets/DropDownMenu/DropDownMenu.vue';
+
+const createWrapper = (props = {}) => {
+  return mount(DropDownMenu, {
+    props,
+    slots: {
+      trigger: '<button data-testid="trigger">Open Menu</button>',
+      content: '<div data-testid="content">Menu Content</div>',
+    },
+    global: {
+      stubs: {
+        Teleport: true,
+      },
+    },
+  });
+};
+
+describe('dropDownMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('basic functionality', () => {
+    it('renders correctly when closed', () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.find('[data-testid="trigger"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="content"]').exists()).toBe(false);
+      expect(wrapper.find('.dropdown-backdrop').exists()).toBe(false);
+    });
+
+    it('opens dropdown when trigger is clicked', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid="trigger"]').trigger('click');
+      await nextTick();
+
+      expect(wrapper.find('[data-testid="content"]').exists()).toBe(true);
+      expect(wrapper.find('.dropdown-backdrop').exists()).toBe(true);
+    });
+
+    it('closes dropdown when trigger is clicked again', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid="trigger"]').trigger('click');
+      await nextTick();
+      expect(wrapper.find('[data-testid="content"]').exists()).toBe(true);
+
+      await wrapper.find('[data-testid="trigger"]').trigger('click');
+      await nextTick();
+      expect(wrapper.find('[data-testid="content"]').exists()).toBe(false);
+    });
+
+    it('closes dropdown when backdrop is clicked', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid="trigger"]').trigger('click');
+      await nextTick();
+      expect(wrapper.find('[data-testid="content"]').exists()).toBe(true);
+
+      await wrapper.find('.dropdown-backdrop').trigger('click');
+      await nextTick();
+      expect(wrapper.find('[data-testid="content"]').exists()).toBe(false);
+    });
+
+    it('does not close when dropdown content is clicked', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid="trigger"]').trigger('click');
+      await nextTick();
+
+      await wrapper.find('[data-testid="content"]').trigger('click');
+      await nextTick();
+      expect(wrapper.find('[data-testid="content"]').exists()).toBe(true);
+    });
+  });
+
+  describe('events', () => {
+    it('emits open event when dropdown opens', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid="trigger"]').trigger('click');
+
+      expect(wrapper.emitted('open')).toBeTruthy();
+      expect(wrapper.emitted('open')).toHaveLength(1);
+    });
+
+    it('emits close event when dropdown closes', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid="trigger"]').trigger('click');
+      await wrapper.find('[data-testid="trigger"]').trigger('click');
+
+      expect(wrapper.emitted('close')).toBeTruthy();
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+
+    it('emits close event when backdrop is clicked', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid="trigger"]').trigger('click');
+      await wrapper.find('.dropdown-backdrop').trigger('click');
+
+      expect(wrapper.emitted('close')).toBeTruthy();
+    });
+  });
+
+  describe('props', () => {
+    it('accepts placement prop', () => {
+      const wrapper = createWrapper({ placement: 'top-end' });
+      expect(wrapper.props().placement).toBe('top-end');
+    });
+
+    it('accepts offset prop', () => {
+      const wrapper = createWrapper({ offset: 16 });
+      expect(wrapper.props().offset).toBe(16);
+    });
+
+    it('uses default props when not provided', () => {
+      const wrapper = createWrapper();
+      expect(wrapper.props().placement).toBe('bottom-start');
+      expect(wrapper.props().offset).toBe(8);
+    });
+  });
+
+  describe('exposed methods', () => {
+    it('exposes isOpen reactive property', async () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.vm.isOpen).toBe(false);
+
+      await wrapper.find('[data-testid="trigger"]').trigger('click');
+      expect(wrapper.vm.isOpen).toBe(true);
+
+      await wrapper.find('[data-testid="trigger"]').trigger('click');
+      expect(wrapper.vm.isOpen).toBe(false);
+    });
+
+    it('exposes open method', async () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.vm.isOpen).toBe(false);
+
+      await wrapper.vm.open();
+      await nextTick();
+
+      expect(wrapper.vm.isOpen).toBe(true);
+      expect(wrapper.find('[data-testid="content"]').exists()).toBe(true);
+    });
+
+    it('exposes close method', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.vm.open();
+      await nextTick();
+      expect(wrapper.vm.isOpen).toBe(true);
+
+      wrapper.vm.close();
+      await nextTick();
+
+      expect(wrapper.vm.isOpen).toBe(false);
+      expect(wrapper.find('[data-testid="content"]').exists()).toBe(false);
+    });
+
+    it('exposes toggle method', async () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.vm.isOpen).toBe(false);
+
+      await wrapper.vm.toggle();
+      await nextTick();
+      expect(wrapper.vm.isOpen).toBe(true);
+
+      await wrapper.vm.toggle();
+      await nextTick();
+      expect(wrapper.vm.isOpen).toBe(false);
+    });
+  });
+
+  describe('slot integration', () => {
+    it('passes isOpen state to trigger slot', async () => {
+      const wrapper = mount(DropDownMenu, {
+        slots: {
+          trigger: `<button :class="{ active: isOpen }" data-testid="trigger">
+            {{ isOpen ? "Close" : "Open" }} Menu
+          </button>`,
+          content: '<div data-testid="content">Menu Content</div>',
+        },
+        global: {
+          stubs: {
+            Teleport: true,
+          },
+        },
+      });
+
+      const trigger = wrapper.find('[data-testid="trigger"]');
+      expect(trigger.text()).toBe('Open Menu');
+      expect(trigger.classes()).not.toContain('active');
+
+      await trigger.trigger('click');
+      await nextTick();
+
+      expect(trigger.text()).toBe('Close Menu');
+      expect(trigger.classes()).toContain('active');
+    });
+
+    it('passes close method to content slot', async () => {
+      const wrapper = mount(DropDownMenu, {
+        slots: {
+          trigger: '<button data-testid="trigger">Open Menu</button>',
+          content: '<div data-testid="content"><button @click="close" data-testid="close-btn">Close</button></div>',
+        },
+        global: {
+          stubs: {
+            Teleport: true,
+          },
+        },
+      });
+
+      await wrapper.find('[data-testid="trigger"]').trigger('click');
+      await nextTick();
+
+      expect(wrapper.find('[data-testid="content"]').exists()).toBe(true);
+
+      await wrapper.find('[data-testid="close-btn"]').trigger('click');
+      await nextTick();
+
+      expect(wrapper.find('[data-testid="content"]').exists()).toBe(false);
+      expect(wrapper.emitted('close')).toBeTruthy();
+    });
+  });
+
+  describe('window event listeners', () => {
+    let addEventListenerSpy: any;
+    let removeEventListenerSpy: any;
+
+    beforeEach(() => {
+      addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+      removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('adds window event listeners on mount', () => {
+      createWrapper();
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+      expect(addEventListenerSpy).toHaveBeenCalledWith('scroll', expect.any(Function), true);
+    });
+
+    it('removes window event listeners on unmount', () => {
+      const wrapper = createWrapper();
+
+      wrapper.unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('scroll', expect.any(Function), true);
+    });
+  });
+});


### PR DESCRIPTION
# [OSIDB-4470] Create `DropDown` widget

## Checklist:

- [x] Commits consolidated
- [-] Changelog updated
- [x] Test cases added/updated
- [-] Integration tests updated
- [x] Jira ticket updated

## Summary:

Bootstrap `dropdown-menu` is very simple to use but lacks some functionality.
I've created a `DropDown` widget that utilizes the `Teleport` Vue component to render itself outside of the parent element, bypassing any issues with overflow styles.

## Considerations:

Closes OSIDB-4470