### PR TITLE
🐛 Fix history hidden on flaw save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 * Fix multi-row operations in affects table (`OSIDB-4381`)
 * Affect's CVSS changes not saved/commited (`OSIDB-4431`)
+* Fix history section becoming hidden after saving flaw changes (`OSIDB-4491`)
 
 ## [2025.9.0]
 ### Added

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -128,6 +128,7 @@ export async function putFlaw(uuid: string, flawObject: ZodFlawType, createJiraT
       url: `/osidb/api/v1/flaws/${uuid}`,
       data: flawObject,
       params: {
+        include_history: 'true',
         ...(createJiraTask && { create_jira_task: true }),
       },
     }, { beforeFetch });


### PR DESCRIPTION
# OSIDB-4491 Fix history hidden on flaw save

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [-] Integration tests updated
- [x] Jira ticket updated

## Summary:

History included param was missing in flaw put request so the response didn't include it and it was becoming hidden after saving any changes.

## Changes:

- Ensure history is included on put flaw response

Closes OSIDB-4491
