### PR TITLE
♻️ Separate Title and Description suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # OSIM Changelog
 ## [Unreleased]
+### Added
 * Support lowercase CVE IDs on URLs (Flaw links, advance search and quick search) (`OSIDB-4925`)
+
+### Changed
+* Make Aegis title and description suggestions atomic (`AEGIS-293`)
 
 ## [2026.4.1]
 ### Added

--- a/src/components/Aegis/AegisTitleActions.vue
+++ b/src/components/Aegis/AegisTitleActions.vue
@@ -3,14 +3,14 @@ import { computed } from 'vue';
 
 import AegisActions from '@/components/Aegis/AegisActions.vue';
 
-import type { UseAegisSuggestDescriptionReturn } from '@/composables/aegis/useAegisSuggestDescription';
+import type { UseAegisSuggestTitleReturn } from '@/composables/aegis/useAegisSuggestTitle';
 import { useAegisFieldFeedback } from '@/composables/aegis/useAegisFieldFeedback';
 import { useAegisMetadataTracking } from '@/composables/aegis/useAegisMetadataTracking';
 
 import { osimRuntime } from '@/stores/osimRuntime';
 
 const props = defineProps<{
-  composable: UseAegisSuggestDescriptionReturn;
+  composable: UseAegisSuggestTitleReturn;
   titleValue?: null | string;
 }>();
 
