### PR TITLE
👽️ Jira API v3 upgrade

### DIFF
--- a/src/components/FlawComments/CommentList.vue
+++ b/src/components/FlawComments/CommentList.vue
@@ -65,9 +65,24 @@ async function parseJiraTags(text: string): Promise<string> {
 
 watch(() => props.commentList, async (comments) => {
   isParsingComments.value = true;
-  parsedComments.value = await Promise.all(
-    comments.map(c => parseJiraTags(linkify(sanitizeHtml(c.text ?? '')))),
+
+  // Pre-resolve display names for internal comment authors (accountId → displayName)
+  await Promise.all(
+    comments
+      .filter(c => c.type === CommentType.Internal && c.creator)
+      .map(c => resolveAccountId(c.creator!)),
   );
+
+  parsedComments.value = await Promise.all(
+    comments.map(async (c) => {
+      if (c.type === CommentType.Internal) {
+        // renderedBody is pre-rendered HTML from Jira — only sanitize, skip wiki parsing
+        return sanitizeHtml(c.text ?? '');
+      }
+      return parseJiraTags(linkify(sanitizeHtml(c.text ?? '')));
+    }),
+  );
+
   isParsingComments.value = false;
 }, { immediate: true });
 
@@ -100,7 +115,7 @@ function getCommentTooltip(type: CommentType | undefined) {
           :href="jiraUserUrl(comment.creator || '')"
           target="_blank"
         >
-          {{ comment.creator }}
+          {{ comment.creator ? (userDisplayNameCache[comment.creator] ?? comment.creator) : '' }}
         </a>
         <span v-else>{{ comment.creator }}</span>
         - {{ DateTime.fromISO(comment.created_dt ?? '',{ setZone: true })

--- a/src/components/FlawComments/CommentList.vue
+++ b/src/components/FlawComments/CommentList.vue
@@ -23,15 +23,7 @@ const isParsingComments = ref(false);
 function linkify(text: string) {
   const bugzillaLink = `${osimRuntime.value.backends.bugzilla}/show_bug.cgi?id=`;
   const bugzillaRegex = /\[bug (\d+)\]/g;
-  // On-premise format: [display text|https://url]
-  const jiraLinkRegex = /\[([^|\]]+)\|(https?:\/\/[^\]]+)\]/g;
-  // Jira Cloud smart link format: [https://url|smart-link]
-  const jiraSmartLinkRegex = /\[(https?:\/\/[^\]|]+)\|smart-link\]/g;
-
-  return text
-    .replace(bugzillaRegex, `<a target="_blank" href="${bugzillaLink}$1">[bug $1]</a>`)
-    .replace(jiraSmartLinkRegex, '<a target="_blank" href="$1">$1</a>')
-    .replace(jiraLinkRegex, '<a target="_blank" href="$2">$1</a>');
+  return text.replace(bugzillaRegex, `<a target="_blank" href="${bugzillaLink}$1">[bug $1]</a>`);
 }
 
 async function resolveAccountId(accountId: string): Promise<string> {
@@ -44,25 +36,6 @@ async function resolveAccountId(accountId: string): Promise<string> {
   return displayName;
 }
 
-async function parseJiraTags(text: string): Promise<string> {
-  const jiraTagRegex = /\[~([^[\]]+)\]/g;
-  const matches = [...text.matchAll(jiraTagRegex)];
-
-  for (const [match, p1] of matches) {
-    const accountIdMatch = p1.match(/^accountid:(.+)$/);
-    if (accountIdMatch) {
-      const accountId = accountIdMatch[1];
-      const displayName = await resolveAccountId(accountId);
-      const url = `${osimRuntime.value.backends.jiraDisplay}/jira/people/${accountId}`;
-      text = text.replace(match, `<a target="_blank" href="${url}">@${displayName}</a>`);
-    } else {
-      const url = `${osimRuntime.value.backends.jiraDisplay}/ViewProfile.jspa?name=${p1}`;
-      text = text.replace(match, `<a target="_blank" href="${url}">${p1}</a>`);
-    }
-  }
-  return text;
-}
-
 watch(() => props.commentList, async (comments) => {
   isParsingComments.value = true;
 
@@ -73,15 +46,13 @@ watch(() => props.commentList, async (comments) => {
       .map(c => resolveAccountId(c.creator!)),
   );
 
-  parsedComments.value = await Promise.all(
-    comments.map(async (c) => {
-      if (c.type === CommentType.Internal) {
-        // renderedBody is pre-rendered HTML from Jira — only sanitize, skip wiki parsing
-        return sanitizeHtml(c.text ?? '');
-      }
-      return parseJiraTags(linkify(sanitizeHtml(c.text ?? '')));
-    }),
-  );
+  parsedComments.value = comments.map((c) => {
+    if (c.type === CommentType.Internal) {
+      // renderedBody is pre-rendered HTML from Jira — only sanitize
+      return sanitizeHtml(c.text ?? '');
+    }
+    return linkify(sanitizeHtml(c.text ?? ''));
+  });
 
   isParsingComments.value = false;
 }, { immediate: true });

--- a/src/components/__tests__/CommentList.spec.ts
+++ b/src/components/__tests__/CommentList.spec.ts
@@ -45,26 +45,6 @@ describe('commentList', () => {
     expect(commentText.text()).toContain('pkg:oci/dotnet-80');
   });
 
-  it('should parse valid Jira link syntax [text|url]', async () => {
-    const comments: ZodFlawCommentType[] = [
-      createTestComment(
-        'Check this link: [Example Docs|https://example.com/docs/policy]',
-      ),
-    ];
-
-    const wrapper = mountWithConfig(CommentList, {
-      props: {
-        commentList: comments,
-      },
-    });
-    await flushPromises();
-
-    const commentText = wrapper.find('.osim-flaw-comment');
-    // Should contain an anchor tag with the proper URL
-    expect(commentText.html())
-      .toContain('<a target="_blank" href="https://example.com/docs/policy">');
-  });
-
   it('should parse bugzilla bug references', async () => {
     const comments: ZodFlawCommentType[] = [
       createTestComment('See [bug 12345] for details'),
@@ -80,23 +60,6 @@ describe('commentList', () => {
     const commentText = wrapper.find('.osim-flaw-comment');
     expect(commentText.html()).toContain('[bug 12345]</a>');
     expect(commentText.html()).toContain('show_bug.cgi?id=12345');
-  });
-
-  it('should parse Jira user tags', async () => {
-    const comments: ZodFlawCommentType[] = [
-      createTestComment('Hey [~someuser] can you check this?'),
-    ];
-
-    const wrapper = mountWithConfig(CommentList, {
-      props: {
-        commentList: comments,
-      },
-    });
-    await flushPromises();
-
-    const commentText = wrapper.find('.osim-flaw-comment');
-    expect(commentText.html()).toContain('ViewProfile.jspa?name=someuser');
-    expect(commentText.html()).toContain('>someuser</a>');
   });
 
   it('should handle text with multiple grep-style pipes without creating links', async () => {
@@ -124,8 +87,7 @@ rhel-8.10.z    pkg:oci/dotnet-90?repository_url=registry.example.com/rhel8/dotne
   it('should handle mixed content with valid and invalid link patterns', async () => {
     const comments: ZodFlawCommentType[] = [
       createTestComment(
-        'See [bug 123] and [Example Site|https://example.com] but not this: '
-        + 'rhel-8.10.z pkg:oci/test (version, nuget)',
+        'See [bug 123] but not this: rhel-8.10.z pkg:oci/test (version, nuget)',
       ),
     ];
 
@@ -137,10 +99,9 @@ rhel-8.10.z    pkg:oci/dotnet-90?repository_url=registry.example.com/rhel8/dotne
     await flushPromises();
 
     const commentText = wrapper.find('.osim-flaw-comment');
-    // Should have exactly 2 links: bug ref and valid Jira link
+    // Should have exactly 1 link: bugzilla bug reference only
     const anchorCount = (commentText.html().match(/<a /g) || []).length;
-    expect(anchorCount).toBe(2);
+    expect(anchorCount).toBe(1);
     expect(commentText.html()).toContain('show_bug.cgi?id=123');
-    expect(commentText.html()).toContain('href="https://example.com"');
   });
 });

--- a/src/composables/__tests__/useFlawCommentsModel.spec.ts
+++ b/src/composables/__tests__/useFlawCommentsModel.spec.ts
@@ -68,7 +68,7 @@ describe('useFlawCommentsModel', () => {
   it('should load internal comments when task_key is present', async () => {
     vi.mocked(getJiraComments, { partial: true }).mockResolvedValue({
       response: { ok: true } as Response,
-      data: { comments: [{ author: { name: 'author' }, created: 'date', body: 'body' }] },
+      data: { comments: [{ author: { accountId: 'author' }, created: 'date', renderedBody: 'body' }] },
     });
     const {
       internalComments,

--- a/src/composables/__tests__/useJiraContributors.spec.ts
+++ b/src/composables/__tests__/useJiraContributors.spec.ts
@@ -27,13 +27,13 @@ describe('useJiraContributors', () => {
       accountId: 'account-id-1',
       displayName: 'Alvaro Tinoco',
       emailAddress: 'atinoco@example.com',
-      self: 'https://redhat.atlassian.net/rest/api/2/user?accountId=account-id-1',
+      self: 'https://redhat.atlassian.net/rest/api/3/user?accountId=account-id-1',
     },
     {
       accountId: 'account-id-2',
       displayName: 'John Doe',
       emailAddress: 'jdoe@example.com',
-      self: 'https://redhat.atlassian.net/rest/api/2/user?accountId=account-id-2',
+      self: 'https://redhat.atlassian.net/rest/api/3/user?accountId=account-id-2',
     },
   ];
 

--- a/src/composables/useFlawCommentsModel.ts
+++ b/src/composables/useFlawCommentsModel.ts
@@ -111,13 +111,13 @@ export function useFlawCommentsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<boole
   }
 
   function parseJiraComments(comments: ZodFlawCommentType[]) {
-    return comments.map((comment: any) => {
-      return {
-        creator: comment.author.name,
-        created_dt: comment.created,
-        text: comment.body,
-      };
-    }) as ZodFlawCommentType[];
+    return comments.map((comment: any) => ({
+      // accountId used by CommentList.vue to build profile URL and resolve display name
+      creator: comment.author.accountId,
+      created_dt: comment.created,
+      // renderedBody is pre-rendered HTML from Jira (requires ?expand=renderedBody)
+      text: comment.renderedBody ?? '',
+    })) as ZodFlawCommentType[];
   }
 
   return {

--- a/src/services/JiraService.ts
+++ b/src/services/JiraService.ts
@@ -90,23 +90,22 @@ async function jiraFetch<T = any>(config: JiraFetchOptions, factoryOptions?: Jir
 export async function getJiraComments(taskId: string) {
   return jiraFetch({
     method: 'get',
-    url: `/rest/api/2/issue/${taskId}/comment`,
+    url: `/rest/api/3/issue/${taskId}/comment`,
   });
 }
 
 export async function getJiraUser(accountId: string) {
   return jiraFetch<{ accountId: string; displayName: string }>({
     method: 'get',
-    url: '/rest/api/2/user',
+    url: '/rest/api/3/user',
     params: { accountId },
   }).then(res => res.data).catch(() => null);
 }
 
 export async function searchJiraUsers(query: string, issueKey: string) {
-  // Jira Cloud uses /rest/api/2/user/assignable/search, on-premise uses /rest/internal/2/users/assignee
   return jiraFetch<ZodJiraUserAssignableType[]>({
     method: 'get',
-    url: '/rest/api/2/user/assignable/search',
+    url: '/rest/api/3/user/assignable/search',
     params: { issueKey, query },
   });
 }
@@ -114,7 +113,7 @@ export async function searchJiraUsers(query: string, issueKey: string) {
 export async function getJiraIssue(taskId: string) {
   return jiraFetch<ZodJiraIssueType>({
     method: 'get',
-    url: `/rest/api/2/issue/${taskId}`,
+    url: `/rest/api/3/issue/${taskId}`,
   });
 }
 
@@ -137,7 +136,7 @@ export async function putJiraIssue<T extends object | undefined,
   U extends putIssueUpdate | undefined>(taskId: string, opts: putIssueOptions<T, U>) {
   return jiraFetch({
     method: 'put',
-    url: `/rest/api/2/issue/${taskId}`,
+    url: `/rest/api/3/issue/${taskId}`,
     ...opts,
   });
 }
@@ -145,7 +144,7 @@ export async function putJiraIssue<T extends object | undefined,
 export async function postJiraComment(taskId: string, comment: string) {
   return jiraFetch({
     method: 'post',
-    url: `/rest/api/2/issue/${taskId}/comment`,
+    url: `/rest/api/3/issue/${taskId}/comment`,
     data: {
       body: comment,
     },
@@ -158,7 +157,7 @@ export async function postJiraComment(taskId: string, comment: string) {
 export async function getJiraUsername() {
   return jiraFetch({
     method: 'get',
-    url: '/rest/api/2/myself',
+    url: '/rest/api/3/myself',
   }).then((res) => {
     if (res.response.ok) {
       return res.data.displayName || res.data.name || res.data.accountId || res.data.emailAddress;

--- a/src/services/JiraService.ts
+++ b/src/services/JiraService.ts
@@ -7,6 +7,7 @@ import {
   osimRuntime,
 } from '@/stores/osimRuntime';
 import type { ZodJiraUserAssignableType, ZodJiraIssueType } from '@/types/zodJira';
+import { jiraMarkupToAdf } from '@/utils/jiraAdf';
 
 type JiraFetchCallbacks = {
   beforeFetch?: (options: JiraFetchOptions) => Promise<void> | void;
@@ -91,6 +92,7 @@ export async function getJiraComments(taskId: string) {
   return jiraFetch({
     method: 'get',
     url: `/rest/api/3/issue/${taskId}/comment`,
+    params: { expand: 'renderedBody' },
   });
 }
 
@@ -146,7 +148,7 @@ export async function postJiraComment(taskId: string, comment: string) {
     method: 'post',
     url: `/rest/api/3/issue/${taskId}/comment`,
     data: {
-      body: comment,
+      body: jiraMarkupToAdf(comment),
     },
   })
     .then(createSuccessHandler({ title: 'Success!', body: 'Internal comment saved' }))

--- a/src/utils/jiraAdf.ts
+++ b/src/utils/jiraAdf.ts
@@ -1,0 +1,129 @@
+/**
+ * Utilities for Atlassian Document Format (ADF) used by Jira Cloud REST API v3.
+ * Converts OSIM's Jira markup (used in internal comment editor) to ADF for posting.
+ */
+
+type AdfTextNode = {
+  marks?: Array<{ attrs?: Record<string, any>; type: string }>;
+  text: string;
+  type: 'text';
+};
+
+type AdfMentionNode = {
+  attrs: { accessLevel: string; id: string; text: string };
+  type: 'mention';
+};
+
+type AdfInlineNode = AdfMentionNode | AdfTextNode;
+
+type AdfParagraphNode = {
+  content: AdfInlineNode[];
+  type: 'paragraph';
+};
+
+type AdfCodeBlockNode = {
+  attrs: { language: string };
+  content: [AdfTextNode];
+  type: 'codeBlock';
+};
+
+type AdfBlockquoteNode = {
+  content: AdfParagraphNode[];
+  type: 'blockquote';
+};
+
+type AdfBlockNode = AdfBlockquoteNode | AdfCodeBlockNode | AdfParagraphNode;
+
+export type AdfDoc = {
+  content: AdfBlockNode[];
+  type: 'doc';
+  version: 1;
+};
+
+function parseLinksAndMentions(text: string): AdfInlineNode[] {
+  const mentionOrLink = new RegExp(
+    String.raw`\[~accountid:(?<accountId>[^\]]+)\]` +
+    String.raw`|\[(?<linkText>[^|\]]+)\|(?<linkHref>https?://[^\]]+)\]` +
+    String.raw`|\[(?<smartHref>https?://[^\]|]+)\|smart-link\]`,
+    'g',
+  );
+  const nodes: AdfInlineNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(mentionOrLink)) {
+    const matchIndex = match.index ?? 0;
+    if (matchIndex > lastIndex) {
+      nodes.push({ text: text.slice(lastIndex, matchIndex), type: 'text' });
+    }
+
+    const { accountId, linkHref, linkText, smartHref } = match.groups!;
+    if (accountId) {
+      nodes.push({ attrs: { accessLevel: '', id: accountId, text: `@${accountId}` }, type: 'mention' });
+    } else {
+      const href = linkHref ?? smartHref;
+      nodes.push({ marks: [{ attrs: { href }, type: 'link' }], text: linkText ?? smartHref, type: 'text' });
+    }
+
+    lastIndex = matchIndex + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push({ text: text.slice(lastIndex), type: 'text' });
+  }
+
+  return nodes;
+}
+
+function textToBlocks(text: string): AdfParagraphNode[] {
+  return text
+    .split(/\n/)
+    .map(line => ({
+      content: parseLinksAndMentions(line),
+      type: 'paragraph' as const,
+    }))
+    .filter(p => p.content.length > 0);
+}
+
+/**
+ * Converts Jira markup to ADF.
+ * Handles: plain text, {noformat} code blocks, {quote} blockquotes,
+ * [~accountid:UUID] mentions, [text|url] links, [url|smart-link] smart links.
+ */
+export function jiraMarkupToAdf(markup: string): AdfDoc {
+  const content: AdfBlockNode[] = [];
+  const blockPattern = /\{noformat\}([\s\S]*?)\{noformat\}|\{quote\}([\s\S]*?)\{quote\}/g;
+
+  let lastIndex = 0;
+  let match: null | RegExpExecArray;
+
+  while ((match = blockPattern.exec(markup)) !== null) {
+    if (match.index > lastIndex) {
+      content.push(...textToBlocks(markup.slice(lastIndex, match.index)));
+    }
+
+    if (match[1] !== undefined) {
+      content.push({
+        attrs: { language: '' },
+        content: [{ text: match[1], type: 'text' }],
+        type: 'codeBlock',
+      });
+    } else if (match[2] !== undefined) {
+      content.push({
+        content: textToBlocks(match[2]),
+        type: 'blockquote',
+      });
+    }
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < markup.length) {
+    content.push(...textToBlocks(markup.slice(lastIndex)));
+  }
+
+  if (content.length === 0) {
+    content.push({ content: [], type: 'paragraph' });
+  }
+
+  return { content, type: 'doc', version: 1 };
+}


### PR DESCRIPTION
# OSIDB-4535 Jira API v3 upgrade

## Checklist:

- [x] Commits consolidated
- [-] Changelog updated
- [x] Test cases added/updated
- [-] Integration tests updated
- [x] Jira ticket updated

## Summary:

Upgrades OSIM's Jira integration from REST API v2 to v3. Comments are now sent as `Atlassian Document Format (ADF)` and displayed using Jira's server-side pre-rendered HTML.

## Changes:

- All Jira endpoints updated to `/rest/api/3/`
- New `jiraAdf` utility converts Jira markup to ADF for posting comments
- Internal comments display now uses `renderedBody` (pre-rendered HTML from Jira) instead of client-side parsing
- Removed `parseJiraTags` — no longer needed since Jira renders mentions and links server-side

## Considerations:

- Pending Jira stage availability for proper testing
- `linkify` still applied to comments from Bugzilla
- Jira link patterns ([text|url], smart links) were removed from `linkify`
- `?expand=renderedBody` is required on the GET comments request — without it, renderedBody is absent and internal comments will display empty

Closes OSIDB-4545
