### PR TITLE
🐛 Fix repeated uuids on multiflaw trackers creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # OSIM Changelog
 ## [Unreleased]
 ### Added
-* Support lowercase CVE IDs on URLs (Flaw links, advance search and quick search) (`OSIDB-4925`)
+* Make Aegis title and description suggestions atomic (`AEGIS-293`)
+
+### Fixed
+* Fix duplicate affect UUIDs in multiflaw tracker requests (`OSIDB-4934`)
 
 ### Changed
-* Make Aegis title and description suggestions atomic (`AEGIS-293`)
+* Support lowercase CVE IDs on URLs (Flaw links, advance search and quick search) (`OSIDB-4925`)
 
 ## [2026.4.1]
 ### Added

--- a/src/composables/__tests__/useMultiFlawTrackers.spec.ts
+++ b/src/composables/__tests__/useMultiFlawTrackers.spec.ts
@@ -382,6 +382,24 @@ describe('useMultiFlawTrackers', () => {
       ]);
     });
 
+    it('should not duplicate current flaw UUID when multiple related flaws share same stream', () => {
+      const { computed, state } = useMultiFlawTrackers();
+
+      state.relatedAffects.set('CVE-2024-0002', mockAffectsForCVE2);
+      state.relatedAffects.set('CVE-2024-0003', mockAffectsForCVE3);
+
+      const sharedStreams = computed.sharedStreams.value;
+      const streamUuids = sharedStreams['stream-1:component-1'];
+
+      // Ensure current flaw UUID appears exactly once
+      const currentFlawCount = streamUuids.filter(uuid => uuid === 'affect-uuid-1').length;
+      expect(currentFlawCount).toBe(1);
+
+      // Ensure all UUIDs are unique
+      const uniqueUuids = new Set(streamUuids);
+      expect(uniqueUuids.size).toBe(streamUuids.length);
+    });
+
     it('should skip loading and error states', () => {
       const { computed, state } = useMultiFlawTrackers();
 

--- a/src/composables/useMultiFlawTrackers.ts
+++ b/src/composables/useMultiFlawTrackers.ts
@@ -43,7 +43,7 @@ function useMultiFlawTrackersComposable() {
   });
 
   const streamData = computed(() => {
-    const sharedStreams: Record<string, string[]> = {};
+    const sharedStreams: Record<string, Set<string>> = {};
     const streamToCveMap: Record<string, Set<string>> = {};
     const cveStreamCount: Record<string, Set<string>> = {};
 
@@ -58,9 +58,9 @@ function useMultiFlawTrackersComposable() {
 
         if (affect.uuid) {
           if (!sharedStreams[streamKey]) {
-            sharedStreams[streamKey] = [currentFlawAffectUuid];
+            sharedStreams[streamKey] = new Set([currentFlawAffectUuid]);
           }
-          sharedStreams[streamKey].push(affect.uuid);
+          sharedStreams[streamKey].add(affect.uuid);
         }
 
         const flawId = getFlawIdentifier(affect);
@@ -79,7 +79,9 @@ function useMultiFlawTrackersComposable() {
     }
 
     return {
-      sharedStreams,
+      sharedStreams: Object.fromEntries(
+        Object.entries(sharedStreams).map(([stream, uuidSet]) => [stream, Array.from(uuidSet)]),
+      ),
       streamToCveMap: Object.fromEntries(
         Object.entries(streamToCveMap).map(([stream, cveSet]) => [stream, Array.from(cveSet)]),
       ),


### PR DESCRIPTION
# OSIDB-4934 Fix repeated uuids on multiflaw trackers creation

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated
- [x] Jira ticket updated

## Summary:

Fix multiflaw tracker creation when several related flaws share the same product stream. The current flaw's affect UUID was listed multiple times (once per related flaw), so OSIDB rejected the request; `sharedStreams` is now accumulated with unique UUIDs (`Set`), then exported as arrays for the API.

## Changes:

- **`useMultiFlawTrackers.ts`:** Compute `sharedStreams` as `Record<string, Set<string>>` so each stream collects affect UUIDs without duplicates; convert to string arrays before sending trackers.
- **`useMultiFlawTrackers.spec.ts`:** Regression test ensuring no duplicate UUIDs when multiple related flaws share streams.