### PR TITLE
✨ Suport lowercase CVE IDs in URL params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # OSIM Changelog
+## [Unreleased]
+* Support lowercase CVE IDs on URLs (Flaw links, advance search and quick search) (`OSIDB-4925`)
+
 ## [2026.4.1]
 ### Added
 * Added email validation on Flaw Owner field (`OSIDB-4846`)

--- a/src/components/Navbar/Navbar.vue
+++ b/src/components/Navbar/Navbar.vue
@@ -14,7 +14,7 @@ import { useSettingsStore } from '@/stores/SettingsStore';
 import { useToastStore } from '@/stores/ToastStore';
 import { navbarBottom, navbarHeight } from '@/stores/responsive';
 import { osimRuntime } from '@/stores/osimRuntime';
-import { cveRegex } from '@/utils/helpers';
+import { cveRegex, normalizeCveId } from '@/utils/helpers';
 import RedHatIconSvg from '@/assets/Logo-Red_Hat-Hat_icon-Standard-RGB.svg';
 
 import TourMenu from '../TourMenu/TourMenu.vue';
@@ -52,7 +52,7 @@ function onSearch(query: string) {
   }
   const maybeCveId = quickMatchCVE(query);
   if (maybeCveId) {
-    router.push({ path: `/flaws/${maybeCveId}` });
+    router.push({ path: `/flaws/${normalizeCveId(maybeCveId)}` });
     return;
   }
   submitQuickSearch(trimmedQuery);

--- a/src/composables/useFetchFlaw.ts
+++ b/src/composables/useFetchFlaw.ts
@@ -10,6 +10,7 @@ import { useTourStore } from '@/stores/TourStore';
 import { osimRuntime } from '@/stores/osimRuntime';
 import { getDisplayedOsidbError } from '@/services/osidb-errors-helpers';
 import { getAffects } from '@/services/AffectService';
+import { isCveValid, normalizeCveId } from '@/utils/helpers';
 
 const isFetchingAffects = ref(false);
 const totalAffectCount = ref(0);
@@ -49,11 +50,13 @@ export function useFetchFlaw() {
       return;
     }
 
+    const normalizedId = isCveValid(flawCveOrId) ? normalizeCveId(flawCveOrId) : flawCveOrId;
+
     try {
       didFetchFail.value = false;
       historyFetchError.value = false;
-      const fetchedFlaw = getFlaw(flawCveOrId);
-      const fetchedAffects = fetchFlawAffects(flawCveOrId);
+      const fetchedFlaw = getFlaw(normalizedId);
+      const fetchedAffects = fetchFlawAffects(normalizedId);
 
       const flawResult = await fetchedFlaw;
       setFlaw(Object.assign({ affects: [], history: undefined }, flawResult));

--- a/src/composables/useMultiFlawTrackers.ts
+++ b/src/composables/useMultiFlawTrackers.ts
@@ -5,7 +5,7 @@ import { createSharedComposable } from '@vueuse/core';
 import { getAffects } from '@/services/AffectService';
 import { useToastStore } from '@/stores/ToastStore';
 import { parseOsidbErrors } from '@/services/osidb-errors-helpers';
-import { isCveValid, isUUID4Valid } from '@/utils/helpers';
+import { isCveValid, isUUID4Valid, normalizeCveId } from '@/utils/helpers';
 import type { ZodAffectType } from '@/types';
 
 import { useFlaw } from './useFlaw';
@@ -94,12 +94,11 @@ function useMultiFlawTrackersComposable() {
   const cveStreamCount = computed(() => streamData.value.cveStreamCount);
 
   function addFlaw(identifier: string) {
-    if (!isIdValid(identifier) || relatedAffects.has(identifier)) {
+    const tmpId = isCveValid(identifier) ? normalizeCveId(identifier) : identifier;
+    if (!isIdValid(tmpId) || relatedAffects.has(tmpId)) {
       return;
     }
-
-    const tmpId = identifier;
-    relatedAffects.set(identifier, 'loading');
+    relatedAffects.set(tmpId, 'loading');
 
     getAffects(tmpId)
       .then(({ data }) => {

--- a/src/composables/useSearchParams.ts
+++ b/src/composables/useSearchParams.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { useRoute, useRouter } from 'vue-router';
 
 import { flawFields, allowedEmptyFieldMapping } from '@/constants/flawFields';
+import { normalizeCveId, isCveValid } from '@/utils/helpers';
 
 export type Facet = {
   field: string;
@@ -45,7 +46,8 @@ export function useSearchParams() {
     if (route.query && Object.keys(route.query).length > 0) {
       Object.keys(route.query).forEach((key) => {
         if (flawFields.includes(key) && typeof route.query[key] === 'string') {
-          facets.push({ field: key, value: route.query[key] as string });
+          const value = route.query[key] as string;
+          facets.push({ field: key, value: key === 'cve_id' && isCveValid(value) ? normalizeCveId(value) : value });
         }
       });
     }
@@ -79,7 +81,8 @@ export function useSearchParams() {
     if (route.query && Object.keys(route.query).length > 0) {
       Object.keys(route.query).forEach((key) => {
         if (flawFields.includes(key) && typeof route.query[key] === 'string') {
-          params[key] = route.query[key] as string;
+          const value = route.query[key] as string;
+          params[key] = key === 'cve_id' && isCveValid(value) ? normalizeCveId(value) : value;
         }
       });
     }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -57,9 +57,11 @@ export const deepMap: deepMapOverload = (transform: (arg: any) => any, object: D
     , object,
   );
 
-export const cveRegex = /^CVE-(?:1999|2\d{3})-(?!0{4})(?:0\d{3}|[1-9]\d{3,})$/;
+export const cveRegex = /^CVE-(?:1999|2\d{3})-(?!0{4})(?:0\d{3}|[1-9]\d{3,})$/i;
 
 export const isCveValid = (cve: string) => cveRegex.test(cve);
+
+export const normalizeCveId = (cve: string) => cve.toUpperCase();
 
 export const UUID4Regex = /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
 export const isUUID4Valid = (uuid: string) => UUID4Regex.test(uuid);


### PR DESCRIPTION
# OSIDB-4925 Suport lowercase CVE IDs in URL params

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [ ] Test cases added/updated
- [ ] Integration tests updated
- [x] Jira ticket updated
## Summary
Adds case-insensitive CVE ID handling so users can navigate to flaws using lowercase or mixed-case CVE IDs in URLs, quick search, and advanced search.

## Changes
- `helpers.ts`: Made `cveRegex` case-insensitive and added `normalizeCveId` utility
- `useFetchFlaw`: Normalize CVE ID to uppercase before fetching flaw and affects
- `useSearchParams`: Normalize `cve_id` query param values when reading URL search params
- `Navbar`: Normalize CVE ID to uppercase before routing from quick search

## Considerations
The `addFlaw` function in the Multi-Flaw Tracker's "CVE or Flaw UUID" input now normalizes lowercase CVE IDs to uppercase before storing them in the map and querying OSIDB, since the CSS text-uppercase only made them look correct visually while the actual API call was still sending the lowercase value.

Closes OSIDB-4925
