### PR TITLE
release v2026.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # OSIM Changelog
-## [Unreleased]
+## [2026.5.0]
 ### Added
 * Make Aegis title and description suggestions atomic (`AEGIS-293`)
 
@@ -669,7 +669,8 @@ The first release for user testing, briefly reaching feature parity with OSIDB
 ### Added
 * Early repo layout & Flaw template
 
-[Unreleased]: https://github.com/RedHatProductSecurity/osim/compare/v2026.4.1...HEAD
+[Unreleased]: https://github.com/RedHatProductSecurity/osim/compare/v2026.5.0...HEAD
+[2026.5.0]: https://github.com/RedHatProductSecurity/osim/compare/v2026.4.1...v2026.5.0
 [2026.4.1]: https://github.com/RedHatProductSecurity/osim/compare/v2026.4.0...v2026.4.1
 [2026.4.0]: https://github.com/RedHatProductSecurity/osim/compare/v2026.3.2...v2026.4.0
 [2026.3.2]: https://github.com/RedHatProductSecurity/osim/compare/v2026.3.1...v2026.3.2


### PR DESCRIPTION
## Release v2026.5.0

### Added
* Make Aegis title and description suggestions atomic (`AEGIS-293`)

### Fixed
* Prevent contributors loading when there is not Jira API key set (`OSIDB-4940`)
* Fix duplicate affect UUIDs in multiflaw tracker requests (`OSIDB-4934`)
* Automatically close Aegis explanation tooltips when clicking outside of them (`OSIDB-4941`)

### Changed
* Support lowercase CVE IDs on URLs (Flaw links, advance search and quick search) (`OSIDB-4925`)

---
Ticket: OSIDB-4981

Made with [Cursor](https://cursor.com)