### PR TITLE
✨ Aegis-AI History badges

### DIFF
--- a/src/__tests__/__fixtures__/sampleFlawHistory.json
+++ b/src/__tests__/__fixtures__/sampleFlawHistory.json
@@ -1,0 +1,37 @@
+{
+  "regularHistoryItem": {
+    "pgh_created_at": "2024-10-04T15:06:56.760289Z",
+    "pgh_slug": "osidb.FlawAudit:123456",
+    "pgh_label": "update",
+    "pgh_context": {
+      "url": "osidb/api/v1/flaws/12d3820a-a43b-417c-a22e-46e47c232a63",
+      "user": 1
+    },
+    "pgh_diff": {
+      "owner": ["", "noemail@example.com"]
+    }
+  },
+  "aegisHistoryItem": {
+    "pgh_created_at": "2024-10-04T15:06:56.760289Z",
+    "pgh_slug": "osidb.FlawAudit:123457",
+    "pgh_label": "update",
+    "pgh_context": {
+      "url": "osidb/api/v1/flaws/12d3820a-a43b-417c-a22e-46e47c232a63",
+      "user": 1
+    },
+    "pgh_diff": {
+      "cwe_id": ["", "CWE-123 (Partial AI)"],
+      "aegis_meta": [
+        {},
+        {
+          "cwe_id": [
+            {
+              "type": "Partial AI",
+              "timestamp": "2024-10-04T15:06:56.760Z"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/components/FlawHistory/FlawHistory.vue
+++ b/src/components/FlawHistory/FlawHistory.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue';
 
 import { usePagination } from '@/composables/usePagination';
+import { useAegisMetadataTracking } from '@/composables/aegis/useAegisMetadataTracking';
 
 import EditableDate from '@/widgets/EditableDate/EditableDate.vue';
 import { capitalize, formatDateWithTimezone } from '@/utils/helpers';
@@ -12,6 +13,8 @@ import LabelCollapsible from '@/widgets/LabelCollapsible/LabelCollapsible.vue';
 const props = defineProps<{
   history: null | undefined | ZodFlawHistoryItemType[];
 }>();
+
+const { getFieldAegisType, isFieldAegisChange } = useAegisMetadataTracking();
 
 const startDate = ref<null | string | undefined>(null);
 const endDate = ref<null | string | undefined>(null);
@@ -128,8 +131,23 @@ function clearFilters() {
                 - {{ historyEntry.pgh_context?.user || 'System' }}
               </span>
               <ul class="mb-2">
-                <li v-for="(diffEntry, diffKey) in historyEntry.pgh_diff" :key="diffKey">
+                <li
+                  v-for="(diffEntry, diffKey) in historyEntry.pgh_diff"
+                  v-show="diffKey !== 'aegis_meta'"
+                  :key="diffKey"
+                >
                   <div class="ms-3 pb-0">
+                    <span
+                      v-if="isFieldAegisChange(historyEntry, diffKey)"
+                      class="badge bg-secondary me-2"
+                      style="cursor: default;"
+                      :title="getFieldAegisType(historyEntry, diffKey) === 'AI'
+                        ? 'This change was suggested by Aegis-AI'
+                        : 'This change was a modified Aegis-AI suggestion'"
+                      data-bs-toggle="tooltip"
+                    >
+                      <i class="bi bi-robot"></i> {{ getFieldAegisType(historyEntry, diffKey) }}
+                    </span>
                     <span>{{ capitalize(historyEntry.pgh_label) }}</span>
                     <span class="fw-bold">{{ ' ' + (flawFieldNamesMapping[diffKey] || diffKey) }}</span>
                     <span>{{ ': ' +

--- a/src/components/__tests__/FlawHistory.spec.ts
+++ b/src/components/__tests__/FlawHistory.spec.ts
@@ -2,22 +2,13 @@ import { computed, ref, type Directive } from 'vue';
 
 import { mount } from '@vue/test-utils';
 import { IMaskDirective } from 'vue-imask';
+import * as historyFixtures from '@test-fixtures/sampleFlawHistory.json';
 
 import FlawHistory from '@/components/FlawHistory/FlawHistory.vue';
 
 import type { ZodFlawHistoryItemType } from '@/types/zodFlaw';
 
 import { osimEmptyFlawTest, osimFullFlawTest } from './test-suite-helpers';
-
-function sampleHistoryItem(): ZodFlawHistoryItemType {
-  return {
-    pgh_created_at: '2024-10-04T15:06:56.760289Z',
-    pgh_slug: 'osidb.FlawAudit:123456',
-    pgh_label: 'update',
-    pgh_context: { url: 'osidb/api/v1/flaws/12d3820a-a43b-417c-a22e-46e47c232a63', user: 1 },
-    pgh_diff: { owner: ['', 'noemail@example.com'] },
-  };
-}
 
 describe('flawHistory', () => {
   osimEmptyFlawTest('is not shown if no history present on flaw', async ({ flaw }) => {
@@ -37,7 +28,7 @@ describe('flawHistory', () => {
 
   osimFullFlawTest('is shown if history present on flaw', async ({ flaw }) => {
     flaw.history = [];
-    flaw.history.push(sampleHistoryItem());
+    flaw.history.push(historyFixtures.regularHistoryItem as ZodFlawHistoryItemType);
     const subject = mount(FlawHistory, {
       props: {
         history: flaw.history,
@@ -55,7 +46,7 @@ describe('flawHistory', () => {
 
   osimFullFlawTest('displays history items', async ({ flaw }) => {
     flaw.history = [];
-    flaw.history.push(sampleHistoryItem());
+    flaw.history.push(historyFixtures.regularHistoryItem as ZodFlawHistoryItemType);
     const subject = mount(FlawHistory, {
       props: {
         history: flaw.history,
@@ -72,7 +63,7 @@ describe('flawHistory', () => {
 
   osimFullFlawTest('shows seconds, minutes, hours in timestamp', async ({ flaw }) => {
     flaw.history = [];
-    flaw.history.push(sampleHistoryItem());
+    flaw.history.push(historyFixtures.regularHistoryItem as ZodFlawHistoryItemType);
     const subject = mount(FlawHistory, {
       props: {
         history: flaw.history,
@@ -153,5 +144,41 @@ describe('flawHistory', () => {
     endDate.value = '2024-02-28';
     await subject.vm.$nextTick();
     expect(filteredHistoryItems.value).toEqual([]);
+  });
+
+  osimFullFlawTest('displays AI badge for Aegis changes', async ({ flaw }) => {
+    flaw.history = [];
+    flaw.history.push(historyFixtures.aegisHistoryItem as ZodFlawHistoryItemType);
+    const subject = mount(FlawHistory, {
+      props: {
+        history: flaw.history,
+      },
+      global: {
+        stubs: {
+          EditableDate: true,
+        },
+      },
+    });
+    const aiBadge = subject.find('.badge');
+    expect(aiBadge.exists()).toBe(true);
+    expect(aiBadge.text()).toContain('AI');
+    expect(aiBadge.find('i.bi-robot').exists()).toBe(true);
+  });
+
+  osimFullFlawTest('does not display AI badge for regular changes', async ({ flaw }) => {
+    flaw.history = [];
+    flaw.history.push(historyFixtures.regularHistoryItem as ZodFlawHistoryItemType);
+    const subject = mount(FlawHistory, {
+      props: {
+        history: flaw.history,
+      },
+      global: {
+        stubs: {
+          EditableDate: true,
+        },
+      },
+    });
+    const aiBadge = subject.find('.badge');
+    expect(aiBadge.exists()).toBe(false);
   });
 });

--- a/src/components/__tests__/__snapshots__/FlawHistory.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawHistory.spec.ts.snap
@@ -15,7 +15,9 @@ exports[`flawHistory > is shown if history present on flaw 1`] = `
           <div data-v-f4fcc8d4="" class="alert alert-info mb-1 p-2"><span data-v-f4fcc8d4="">2024-10-04 15:06:56 UTC - 1</span>
             <ul data-v-f4fcc8d4="" class="mb-2">
               <li data-v-f4fcc8d4="">
-                <div data-v-f4fcc8d4="" class="ms-3 pb-0"><span data-v-f4fcc8d4="">Update</span><span data-v-f4fcc8d4="" class="fw-bold"> Owner</span><span data-v-f4fcc8d4="">:  </span><i data-v-f4fcc8d4="" class="bi bi-arrow-right"></i> noemail@example.com</div>
+                <div data-v-f4fcc8d4="" class="ms-3 pb-0">
+                  <!--v-if--><span data-v-f4fcc8d4="">Update</span><span data-v-f4fcc8d4="" class="fw-bold"> Owner</span><span data-v-f4fcc8d4="">:  </span><i data-v-f4fcc8d4="" class="bi bi-arrow-right"></i> noemail@example.com
+                </div>
               </li>
             </ul>
           </div>

--- a/src/composables/aegis/__tests__/useAegisMetadataTracking.spec.ts
+++ b/src/composables/aegis/__tests__/useAegisMetadataTracking.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { useAegisMetadataTracking } from '../useAegisMetadataTracking';
+
+describe('useAegisMetadataTracking', () => {
+  let tracking: ReturnType<typeof useAegisMetadataTracking>;
+
+  beforeEach(() => {
+    tracking = useAegisMetadataTracking();
+    tracking.setAegisMetadata({});
+  });
+
+  describe('trackAIChange', () => {
+    it('should track AI changes for fields', () => {
+      tracking.trackAIChange('cwe_id', 'AI');
+
+      const metadata = tracking.getAegisMetadata();
+      expect(metadata.cwe_id).toHaveLength(1);
+      expect(metadata.cwe_id[0].type).toBe('AI');
+      expect(tracking.hasAegisChanges()).toBe(true);
+    });
+
+    it('should track partial AI changes', () => {
+      tracking.trackAIChange('description', 'Partial AI');
+
+      const metadata = tracking.getAegisMetadata();
+      expect(metadata.description).toHaveLength(1);
+      expect(metadata.description[0].type).toBe('Partial AI');
+      expect(tracking.hasAegisChanges()).toBe(true);
+    });
+
+    it('should track multiple changes to the same field', () => {
+      tracking.trackAIChange('cwe_id', 'AI', 'CWE-123');
+      tracking.trackAIChange('cwe_id', 'Partial AI', 'CWE-123 modified');
+
+      const metadata = tracking.getAegisMetadata();
+      expect(metadata.cwe_id).toHaveLength(2);
+      expect(metadata.cwe_id[0].type).toBe('AI');
+      expect(metadata.cwe_id[1].type).toBe('Partial AI');
+    });
+
+    it('should include timestamp and value in tracked changes', () => {
+      const beforeTime = new Date().toISOString();
+      tracking.trackAIChange('cwe_id', 'AI', 'CWE-123');
+      const afterTime = new Date().toISOString();
+
+      const metadata = tracking.getAegisMetadata();
+      const change = metadata.cwe_id[0];
+      expect(change.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      expect(new Date(change.timestamp).getTime()).toBeGreaterThanOrEqual(new Date(beforeTime).getTime());
+      expect(new Date(change.timestamp).getTime()).toBeLessThanOrEqual(new Date(afterTime).getTime());
+      expect(change.value).toBe('CWE-123');
+    });
+  });
+
+  describe('untrackAIChange', () => {
+    it('should remove AI tracking for a field', () => {
+      tracking.trackAIChange('cwe_id', 'AI');
+      tracking.untrackAIChange('cwe_id');
+
+      const metadata = tracking.getAegisMetadata();
+      expect(metadata.cwe_id).toBeUndefined();
+      expect(tracking.hasAegisChanges()).toBe(false);
+    });
+  });
+
+  describe('getAegisMetadata', () => {
+    it('should return all tracked metadata as arrays', () => {
+      tracking.trackAIChange('cwe_id', 'AI');
+      tracking.trackAIChange('description', 'Partial AI');
+
+      const metadata = tracking.getAegisMetadata();
+      expect(metadata.cwe_id).toHaveLength(1);
+      expect(metadata.cwe_id[0].type).toBe('AI');
+      expect(metadata.description).toHaveLength(1);
+      expect(metadata.description[0].type).toBe('Partial AI');
+    });
+
+    it('should return empty object when no tracking', () => {
+      const metadata = tracking.getAegisMetadata();
+      expect(metadata).toEqual({});
+    });
+  });
+
+  describe('setAegisMetadata', () => {
+    it('should set metadata from external source (new format)', () => {
+      const metadata = {
+        cwe_id: [{ type: 'AI' as const, timestamp: '2024-01-01T00:00:00Z' }],
+        description: [{ type: 'Partial AI' as const, timestamp: '2024-01-01T00:00:00Z' }],
+      };
+      tracking.setAegisMetadata(metadata);
+
+      const newMetadata = tracking.getAegisMetadata();
+      expect(newMetadata.cwe_id[0].type).toBe('AI');
+      expect(newMetadata.description[0].type).toBe('Partial AI');
+    });
+
+    it('should handle null/undefined metadata', () => {
+      tracking.trackAIChange('cwe_id', 'AI');
+      tracking.setAegisMetadata(null);
+
+      expect(tracking.hasAegisChanges()).toBe(false);
+
+      tracking.setAegisMetadata(undefined);
+      expect(tracking.hasAegisChanges()).toBe(false);
+    });
+  });
+
+  describe('setAegisMetadata with empty object', () => {
+    it('should clear all tracking when set to empty object', () => {
+      tracking.trackAIChange('cwe_id', 'AI');
+      tracking.trackAIChange('description', 'Partial AI');
+
+      tracking.setAegisMetadata({});
+
+      expect(tracking.hasAegisChanges()).toBe(false);
+      expect(tracking.getAegisMetadata()).toEqual({});
+    });
+  });
+});

--- a/src/composables/aegis/useAISuggestionsWatcher.ts
+++ b/src/composables/aegis/useAISuggestionsWatcher.ts
@@ -1,0 +1,36 @@
+import { ref, readonly, watch, type Ref } from 'vue';
+
+import { useAegisMetadataTracking } from './useAegisMetadataTracking';
+
+export function useAISuggestionsWatcher(fieldName: string, valueRef: Ref<null | string>) {
+  const { trackAIChange, untrackAIChange } = useAegisMetadataTracking();
+
+  const hasAppliedSuggestion = ref(false);
+  const originalSuggestion = ref<null | string>(null);
+
+  // Watch for manual changes after AI suggestion has been applied
+  watch(valueRef, (newValue, oldValue) => {
+    if (hasAppliedSuggestion.value && newValue !== originalSuggestion.value && newValue !== oldValue) {
+      trackAIChange(fieldName, 'Partial AI', newValue || undefined);
+    }
+  });
+
+  const applyAISuggestion = (suggestion: string) => {
+    hasAppliedSuggestion.value = true;
+    originalSuggestion.value = suggestion;
+    valueRef.value = suggestion;
+    trackAIChange(fieldName, 'AI', suggestion);
+  };
+
+  const revertAISuggestion = () => {
+    untrackAIChange(fieldName);
+    hasAppliedSuggestion.value = false;
+    originalSuggestion.value = null;
+  };
+
+  return {
+    hasAppliedSuggestion: readonly(hasAppliedSuggestion),
+    applyAISuggestion,
+    revertAISuggestion,
+  };
+}

--- a/src/composables/aegis/useAegisMetadataTracking.ts
+++ b/src/composables/aegis/useAegisMetadataTracking.ts
@@ -1,7 +1,7 @@
 import { ref } from 'vue';
 
-import type { ZodFlawHistoryItemType } from '../../types/zodFlaw';
-import type { AegisChangeType, AegisChangeEntry, AegisMetadata } from '../../types/aegisAI';
+import type { ZodFlawHistoryItemType, AegisChangeType } from '../../types/zodFlaw';
+import type { AegisChangeEntry, AegisMetadata } from '../../types/aegisAI';
 
 const aegisMetadata = ref<AegisMetadata>({});
 

--- a/src/composables/aegis/useAegisMetadataTracking.ts
+++ b/src/composables/aegis/useAegisMetadataTracking.ts
@@ -1,0 +1,91 @@
+import { ref } from 'vue';
+
+import type { ZodFlawHistoryItemType } from '../../types/zodFlaw';
+import type { AegisChangeType, AegisChangeEntry, AegisMetadata } from '../../types/aegisAI';
+
+const aegisMetadata = ref<AegisMetadata>({});
+
+function trackAIChange(fieldName: string, changeType: AegisChangeType, value?: string) {
+  aegisMetadata.value[fieldName] ||= [];
+  aegisMetadata.value[fieldName].push({
+    type: changeType,
+    timestamp: new Date().toISOString(),
+    value,
+  });
+}
+
+function untrackAIChange(fieldName: string) {
+  delete aegisMetadata.value[fieldName];
+}
+
+function getAegisMetadata(): AegisMetadata {
+  return { ...aegisMetadata.value };
+}
+
+function setAegisMetadata(metadata: AegisMetadata | null | undefined) {
+  aegisMetadata.value = metadata ? { ...metadata } : {};
+}
+
+function hasAegisChanges(): boolean {
+  return Object.keys(aegisMetadata.value).length > 0;
+}
+
+function findMatchingAegisMetadataEntry(fieldMetadata: AegisChangeEntry[], historyTimestamp: Date) {
+  // Find the closest aegis metadata entry by timestamp
+  let closestEntry = null;
+  let smallestDiff = Infinity;
+
+  for (const entry of fieldMetadata) {
+    const entryTimestamp = new Date(entry.timestamp);
+    const timeDiff = Math.abs(entryTimestamp.getTime() - historyTimestamp.getTime());
+
+    if (timeDiff < 15000 && timeDiff < smallestDiff) { // Within 15 second tolerance
+      smallestDiff = timeDiff;
+      closestEntry = entry;
+    }
+  }
+
+  return closestEntry;
+}
+
+function getFieldAegisTypeFromHistory(
+  fieldMetadata: AegisChangeEntry[],
+  historyTimestamp: string): AegisChangeType | null {
+  if (!Array.isArray(fieldMetadata) || fieldMetadata.length === 0) return null;
+
+  const timestamp = new Date(historyTimestamp);
+  const matchingEntry = findMatchingAegisMetadataEntry(fieldMetadata, timestamp);
+
+  return matchingEntry ? matchingEntry.type : null;
+}
+
+function getFieldAegisType(historyEntry: ZodFlawHistoryItemType, fieldName: string): null | string {
+  if (!historyEntry.pgh_diff || fieldName === 'aegis_meta') return null;
+
+  const aegisHistoryChanges = historyEntry.pgh_diff.aegis_meta;
+  if (aegisHistoryChanges && Array.isArray(aegisHistoryChanges) && aegisHistoryChanges.length >= 2) {
+    const newAegisMetaValue = aegisHistoryChanges[1];
+    if (newAegisMetaValue && typeof newAegisMetaValue === 'object') {
+      const fieldMetadata = newAegisMetaValue[fieldName];
+      return getFieldAegisTypeFromHistory(fieldMetadata, historyEntry.pgh_created_at || '');
+    }
+  }
+
+  return null;
+}
+
+function isFieldAegisChange(historyEntry: ZodFlawHistoryItemType, fieldName: string): boolean {
+  return !!getFieldAegisType(historyEntry, fieldName);
+}
+
+export function useAegisMetadataTracking() {
+  return {
+    trackAIChange,
+    untrackAIChange,
+    getAegisMetadata,
+    setAegisMetadata,
+    hasAegisChanges,
+    getFieldAegisType,
+    isFieldAegisChange,
+  };
+}

--- a/src/composables/aegis/useAegisSuggestCwe.ts
+++ b/src/composables/aegis/useAegisSuggestCwe.ts
@@ -33,10 +33,6 @@ export function useAegisSuggestCwe(options: UseAegisSuggestCweOptions) {
 
   const canSuggest = computed(() => isCveIdValid.value && !isSuggesting.value);
 
-  function applyValue(value: string) {
-    (options.valueRef as Ref<null | string>).value = value;
-  }
-
   async function suggestCwe() {
     if (!canSuggest.value) {
       toastStore.addToast({ title: 'AI Suggestion', body: 'Valid CVE ID required for suggestions.' });
@@ -77,7 +73,7 @@ export function useAegisSuggestCwe(options: UseAegisSuggestCweOptions) {
 
   function revert() {
     if (previousValue.value !== null) {
-      applyValue(previousValue.value as string);
+      options.valueRef.value = previousValue.value;
     }
     previousValue.value = null;
     hasAppliedSuggestion.value = false;

--- a/src/composables/aegis/useAegisSuggestCwe.ts
+++ b/src/composables/aegis/useAegisSuggestCwe.ts
@@ -4,6 +4,7 @@ import {
   serializeAegisContext,
   type AegisSuggestionContextRefs,
 } from '@/composables/aegis/useAegisSuggestionContext';
+import { useAISuggestionsWatcher } from '@/composables/aegis/useAISuggestionsWatcher';
 
 import { AegisAIService } from '@/services/AegisAIService';
 import { useToastStore } from '@/stores/ToastStore';
@@ -18,12 +19,13 @@ export type UseAegisSuggestCweOptions = {
 export function useAegisSuggestCwe(options: UseAegisSuggestCweOptions) {
   const toastStore = useToastStore();
   const service = new AegisAIService();
+  const aegisCweSuggestionWatcher = useAISuggestionsWatcher('cwe_id', options.valueRef);
   const isSuggesting = ref(false);
-  const hasAppliedSuggestion = ref(false);
   const previousValue = ref<null | string>(null);
   const details = ref<CweSuggestionDetails | null>(null);
   const requestDuration = ref<null | number>(null);
-  const canShowFeedback = computed(() => hasAppliedSuggestion.value && !isSuggesting.value);
+
+  const canShowFeedback = computed(() => aegisCweSuggestionWatcher.hasAppliedSuggestion.value && !isSuggesting.value);
 
   const isCveIdValid = computed(() => {
     const cveId = (options.context as any)?.cveId?.value ?? (options.context as any)?.cveId;
@@ -41,11 +43,11 @@ export function useAegisSuggestCwe(options: UseAegisSuggestCweOptions) {
     isSuggesting.value = true;
     const requestStartTime = Date.now();
     try {
-      if (!hasAppliedSuggestion.value && previousValue.value == null) {
+      if (!aegisCweSuggestionWatcher.hasAppliedSuggestion.value && previousValue.value == null) {
         previousValue.value = options.valueRef.value;
       }
       const data = await service.analyzeCVEWithContext({
-        feature: 'suggest-cwe',
+        feature: 'suggest-cwe' as const,
         ...serializeAegisContext(options.context),
       });
       requestDuration.value = Date.now() - requestStartTime;
@@ -54,9 +56,13 @@ export function useAegisSuggestCwe(options: UseAegisSuggestCweOptions) {
         toastStore.addToast({ title: 'AI Suggestion', body: 'No valid suggestion received.' });
         return;
       }
-      applyValue(first);
-      details.value = data;
-      hasAppliedSuggestion.value = true;
+      details.value = {
+        cwe: [first],
+        confidence: data.confidence,
+        explanation: data.explanation,
+        tools_used: data.tools_used,
+      };
+      aegisCweSuggestionWatcher.applyAISuggestion(first);
       toastStore.addToast({
         title: 'AI Suggestion Applied',
         body: 'Suggestion applied. Always review AI generated responses prior to use.',
@@ -76,8 +82,8 @@ export function useAegisSuggestCwe(options: UseAegisSuggestCweOptions) {
       options.valueRef.value = previousValue.value;
     }
     previousValue.value = null;
-    hasAppliedSuggestion.value = false;
     details.value = null;
+    aegisCweSuggestionWatcher.revertAISuggestion();
   }
 
   function sendFeedback(kind: 'down' | 'up') {
@@ -131,5 +137,14 @@ export function useAegisSuggestCwe(options: UseAegisSuggestCweOptions) {
     return `${baseUrl}?${params.toString()}`;
   }
 
-  return { canSuggest, canShowFeedback, details, hasAppliedSuggestion, isSuggesting, revert, sendFeedback, suggestCwe };
+  return {
+    canSuggest,
+    canShowFeedback,
+    details,
+    hasAppliedSuggestion: aegisCweSuggestionWatcher.hasAppliedSuggestion,
+    isSuggesting,
+    revert,
+    sendFeedback,
+    suggestCwe,
+  };
 }

--- a/src/composables/useFetchFlaw.ts
+++ b/src/composables/useFetchFlaw.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue';
 
 import { useFlaw } from '@/composables/useFlaw';
 import { resetInitialAffects } from '@/composables/useFlawAffectsModel';
+import { useAegisMetadataTracking } from '@/composables/aegis/useAegisMetadataTracking';
 
 import { getFlaw, getRelatedFlaws } from '@/services/FlawService';
 import type { ZodAffectType } from '@/types';
@@ -15,6 +16,7 @@ const isFetchingAffects = ref(false);
 export function useFetchFlaw() {
   const { flaw, relatedFlaws, resetFlaw, setFlaw } = useFlaw();
   const { addToast } = useToastStore();
+  const { setAegisMetadata } = useAegisMetadataTracking();
 
   const didFetchFail = ref<boolean>(false);
 
@@ -51,6 +53,9 @@ export function useFetchFlaw() {
       const flawResult = await fetchedFlaw;
       setFlaw(Object.assign({ affects: [] }, flawResult));
       history.replaceState(null, '', `/flaws/${(flawResult.cve_id || flawResult.uuid)}`);
+
+      // Initialize aegis metadata tracking with existing data
+      setAegisMetadata(flawResult.aegis_meta);
 
       const affectResults = (await fetchedAffects).data.results;
       flaw.value.affects = affectResults;

--- a/src/types/aegisAI.ts
+++ b/src/types/aegisAI.ts
@@ -1,3 +1,6 @@
+// AI Change Tracking Types
+import type { AegisChangeType } from './zodFlaw';
+
 // Component Feature Names for CVE Analysis
 export type AegisAIComponentFeatureNameType =
   | 'cvss-diff-explainer'
@@ -57,8 +60,6 @@ export type AegisAIHTTPValidationErrorType = {
 };
 
 // AI Change Tracking Types
-export type AegisChangeType = 'AI' | 'Partial AI';
-
 export type AegisChangeEntry = {
   timestamp: string;
   type: AegisChangeType;

--- a/src/types/aegisAI.ts
+++ b/src/types/aegisAI.ts
@@ -55,3 +55,16 @@ export type CweSuggestionDetails = {
 export type AegisAIHTTPValidationErrorType = {
   detail?: AegisAIValidationErrorType[];
 };
+
+// AI Change Tracking Types
+export type AegisChangeType = 'AI' | 'Partial AI';
+
+export type AegisChangeEntry = {
+  timestamp: string;
+  type: AegisChangeType;
+  value?: string;
+};
+
+export type AegisMetadata = {
+  [fieldName: string]: AegisChangeEntry[];
+};

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -19,6 +19,10 @@ import {
 import { zodOsimDateTime, ImpactEnumWithBlank, ZodFlawClassification, ZodAlertSchema } from './zodShared';
 import { ZodAffectSchema, type ZodAffectType } from './zodAffect';
 
+// Aegis AI Change Types
+export const ZodAegisChangeTypeEnum = z.enum(['AI', 'Partial AI']);
+export type AegisChangeType = z.infer<typeof ZodAegisChangeTypeEnum>;
+
 export const RequiresDescriptionEnumWithBlank = { '': '', ...RequiresCveDescriptionEnum } as const;
 export const FlawSourceEnumWithBlank = { '': '', ...FlawSourceEnum } as const;
 // TODO: Remove once OSIDB-3959 is resolved
@@ -188,7 +192,7 @@ export const ZodFlawSchema = z.object({
   ),
   meta_attr: z.record(z.string(), z.string().nullish()).nullish(),
   aegis_meta: z.record(z.string(), z.array(z.object({
-    type: z.enum(['AI', 'Partial AI']),
+    type: ZodAegisChangeTypeEnum,
     timestamp: z.string(),
     value: z.string().optional(),
   }))).nullish(),

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -187,6 +187,11 @@ export const ZodFlawSchema = z.object({
     { message: 'You must specify a source for this Flaw before saving.' },
   ),
   meta_attr: z.record(z.string(), z.string().nullish()).nullish(),
+  aegis_meta: z.record(z.string(), z.array(z.object({
+    type: z.enum(['AI', 'Partial AI']),
+    timestamp: z.string(),
+    value: z.string().optional(),
+  }))).nullish(),
   mitigation: z.string().nullish(),
   major_incident_state: z.nativeEnum(MajorIncidentStateEnumWithBlank).nullable(),
   nist_cvss_validation: z.nativeEnum(NistCvssValidationEnumWithBlank).nullish(),


### PR DESCRIPTION
# OSIDB-4454 Aegis-AI History badges

## Checklist:

- [x] Commits consolidated
- [-] Changelog updated
- [x] Test cases added/updated
- [-] Integration tests updated
- [x] Jira ticket updated

## Summary:

Implement AI metadata tracking for Aegis suggestions in flaw history to flag AI-generated and user-modified AI changes.

## Changes:

- Send AI metadata to OSIDB when saving flaws with AI changes
- Added `aegis_meta` field to Flaw schema for tracking AI interactions
- Created composables for AI metadata tracking and suggestion watching patterns
- Refactored CWE suggestion logic to use new AI tracking system
- Display AI/Partial AI badges in flaw history with explanatory tooltips
- Hide internal `aegis_meta` field from history display


Closes OSIDB-4454