@@ -22,7 +22,7 @@ const {
   isSuggesting,
   revertTitle,
   sendTitleFeedback,
-  suggestDescription,
+  suggestTitle,
 } = props.composable;
 
 defineExpose({
@@ -74,7 +74,7 @@ const suggestionTooltip = computed(() => {
     :suggestions="[]"
     :selectedIndex="0"
     :tooltipText="suggestionTooltip"
-    @suggest="suggestDescription"
+    @suggest="suggestTitle"
     @revert="revertTitle"
     @feedback="handleTitleFeedback"
   />

--- a/src/components/Aegis/__tests__/AegisTitleActions.spec.ts
+++ b/src/components/Aegis/__tests__/AegisTitleActions.spec.ts
@@ -4,26 +4,22 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import AegisTitleActions from '@/components/Aegis/AegisTitleActions.vue';
 
-import type { UseAegisSuggestDescriptionReturn } from '@/composables/aegis/useAegisSuggestDescription';
+import type { UseAegisSuggestTitleReturn } from '@/composables/aegis/useAegisSuggestTitle';
 
 import { mountWithConfig } from '@/__tests__/helpers';
 import { osimRuntime } from '@/stores/osimRuntime';
 
-const createMockComposable = (overrides = {}): UseAegisSuggestDescriptionReturn => ({
+const createMockComposable = (overrides = {}): UseAegisSuggestTitleReturn => ({
   canShowTitleFeedback: computed(() => false),
-  canShowDescriptionFeedback: computed(() => false),
   canSuggest: computed(() => true),
   details: computed(() => null),
   hasAppliedTitleSuggestion: computed(() => false),
-  hasAppliedDescriptionSuggestion: computed(() => false),
   isSuggesting: computed(() => false),
   revertTitle: vi.fn(),
-  revertDescription: vi.fn(),
   sendTitleFeedback: vi.fn(),
-  sendDescriptionFeedback: vi.fn(),
-  suggestDescription: vi.fn(),
+  suggestTitle: vi.fn(),
   ...overrides,
-} as UseAegisSuggestDescriptionReturn);
+} as UseAegisSuggestTitleReturn);
 
 describe('aegisTitleActions', () => {
   beforeEach(() => {
@@ -72,10 +68,10 @@ describe('aegisTitleActions', () => {
     expect(wrapper.vm.isSuggesting).toBeDefined();
   });
 
-  it('calls suggestDescription when suggest action is triggered', async () => {
-    const mockSuggestDescription = vi.fn();
+  it('calls suggestTitle when suggest action is triggered', async () => {
+    const mockSuggestTitle = vi.fn();
     const mockComposable = createMockComposable({
-      suggestDescription: mockSuggestDescription,
+      suggestTitle: mockSuggestTitle,
     });
 
     const wrapper = mountWithConfig(AegisTitleActions, {
@@ -87,7 +83,7 @@ describe('aegisTitleActions', () => {
     const aegisActions = wrapper.findComponent({ name: 'AegisActions' });
     await aegisActions.vm.$emit('suggest');
 
-    expect(mockSuggestDescription).toHaveBeenCalled();
+    expect(mockSuggestTitle).toHaveBeenCalled();
   });
 
   it('calls revertTitle when revert action is triggered', async () => {

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -37,6 +37,7 @@ import {
   type AegisSuggestionContextRefs,
 } from '@/composables/aegis/useAegisSuggestionContext';
 import { useAegisSuggestDescription } from '@/composables/aegis/useAegisSuggestDescription';
+import { useAegisSuggestTitle } from '@/composables/aegis/useAegisSuggestTitle';
 import { useAegisMetadataTracking } from '@/composables/aegis/useAegisMetadataTracking';
 import { useComponentsFeedback, AegisFeedback } from '@/composables/aegis/useComponentsFeedback';
 import { useAffectsModel } from '@/composables/useAffectsModel';
@@ -218,9 +219,13 @@ const aegisContext: AegisSuggestionContextRefs = aegisSuggestionRequestBody(flaw
 const titleRefForAegis = toRef(flaw.value, 'title');
 const descriptionRefForAegis = toRef(flaw.value, 'cve_description');
 
-const aegisSuggestDescriptionComposable = useAegisSuggestDescription({
+const aegisSuggestTitleComposable = useAegisSuggestTitle({
   context: aegisContext,
   titleRef: titleRefForAegis,
+});
+
+const aegisSuggestDescriptionComposable = useAegisSuggestDescription({
+  context: aegisContext,
   descriptionRef: descriptionRefForAegis,
 });
 
@@ -288,7 +293,7 @@ const toggleComponentsTooltip = () => {
         <div :id="flaw.uuid" class="col-6">
           <LabelDiv
             label="Title"
-            :loading="aegisSuggestDescriptionComposable.isSuggesting.value"
+            :loading="aegisSuggestTitleComposable.isSuggesting.value"
             :highlighted="isFieldValueAIBot('title', flaw.title)"
             class="mb-2"
           >
@@ -299,7 +304,7 @@ const toggleComponentsTooltip = () => {
                   class="bi bi-robot text-primary me-1"
                 ></i>
                 <AegisTitleActions
-                  :composable="aegisSuggestDescriptionComposable"
+                  :composable="aegisSuggestTitleComposable"
                   :titleValue="flaw.title"
                 />
               </div>

--- a/src/composables/aegis/__tests__/useAegisSuggestTitle.spec.ts
+++ b/src/composables/aegis/__tests__/useAegisSuggestTitle.spec.ts
@@ -2,7 +2,7 @@ import { ref } from 'vue';
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { useAegisSuggestDescription } from '@/composables/aegis/useAegisSuggestDescription';
+import { useAegisSuggestTitle } from '@/composables/aegis/useAegisSuggestTitle';
 import {
   serializeAegisContext,
   type AegisSuggestionContextRefs,
@@ -50,33 +50,34 @@ function createContext(overrides?: Partial<Parameters<typeof serializeAegisConte
   return ctx;
 }
 
-describe('useAegisSuggestDescription', () => {
-  it('applies description suggestion correctly', async () => {
+describe('useAegisSuggestTitle', () => {
+  it('applies title suggestion correctly', async () => {
     const toastStore = (await import('@/stores/ToastStore')).useToastStore();
     const addToast = vi.mocked(toastStore.addToast);
-    const descriptionRef = ref<null | string | undefined>('Original Description');
+    const titleRef = ref<null | string | undefined>('Original Title');
     const context = createContext({ cveId: ref('CVE-2024-1234') });
 
     analyzeMock.mockResolvedValueOnce({
-      suggested_description: 'New Suggested Description',
+      suggested_title: 'New Suggested Title',
+      suggested_description: 'Generated description',
       confidence: 0.95,
       explanation: 'Analysis reasoning',
       tools_used: ['ai_tool'],
     });
 
     const [composable] = withSetup(
-      () => useAegisSuggestDescription({
+      () => useAegisSuggestTitle({
         context: context as AegisSuggestionContextRefs,
-        descriptionRef,
+        titleRef,
       }), [],
     );
 
-    await composable.suggestDescription();
+    await composable.suggestTitle();
 
-    expect(descriptionRef.value).toBe('New Suggested Description');
-    expect(composable.hasAppliedDescriptionSuggestion.value).toBe(true);
+    expect(titleRef.value).toBe('New Suggested Title');
+    expect(composable.hasAppliedTitleSuggestion.value).toBe(true);
     expect(composable.details.value).toMatchObject({
-      suggested_description: 'New Suggested Description',
+      suggested_title: 'New Suggested Title',
       confidence: 0.95,
     });
     expect(addToast).toHaveBeenCalledWith(expect.objectContaining({
@@ -85,92 +86,95 @@ describe('useAegisSuggestDescription', () => {
     }));
   });
 
-  it('shows toast when no description suggestion received', async () => {
-    const descriptionRef = ref<null | string | undefined>('Original Description');
+  it('shows toast when no title suggestion received', async () => {
+    const titleRef = ref<null | string | undefined>('Original Title');
     const context = createContext({ cveId: ref('CVE-2024-1234') });
 
     analyzeMock.mockResolvedValueOnce({
-      suggested_description: '',
+      suggested_title: '',
+      suggested_description: 'Some description',
       confidence: 0.95,
     });
 
     const [composable] = withSetup(
-      () => useAegisSuggestDescription({
+      () => useAegisSuggestTitle({
         context: context as AegisSuggestionContextRefs,
-        descriptionRef,
+        titleRef,
       }), [],
     );
 
-    await composable.suggestDescription();
+    await composable.suggestTitle();
 
     expect(mockAddToast).toHaveBeenCalledWith({
       title: 'AI Suggestion',
-      body: 'No valid description suggestion received.',
+      body: 'No valid title suggestion received.',
     });
   });
 
-  it('reverts description correctly', async () => {
-    const descriptionRef = ref<null | string | undefined>('Original Description');
+  it('reverts title correctly', async () => {
+    const titleRef = ref<null | string | undefined>('Original Title');
     const context = createContext({ cveId: ref('CVE-2024-1234') });
 
     analyzeMock.mockResolvedValueOnce({
+      suggested_title: 'New Title',
       suggested_description: 'New Description',
       confidence: 0.92,
     });
 
     const [composable] = withSetup(
-      () => useAegisSuggestDescription({
+      () => useAegisSuggestTitle({
         context: context as AegisSuggestionContextRefs,
-        descriptionRef,
+        titleRef,
       }), [],
     );
 
-    await composable.suggestDescription();
-    expect(descriptionRef.value).toBe('New Description');
+    await composable.suggestTitle();
+    expect(titleRef.value).toBe('New Title');
 
-    composable.revertDescription();
-    expect(descriptionRef.value).toBe('Original Description');
-    expect(composable.hasAppliedDescriptionSuggestion.value).toBe(false);
+    composable.revertTitle();
+    expect(titleRef.value).toBe('Original Title');
+    expect(composable.hasAppliedTitleSuggestion.value).toBe(false);
     expect(composable.details.value).toBe(null);
   });
 
   it('shows feedback controls after suggestion is applied', async () => {
-    const descriptionRef = ref<null | string | undefined>('Original Description');
+    const titleRef = ref<null | string | undefined>('Original Title');
     const context = createContext({ cveId: ref('CVE-2024-1234') });
 
     analyzeMock.mockResolvedValueOnce({
+      suggested_title: 'New Title',
       suggested_description: 'New Description',
       confidence: 0.92,
     });
 
     const [composable] = withSetup(
-      () => useAegisSuggestDescription({
+      () => useAegisSuggestTitle({
         context: context as AegisSuggestionContextRefs,
-        descriptionRef,
+        titleRef,
       }), [],
     );
 
-    expect(composable.canShowDescriptionFeedback.value).toBe(false);
+    expect(composable.canShowTitleFeedback.value).toBe(false);
 
-    await composable.suggestDescription();
+    await composable.suggestTitle();
 
-    expect(composable.canShowDescriptionFeedback.value).toBe(true);
+    expect(composable.canShowTitleFeedback.value).toBe(true);
   });
 
   it('handles service errors gracefully', async () => {
-    const descriptionRef = ref<null | string | undefined>('Original Description');
+    const titleRef = ref<null | string | undefined>('Original Title');
     const context = createContext({ cveId: ref('CVE-2024-1234') });
 
     analyzeMock.mockRejectedValueOnce(new Error('Service unavailable'));
 
     const [composable] = withSetup(
-      () => useAegisSuggestDescription({
+      () => useAegisSuggestTitle({
         context: context as AegisSuggestionContextRefs,
-        descriptionRef,
+        titleRef,
       }), [],
     );
 
-    await composable.suggestDescription();
+    await composable.suggestTitle();
 
     expect(mockAddToast).toHaveBeenCalledWith({
       title: 'AI Suggestion Error',
@@ -179,10 +183,11 @@ describe('useAegisSuggestDescription', () => {
   });
 
   it('sends feedback successfully', async () => {
-    const descriptionRef = ref<null | string | undefined>('Original Description');
+    const titleRef = ref<null | string | undefined>('Original Title');
     const context = createContext({ cveId: ref('CVE-2024-1234') });
 
     analyzeMock.mockResolvedValueOnce({
+      suggested_title: 'New Title',
       suggested_description: 'New Description',
       confidence: 0.92,
     });
@@ -190,21 +195,21 @@ describe('useAegisSuggestDescription', () => {
     sendFeedbackMock.mockResolvedValueOnce({});
 
     const [composable] = withSetup(
-      () => useAegisSuggestDescription({
+      () => useAegisSuggestTitle({
         context: context as AegisSuggestionContextRefs,
-        descriptionRef,
+        titleRef,
       }), [],
     );
 
-    await composable.suggestDescription();
-    await composable.sendDescriptionFeedback('positive');
+    await composable.suggestTitle();
+    await composable.sendTitleFeedback('positive');
 
     expect(sendFeedbackMock).toHaveBeenCalledWith({
-      feature: 'suggest-description',
+      feature: 'suggest-title',
       cve_id: 'CVE-2024-1234',
       email: 'test@example.com',
       request_time: expect.stringMatching(/\d+ms/),
-      actual: 'New Description',
+      actual: 'New Title',
       accept: true,
     });
 
@@ -216,10 +221,11 @@ describe('useAegisSuggestDescription', () => {
   });
 
   it('prevents duplicate feedback submission', async () => {
-    const descriptionRef = ref<null | string | undefined>('Original Description');
+    const titleRef = ref<null | string | undefined>('Original Title');
     const context = createContext({ cveId: ref('CVE-2024-1234') });
 
     analyzeMock.mockResolvedValueOnce({
+      suggested_title: 'New Title',
       suggested_description: 'New Description',
       confidence: 0.92,
     });
@@ -227,22 +233,22 @@ describe('useAegisSuggestDescription', () => {
     sendFeedbackMock.mockResolvedValueOnce({});
 
     const [composable] = withSetup(
-      () => useAegisSuggestDescription({
+      () => useAegisSuggestTitle({
         context: context as AegisSuggestionContextRefs,
-        descriptionRef,
+        titleRef,
       }), [],
     );
 
-    await composable.suggestDescription();
-    await composable.sendDescriptionFeedback('positive');
+    await composable.suggestTitle();
+    await composable.sendTitleFeedback('positive');
 
     // Try to send feedback again
-    await composable.sendDescriptionFeedback('negative');
+    await composable.sendTitleFeedback('negative');
 
     expect(sendFeedbackMock).toHaveBeenCalledTimes(1);
     expect(mockAddToast).toHaveBeenLastCalledWith({
       title: 'Feedback Already Submitted',
-      body: 'You have already provided feedback for this description suggestion.',
+      body: 'You have already provided feedback for this title suggestion.',
       css: 'warning',
     });
   });

--- a/src/composables/aegis/useAegisSuggestDescription.ts
+++ b/src/composables/aegis/useAegisSuggestDescription.ts
@@ -11,7 +11,6 @@ import { serializeAegisContext, type AegisSuggestionContextRefs } from './useAeg
 export type UseAegisSuggestDescriptionOptions = {
   context: AegisSuggestionContextRefs;
   descriptionRef: Ref<null | string | undefined>;
-  titleRef: Ref<null | string | undefined>;
 };
 
 export type UseAegisSuggestDescriptionReturn = ReturnType<typeof useAegisSuggestDescription>;
@@ -20,24 +19,12 @@ export function useAegisSuggestDescription(options: UseAegisSuggestDescriptionOp
   const toastStore = useToastStore();
   const userStore = useUserStore();
   const service = new AegisAIService();
-  const aegisTitleSuggestionWatcher = useAISuggestionsWatcher('title', options.titleRef);
   const aegisDescriptionSuggestionWatcher = useAISuggestionsWatcher('cve_description', options.descriptionRef);
   const isSuggesting = ref(false);
-  const previousTitleValue = ref<null | string | undefined>(null);
   const previousDescriptionValue = ref<null | string | undefined>(null);
   const details = ref<DescriptionSuggestionDetails | null>(null);
   const requestDuration = ref<null | number>(null);
-  const titleFeedbackSubmitted = ref<Set<string>>(new Set());
   const descriptionFeedbackSubmitted = ref<Set<string>>(new Set());
-
-  const canShowTitleFeedback = computed(() => {
-    const hasApplied = aegisTitleSuggestionWatcher.hasAppliedSuggestion.value;
-    const notSuggesting = !isSuggesting.value;
-    const titleValue = details.value?.suggested_title ?? '';
-    const feedbackNotSubmitted = !titleFeedbackSubmitted.value.has(titleValue);
-
-    return hasApplied && notSuggesting && feedbackNotSubmitted;
-  });
 
   const canShowDescriptionFeedback = computed(() => {
     const hasApplied = aegisDescriptionSuggestionWatcher.hasAppliedSuggestion.value;
@@ -64,10 +51,7 @@ export function useAegisSuggestDescription(options: UseAegisSuggestDescriptionOp
     isSuggesting.value = true;
     const requestStartTime = Date.now();
     try {
-      // Store previous values if not already stored
-      if (!aegisTitleSuggestionWatcher.hasAppliedSuggestion.value && previousTitleValue.value == null) {
-        previousTitleValue.value = options.titleRef.value;
-      }
+      // Store previous value if not already stored
       if (!aegisDescriptionSuggestionWatcher.hasAppliedSuggestion.value && previousDescriptionValue.value == null) {
         previousDescriptionValue.value = options.descriptionRef.value;
       }
@@ -80,33 +64,26 @@ export function useAegisSuggestDescription(options: UseAegisSuggestDescriptionOp
       // An incoming service logic can be used here
       requestDuration.value = Date.now() - requestStartTime;
 
-      const title = data.suggested_title ?? '';
       const description = data.suggested_description ?? '';
 
-      if (!title && !description) {
-        toastStore.addToast({ title: 'AI Suggestion', body: 'No valid suggestion received.' });
+      if (!description) {
+        toastStore.addToast({ title: 'AI Suggestion', body: 'No valid description suggestion received.' });
         return;
       }
 
       details.value = {
-        suggested_title: title,
         suggested_description: description,
         confidence: data.confidence,
         explanation: data.explanation,
         tools_used: data.tools_used,
       };
 
-      // Apply both suggestions - applyAISuggestion will set the value
-      if (title) {
-        aegisTitleSuggestionWatcher.applyAISuggestion(title);
-      }
-      if (description) {
-        aegisDescriptionSuggestionWatcher.applyAISuggestion(description);
-      }
+      // Apply only description suggestion
+      aegisDescriptionSuggestionWatcher.applyAISuggestion(description);
 
       toastStore.addToast({
         title: 'AI Suggestion Applied',
-        body: 'Suggestion applied. Always review AI generated responses prior to use.',
+        body: 'Description suggestion applied. Always review AI generated responses prior to use.',
         css: 'info',
         timeoutMs: 8000,
       });
@@ -118,81 +95,13 @@ export function useAegisSuggestDescription(options: UseAegisSuggestDescriptionOp
     }
   }
 
-  function revertTitle() {
-    if (previousTitleValue.value !== null) {
-      options.titleRef.value = previousTitleValue.value;
-    }
-    previousTitleValue.value = null;
-    aegisTitleSuggestionWatcher.revertAISuggestion();
-    // Clear details if both are reverted
-    if (!aegisDescriptionSuggestionWatcher.hasAppliedSuggestion.value) {
-      details.value = null;
-    }
-  }
-
   function revertDescription() {
     if (previousDescriptionValue.value !== null) {
       options.descriptionRef.value = previousDescriptionValue.value;
     }
     previousDescriptionValue.value = null;
     aegisDescriptionSuggestionWatcher.revertAISuggestion();
-    // Clear details if both are reverted
-    if (!aegisTitleSuggestionWatcher.hasAppliedSuggestion.value) {
-      details.value = null;
-    }
-  }
-
-  async function sendTitleFeedback(kind: 'negative' | 'positive', comment?: string) {
-    try {
-      const cveId = (options.context as any)?.cveId?.value ?? (options.context as any)?.cveId;
-      if (!cveId) {
-        toastStore.addToast({
-          title: 'Feedback Error',
-          body: 'Cannot submit feedback without a valid CVE ID.',
-        });
-        return;
-      }
-
-      const suggestedTitle = details.value?.suggested_title ?? '';
-
-      // Check if feedback already submitted for this suggestion
-      if (titleFeedbackSubmitted.value.has(suggestedTitle)) {
-        toastStore.addToast({
-          title: 'Feedback Already Submitted',
-          body: 'You have already provided feedback for this title suggestion.',
-          css: 'warning',
-        });
-        return;
-      }
-
-      await service.sendFeedback({
-        feature: 'suggest-title',
-        cve_id: cveId,
-        email: userStore.userEmail,
-        request_time: `${requestDuration.value ?? 0}ms`,
-        actual: suggestedTitle,
-        accept: kind === 'positive',
-        ...(comment && { rejection_comment: comment }),
-      });
-
-      // Mark feedback as submitted for this suggestion
-      titleFeedbackSubmitted.value.add(suggestedTitle);
-
-      toastStore.addToast({
-        title: 'AI Suggestion Feedback',
-        body: kind === 'positive' ? 'Thanks for the positive feedback.' : 'Thanks for the feedback.',
-        css: 'info',
-      });
-    } catch (error: any) {
-      const detail = error?.data?.detail ?? error?.response?.data?.detail;
-      const msg = typeof detail === 'string'
-        ? detail
-        : (error?.message ?? 'Failed to submit feedback');
-      toastStore.addToast({
-        title: 'Feedback Error',
-        body: msg,
-      });
-    }
+    details.value = null;
   }
 
   async function sendDescriptionFeedback(kind: 'negative' | 'positive', comment?: string) {
@@ -249,16 +158,12 @@ export function useAegisSuggestDescription(options: UseAegisSuggestDescriptionOp
   }
 
   return {
-    canShowTitleFeedback,
     canShowDescriptionFeedback,
     canSuggest,
     details,
-    hasAppliedTitleSuggestion: aegisTitleSuggestionWatcher.hasAppliedSuggestion,
     hasAppliedDescriptionSuggestion: aegisDescriptionSuggestionWatcher.hasAppliedSuggestion,
     isSuggesting,
-    revertTitle,
     revertDescription,
-    sendTitleFeedback,
     sendDescriptionFeedback,
     suggestDescription,
   };

--- a/src/composables/aegis/useAegisSuggestTitle.ts
+++ b/src/composables/aegis/useAegisSuggestTitle.ts
@@ -1,0 +1,171 @@
+import { computed, ref, type Ref } from 'vue';
+
+import { AegisAIService } from '@/services/AegisAIService';
+import { useToastStore } from '@/stores/ToastStore';
+import { useUserStore } from '@/stores/UserStore';
+import type { AegisAIComponentFeatureNameType, DescriptionSuggestionDetails } from '@/types/aegisAI';
+
+import { useAISuggestionsWatcher } from './useAISuggestionsWatcher';
+import { serializeAegisContext, type AegisSuggestionContextRefs } from './useAegisSuggestionContext';
+
+export type UseAegisSuggestTitleOptions = {
+  context: AegisSuggestionContextRefs;
+  titleRef: Ref<null | string | undefined>;
+};
+
+export type UseAegisSuggestTitleReturn = ReturnType<typeof useAegisSuggestTitle>;
+
+export function useAegisSuggestTitle(options: UseAegisSuggestTitleOptions) {
+  const toastStore = useToastStore();
+  const userStore = useUserStore();
+  const service = new AegisAIService();
+  const aegisTitleSuggestionWatcher = useAISuggestionsWatcher('title', options.titleRef);
+  const isSuggesting = ref(false);
+  const previousTitleValue = ref<null | string | undefined>(null);
+  const details = ref<DescriptionSuggestionDetails | null>(null);
+  const requestDuration = ref<null | number>(null);
+  const titleFeedbackSubmitted = ref<Set<string>>(new Set());
+
+  const canShowTitleFeedback = computed(() => {
+    const hasApplied = aegisTitleSuggestionWatcher.hasAppliedSuggestion.value;
+    const notSuggesting = !isSuggesting.value;
+    const titleValue = details.value?.suggested_title ?? '';
+    const feedbackNotSubmitted = !titleFeedbackSubmitted.value.has(titleValue);
+
+    return hasApplied && notSuggesting && feedbackNotSubmitted;
+  });
+
+  const isCveIdValid = computed(() => {
+    const cveId = (options.context as any)?.cveId?.value ?? (options.context as any)?.cveId;
+    if (!cveId) return false;
+    return /^CVE-\d{4}-\d{4,7}$/i.test(cveId);
+  });
+
+  const canSuggest = computed(() => isCveIdValid.value && !isSuggesting.value);
+
+  async function suggestTitle() {
+    if (!canSuggest.value) {
+      toastStore.addToast({ title: 'AI Suggestion', body: 'Valid CVE ID required for suggestions.' });
+      return;
+    }
+    isSuggesting.value = true;
+    const requestStartTime = Date.now();
+    try {
+      // Store previous value if not already stored
+      if (!aegisTitleSuggestionWatcher.hasAppliedSuggestion.value && previousTitleValue.value == null) {
+        previousTitleValue.value = options.titleRef.value;
+      }
+
+      const feature: AegisAIComponentFeatureNameType = 'suggest-description';
+      const data = await service.analyzeCVEWithContext({
+        feature,
+        ...serializeAegisContext(options.context),
+      });
+
+      requestDuration.value = Date.now() - requestStartTime;
+
+      const title = data.suggested_title ?? '';
+
+      if (!title) {
+        toastStore.addToast({ title: 'AI Suggestion', body: 'No valid title suggestion received.' });
+        return;
+      }
+
+      details.value = {
+        suggested_title: title,
+        suggested_description: data.suggested_description,
+        confidence: data.confidence,
+        explanation: data.explanation,
+        tools_used: data.tools_used,
+      };
+
+      // Apply only title suggestion
+      aegisTitleSuggestionWatcher.applyAISuggestion(title);
+
+      toastStore.addToast({
+        title: 'AI Suggestion Applied',
+        body: 'Title suggestion applied. Always review AI generated responses prior to use.',
+        css: 'info',
+        timeoutMs: 8000,
+      });
+    } catch (e: any) {
+      const msg = e?.message ?? e?.data?.detail ?? 'Request failed';
+      toastStore.addToast({ title: 'AI Suggestion Error', body: msg });
+    } finally {
+      isSuggesting.value = false;
+    }
+  }
+
+  function revertTitle() {
+    if (previousTitleValue.value !== null) {
+      options.titleRef.value = previousTitleValue.value;
+    }
+    previousTitleValue.value = null;
+    aegisTitleSuggestionWatcher.revertAISuggestion();
+    details.value = null;
+  }
+
+  async function sendTitleFeedback(kind: 'negative' | 'positive', comment?: string) {
+    try {
+      const cveId = (options.context as any)?.cveId?.value ?? (options.context as any)?.cveId;
+      if (!cveId) {
+        toastStore.addToast({
+          title: 'Feedback Error',
+          body: 'Cannot submit feedback without a valid CVE ID.',
+        });
+        return;
+      }
+
+      const suggestedTitle = details.value?.suggested_title ?? '';
+
+      // Check if feedback already submitted for this suggestion
+      if (titleFeedbackSubmitted.value.has(suggestedTitle)) {
+        toastStore.addToast({
+          title: 'Feedback Already Submitted',
+          body: 'You have already provided feedback for this title suggestion.',
+          css: 'warning',
+        });
+        return;
+      }
+
+      await service.sendFeedback({
+        feature: 'suggest-title',
+        cve_id: cveId,
+        email: userStore.userEmail,
+        request_time: `${requestDuration.value ?? 0}ms`,
+        actual: suggestedTitle,
+        accept: kind === 'positive',
+        ...(comment && { rejection_comment: comment }),
+      });
+
+      // Mark feedback as submitted for this suggestion
+      titleFeedbackSubmitted.value.add(suggestedTitle);
+
+      toastStore.addToast({
+        title: 'AI Suggestion Feedback',
+        body: kind === 'positive' ? 'Thanks for the positive feedback.' : 'Thanks for the feedback.',
+        css: 'info',
+      });
+    } catch (error: any) {
+      const detail = error?.data?.detail ?? error?.response?.data?.detail;
+      const msg = typeof detail === 'string'
+        ? detail
+        : (error?.message ?? 'Failed to submit feedback');
+      toastStore.addToast({
+        title: 'Feedback Error',
+        body: msg,
+      });
+    }
+  }
+
+  return {
+    canShowTitleFeedback,
+    canSuggest,
+    details,
+    hasAppliedTitleSuggestion: aegisTitleSuggestionWatcher.hasAppliedSuggestion,
+    isSuggesting,
+    revertTitle,
+    sendTitleFeedback,
+    suggestTitle,
+  };
+}


### PR DESCRIPTION
♻️ Aegis-293 Separate Title and Description suggestions
## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated
- [x] Jira ticket updated

## Summary  
Splits Aegis title and description in indedependent actions so each suggestion applies only its own field.

## Changes  
- New composable for title-only suggestions `AegisTitleActions`.  
- Remove title references from description suggestion component
- Type adjustments
- Tests update

## Considerations  
- Title suggestions still call endpoint **`suggest-description`**  as backend division is not currently on scope

Closes Aegis-293
