### PR TITLE
✨ Add email validation to owner field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # OSIM Changelog
+## [Unreleased]
+### Added
+* Added email validation on Flaw Owner field (`OSIDB-4846`)
+
 ## [2026.4.0]
 ### Added
 * Add explanation tooltips to Aegis Bot values (`OSIDB-4841`)

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -451,7 +451,7 @@ const isArrayFieldValueAIBot = (fieldName: string, currentValue: null | string[]
             @updateFlaw="updateFlaw"
             @update:model-value="onUnembargoed"
           />
-          <FlawFormOwner v-model="flaw.owner" :taskKey="flaw.task_key" />
+          <FlawFormOwner v-model="flaw.owner" :taskKey="flaw.task_key" :error="errors.owner" />
           <LabelStatic
             v-if="mode === 'edit'"
             :modelValue="createdDate"

--- a/src/components/FlawFormOwner/FlawFormOwner.vue
+++ b/src/components/FlawFormOwner/FlawFormOwner.vue
@@ -6,6 +6,7 @@ import { useMemoize } from '@vueuse/core';
 import { createCatchHandler } from '@/composables/service-helpers';
 
 import { searchJiraUsers } from '@/services/JiraService';
+import { useToastStore } from '@/stores/ToastStore';
 import { useUserStore } from '@/stores/UserStore';
 import type { ZodJiraUserAssignableType } from '@/types/zodJira';
 import LabelDiv from '@/widgets/LabelDiv/LabelDiv.vue';
@@ -13,16 +14,18 @@ import EditableTextWithSuggestions from '@/widgets/EditableTextWithSuggestions/E
 import JiraUser from '@/widgets/JiraUser/JiraUser.vue';
 
 const props = defineProps<{
+  error?: null | string;
   taskKey?: null | string;
 }>();
 const owner = defineModel<null | string>({ default: null });
 const userStore = useUserStore();
+const { addToast } = useToastStore();
 
-function selfAssign(fn?: (arg?: any) => any) {
+function selfAssign(onComplete?: () => void) {
   if (userStore.userEmail) {
     owner.value = userStore.userEmail;
   }
-  if (fn) nextTick(fn);
+  if (onComplete) nextTick(onComplete);
 }
 
 const isAssignedToMe = computed(() =>
@@ -50,22 +53,37 @@ const onQueryChange = async (query: string) => {
   queryRef.value = query;
 };
 
-const handleSuggestionClick = (fn: (args?: any) => void, user: ZodJiraUserAssignableType) => {
-  owner.value = user.emailAddress ?? user.name ?? null;
+function handleSuggestionClick(closeSuggestions: () => void, user: ZodJiraUserAssignableType) {
+  const email = user.emailAddress?.trim();
+  if (!email) {
+    addToast({
+      title: 'Cannot assign owner',
+      body: 'This Jira user has no visible email address. Choose another user or enter an email manually.',
+      css: 'warning',
+    });
+    nextTick(closeSuggestions);
+    return;
+  }
+  owner.value = email;
   results.value = [];
-  nextTick(fn);
-};
+  nextTick(closeSuggestions);
+}
 </script>
 
 <template>
   <LabelDiv label="Owner" :loading="isLoading" class="mb-2">
-    <EditableTextWithSuggestions v-model="owner" class="col-12" @update:query="onQueryChange">
+    <EditableTextWithSuggestions
+      v-model="owner"
+      class="col-12"
+      :error="error"
+      @update:query="onQueryChange"
+    >
       <template v-if="!isAssignedToMe" #buttons-out-of-editing-mode="{ onBlur }">
         <button
           type="button"
           class="btn btn-primary osim-self-assign"
           :disabled="isLoading"
-          @click.prevent.stop="selfAssign(onBlur)"
+          @click.prevent.stop="selfAssign(() => onBlur(null))"
         >
           Self Assign
         </button>
@@ -75,7 +93,7 @@ const handleSuggestionClick = (fn: (args?: any) => void, user: ZodJiraUserAssign
           type="button"
           class="btn btn-primary osim-self-assign"
           :disabled="isLoading"
-          @click.prevent.stop="selfAssign(onBlur)"
+          @click.prevent.stop="selfAssign(() => onBlur(null))"
         >
           Self Assign
         </button>

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -312,12 +312,12 @@ describe('flawForm', () => {
   });
 
   osimFullFlawTest('displays correct Owner field value from props', async ({ flaw }) => {
-    flaw.owner = 'test owner';
+    flaw.owner = 'test.owner@example.com';
     const subject = mountWithProps(flaw, { mode: 'edit' });
     const assigneeField = subject.findComponent(FlawFormOwner);
     expect(assigneeField?.find('span.form-label').text()).toBe('Owner');
-    expect(assigneeField?.props().modelValue).toBe('test owner');
-    expect(assigneeField?.html()).toContain('test owner');
+    expect(assigneeField?.props().modelValue).toBe('test.owner@example.com');
+    expect(assigneeField?.html()).toContain('test.owner@example.com');
   });
 
   osimFullFlawTest('displays correct State field value from props', async ({ flaw }) => {

--- a/src/components/__tests__/FlawFormOwner.spec.ts
+++ b/src/components/__tests__/FlawFormOwner.spec.ts
@@ -16,6 +16,11 @@ vi.mock('@/stores/UserStore', () => ({
   }),
 }));
 
+const addToast = vi.fn();
+vi.mock('@/stores/ToastStore', () => ({
+  useToastStore: vi.fn(() => ({ addToast })),
+}));
+
 describe('owner field', () => {
   let subject: VueWrapper<InstanceType<typeof FlawFormOwner>>;
 
@@ -24,6 +29,7 @@ describe('owner field', () => {
   });
 
   beforeEach(() => {
+    addToast.mockClear();
     subject = mountWithConfig(FlawFormOwner, {
       props: {
         taskKey: 'OSIM-1234',
@@ -65,6 +71,16 @@ describe('owner field', () => {
     expect(searchJiraUsers).toHaveBeenCalled();
   });
 
+  it('shows validation error when error prop is set', () => {
+    subject = mountWithConfig(FlawFormOwner, {
+      props: {
+        taskKey: 'OSIM-1234',
+        error: 'Owner must be a valid email address.',
+      },
+    });
+    expect(subject.find('.invalid-tooltip').text()).toBe('Owner must be a valid email address.');
+  });
+
   it('should show results when input changes', async () => {
     vi.mocked(searchJiraUsers, { partial: true }).mockResolvedValueOnce({
       data: [{ accountId: 'test-id', displayName: 'Test User' }],
@@ -76,5 +92,50 @@ describe('owner field', () => {
     await flushPromises();
 
     expect(subject.text()).toContain('Test User');
+  });
+
+  it('does not set owner when Jira user has no email; shows toast', async () => {
+    vi.mocked(searchJiraUsers, { partial: true }).mockResolvedValueOnce({
+      data: [{ accountId: 'test-id', displayName: 'Test User', name: 'jdoe' }],
+    });
+    const input = subject.find('input');
+    await input.setValue('test');
+
+    vi.runAllTimers();
+    await flushPromises();
+
+    await subject.find('.item').trigger('click');
+    await flushPromises();
+
+    expect(addToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Cannot assign owner',
+        css: 'warning',
+      }),
+    );
+    expect(subject.props('modelValue')).toBeNull();
+  });
+
+  it('sets owner from Jira user emailAddress only', async () => {
+    vi.mocked(searchJiraUsers, { partial: true }).mockResolvedValueOnce({
+      data: [{
+        accountId: 'test-id',
+        displayName: 'Test User',
+        name: 'jdoe',
+        emailAddress: 'colleague@redhat.com',
+      }],
+    });
+    const input = subject.find('input');
+    await input.setValue('test');
+
+    vi.runAllTimers();
+    await flushPromises();
+
+    await subject.find('.item').trigger('click');
+    await flushPromises();
+
+    expect(addToast).not.toHaveBeenCalled();
+    const updates = subject.emitted('update:modelValue');
+    expect(updates?.at(-1)).toEqual(['colleague@redhat.com']);
   });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,7 @@ export {
   flawImpacts,
   flawIncidentStates,
   flawSources,
+  ZodFlawOwnerSchema,
   ZodFlawSchema,
 } from '@/types/zodFlaw';
 

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -156,6 +156,16 @@ export type ZodFlawLabelType = NonNullable<ZodFlawType['labels']>[number];
 export type ZodFlawType = z.infer<typeof ZodFlawSchema>;
 export type FlawSchemaType = typeof ZodFlawSchema;
 
+export const ZodFlawOwnerSchema = z.preprocess(
+  v => typeof v === 'string' ? v.trim() || '' : v,
+  z.union([
+    z.null(),
+    z.undefined(),
+    z.literal(''),
+    z.string().max(60, 'Owner cannot exceed 60 characters.').email('Owner must be a valid email address.'),
+  ]),
+);
+
 export const ZodFlawSchema = z.object({
   uuid: z.string().default(''),
   cve_id: z.string().nullable().refine(
@@ -170,7 +180,7 @@ export const ZodFlawSchema = z.object({
   impact: z.nativeEnum(ImpactEnumWithBlank).nullable(),
   components: z.array(z.string().min(1).max(100)),
   title: z.string().min(4),
-  owner: z.string().nullish(),
+  owner: ZodFlawOwnerSchema,
   history: z.array(z.any()).nullish(),
   team_id: z.string().nullish(),
   trackers: z.array(z.string()).nullish(), // read-only


### PR DESCRIPTION
# OSIDB-4846 Add email validation to owner field

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated
- [x] Jira ticket updated

## Summary:

Adds email validation to the owner field with automatic whitespace trimming. Only Jira users with visible emails can be assigned.

## Changes:

- Add email validation schema with 60 char limit and auto-trim
- Block Jira assignments without visible email (show warning toast)
- Add comprehensive schema and component tests
- Document breaking change for legacy non-email owners

## Considerations:

[Replace with any additional considerations, notes, or instructions for reviewers.]

Closes OSIDB-4846
