### PR TITLE
Add fields to Aegis context requests

### DIFF
--- a/src/composables/aegis/useAegisSuggestionContext.ts
+++ b/src/composables/aegis/useAegisSuggestionContext.ts
@@ -1,19 +1,39 @@
 import { computed, type Ref } from 'vue';
 
-import type { ZodFlawType } from '@/types/zodFlaw';
+import { omit } from 'ramda';
+
+import type { ZodFlawCommentType, ZodFlawType } from '@/types/zodFlaw';
+import type { ZodAffectCVSSType, ZodAffectType, ZodFlawCVSSType, ZodFlawReferenceType } from '@/types';
+import { CommentType } from '@/constants';
+
+type AffectWithoutTracker = Omit<ZodAffectType, 'trackers'>;
+
+export function serializePublicComments(comments: ZodFlawCommentType[]) {
+  const maxComments = 15;
+  return comments
+    .filter(comment => comment.type === CommentType.Public)
+    .slice(0, maxComments)
+    .map(comment => comment.text)
+    .join('\n');
+}
 
 export type AegisSuggestionContextRefs = {
-  commentZero?: null | Ref<null | string | undefined>;
-  components?: null | Ref<null | string[] | undefined>;
+  affects?: null | Ref<AffectWithoutTracker[] | null>;
+  comments?: null | Ref<string>;
+  commentZero?: null | Ref<null | string>;
+  components?: null | Ref<null | string[]>;
   cveDescription?: null | Ref<null | string | undefined>;
-  cveId?: null | Ref<null | string | undefined>;
+  cveId?: null | Ref<null | string>;
+  cvssScores?: null | Ref<null | ZodAffectCVSSType[] | ZodFlawCVSSType[]> ;
+  embargoed?: null | Ref<boolean | null>;
+  references?: null | Ref<null | ZodFlawReferenceType[]>;
   requiresCveDescription?: null | Ref<null | string | undefined>;
   statement?: null | Ref<null | string | undefined>;
-  title?: null | Ref<null | string | undefined>;
+  title?: null | Ref<null | string>;
 };
 
 export function aegisSuggestionRequestBody(flaw: Ref<ZodFlawType>): AegisSuggestionContextRefs {
-  const ctx = {
+  return {
     cveId: computed(() => flaw.value.cve_id),
     title: computed(() => flaw.value.title),
     commentZero: computed(() => flaw.value.comment_zero),
@@ -21,9 +41,12 @@ export function aegisSuggestionRequestBody(flaw: Ref<ZodFlawType>): AegisSuggest
     requiresCveDescription: computed(() => flaw.value.requires_cve_description),
     statement: computed(() => flaw.value.statement),
     components: computed(() => flaw.value.components),
+    comments: computed(() => serializePublicComments(flaw.value.comments)),
+    references: computed(() => flaw.value.references),
+    embargoed: computed(() => flaw.value.embargoed),
+    cvssScores: computed(() => flaw.value.cvss_scores),
+    affects: computed(() => flaw.value.affects.map(affect => omit(['trackers'], affect))),
   };
-
-  return ctx;
 }
 
 export function serializeAegisContext(ctx: AegisSuggestionContextRefs) {
@@ -35,5 +58,10 @@ export function serializeAegisContext(ctx: AegisSuggestionContextRefs) {
     requires_cve_description: ctx.requiresCveDescription?.value ?? undefined,
     statement: ctx.statement?.value ?? undefined,
     components: ctx.components?.value ?? undefined,
+    comments: ctx.comments?.value ?? undefined,
+    references: ctx.references?.value ?? undefined,
+    embargoed: ctx.embargoed?.value ?? undefined,
+    cvss_scores: ctx.cvssScores?.value ?? undefined,
+    affects: ctx.affects?.value ?? undefined,
   };
 }


### PR DESCRIPTION
Adds cvss_scores, comments, affects, references, and embargoed fields to request to Aegis
