### PR TITLE
🐛 Skip contributors load when there is no Jira API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Make Aegis title and description suggestions atomic (`AEGIS-293`)
 
 ### Fixed
+* Prevent contributors loading when there is not Jira API key set (`OSIDB-4940`)
 * Fix duplicate affect UUIDs in multiflaw tracker requests (`OSIDB-4934`)
 
 ### Changed

--- a/src/components/FlawContributors/FlawContributors.vue
+++ b/src/components/FlawContributors/FlawContributors.vue
@@ -6,6 +6,7 @@ import { isDefined, watchDebounced } from '@vueuse/core';
 import useJiraContributors from '@/composables/useJiraContributors';
 import { createCatchHandler } from '@/composables/service-helpers';
 
+import { useSettingsStore } from '@/stores/SettingsStore';
 import type { ZodJiraUserAssignableType } from '@/types/zodJira';
 import LabelDiv from '@/widgets/LabelDiv/LabelDiv.vue';
 import DropDown from '@/widgets/DropDown/DropDown.vue';
@@ -27,7 +28,9 @@ const {
   searchContributors,
 } = useJiraContributors(props.taskKey);
 
-onBeforeMount(loadJiraContributors);
+onBeforeMount(() => {
+  if (useSettingsStore().apiKeys.jiraApiKey) loadJiraContributors();
+});
 
 watchDebounced(query, async () => {
   if (!isDefined(query)) {

--- a/src/components/__tests__/FlawContributors.spec.ts
+++ b/src/components/__tests__/FlawContributors.spec.ts
@@ -20,6 +20,12 @@ vi.mock('@/composables/useJiraContributors', () => ({
   default: () => useJiraContributors,
 }));
 
+vi.mock('@/stores/SettingsStore', () => ({
+  useSettingsStore: vi.fn(() => ({
+    apiKeys: { jiraApiKey: 'test-token' },
+  })),
+}));
+
 const mountComponent = (props?: ExtractPublicPropTypes<typeof FlawContributors>) =>
   mount(FlawContributors, {
     props: {


### PR DESCRIPTION
# OSIDB-4940 Skip contributors load when there is no Jira API key

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated

## Summary:

Small change to reduce notification noise and unnecessary API requests

## Changes:

- Add a guard to the contributors loading so it is skipped when there is no Jira token
