### PR TITLE
✨ BU label type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # OSIM Changelog
+## [Unreleased]
+### Added
+* Add support for Business Unit (BU) label type for flaw triage (`OSIDB-4982`)
+
 ## [2026.5.0]
 ### Added
 * Make Aegis title and description suggestions atomic (`AEGIS-293`)

--- a/openapi-osidb.yml
+++ b/openapi-osidb.yml
@@ -12888,6 +12888,7 @@ components:
       - alias
       - context_based
       - product_family
+      - bu
       type: string
     FlawPackageVersion:
       type: object

--- a/src/components/FlawLabels/FlawLabelTableEditingRow.vue
+++ b/src/components/FlawLabels/FlawLabelTableEditingRow.vue
@@ -8,7 +8,8 @@ import { watchedRef } from '@/utils/helpers';
 
 import FlawLabelsContributor from './FlawLabelsContributor.vue';
 
-const { contextLabels, initalLabel } = defineProps<{
+const { buLabels, contextLabels, initalLabel } = defineProps<{
+  buLabels?: string[];
   contextLabels?: string[];
   initalLabel?: NonNullable<ZodFlawType['labels']>[number];
 }>();
@@ -27,6 +28,7 @@ const [labelType, hasTypeChanged] = watchedRef<FlawLabelTypeEnum>(
 
 const isNewLabel = computed(() => !initalLabel);
 const isAliasType = computed(() => labelType.value === FlawLabelTypeEnum.ALIAS);
+const isBuType = computed(() => labelType.value === FlawLabelTypeEnum.BU);
 
 const emitSave = () => {
   // if nothing changed, do not emit save
@@ -73,8 +75,9 @@ const emitSave = () => {
       class="form-select"
       title="Label type"
     >
-      <option :value="FlawLabelTypeEnum.CONTEXT_BASED">context_based</option>
       <option :value="FlawLabelTypeEnum.ALIAS">alias</option>
+      <option :value="FlawLabelTypeEnum.BU">bu</option>
+      <option :value="FlawLabelTypeEnum.CONTEXT_BASED">context_based</option>
     </select>
     <template v-else>
       {{ initalLabel?.type }}
@@ -99,6 +102,20 @@ const emitSave = () => {
         placeholder="Enter alias name"
         required
       >
+    </template>
+    <!-- BU labels use dropdown -->
+    <template v-else-if="isBuType">
+      <select
+        v-model="labelName"
+        class="form-select"
+        required
+      >
+        <option
+          v-for="label in buLabels"
+          :key="label"
+          :value="label"
+        >{{ label }}</option>
+      </select>
     </template>
     <!-- Context-based labels use dropdown -->
     <template v-else>

--- a/src/components/FlawLabels/FlawLabelsTable.vue
+++ b/src/components/FlawLabels/FlawLabelsTable.vue
@@ -18,6 +18,7 @@ const {
   isNewLabel,
   isUpdatedLabel,
   labels,
+  loadBuLabels,
   loadContextLabels,
   newLabels,
   updatedLabels,
@@ -26,9 +27,15 @@ const {
 const isCreatingLabel = ref(false);
 const isUpdatingLabel = ref<string>();
 const contextLabels = computedAsync(loadContextLabels, []);
+const buLabels = computedAsync(loadBuLabels, []);
 const availableLabels = computed(() =>
   contextLabels.value.filter(contextLabel =>
     !Object.values(labels.value).some(({ label }) => label === contextLabel),
+  ),
+);
+const availableBuLabels = computed(() =>
+  buLabels.value.filter(buLabel =>
+    !Object.values(labels.value).some(({ label }) => label === buLabel),
   ),
 );
 
@@ -89,6 +96,7 @@ function handleUndoDelete(label: ZodFlawLabelType) {
         >
           <FlawLabelTableEditingRow
             v-if="isUpdatingLabel === label.label"
+            :buLabels="buLabels"
             :contextLabels="contextLabels"
             :initalLabel="label"
             @save="handleUpdateLabel"
@@ -144,6 +152,7 @@ function handleUndoDelete(label: ZodFlawLabelType) {
         </tr>
         <tr v-if="isCreatingLabel">
           <FlawLabelTableEditingRow
+            :buLabels="availableBuLabels"
             :contextLabels="availableLabels"
             @save="handleNewLabel"
             @cancel="isCreatingLabel = false"

--- a/src/components/FlawLabels/__tests__/FlawLabelsTable.spec.ts
+++ b/src/components/FlawLabels/__tests__/FlawLabelsTable.spec.ts
@@ -13,6 +13,7 @@ vi.mock('@/services/LabelsService', () => ({
   fetchLabels: vi.fn().mockResolvedValue([
     { type: 'context_based', name: 'test' },
     { type: 'context_based', name: 'test1' },
+    { type: 'bu', name: 'core_bu' },
   ]),
 }));
 
@@ -81,6 +82,24 @@ describe('flawLabelsTable', () => {
 
     expect(areLabelsUpdated.value).toBe(true);
     expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should handle add BU label', async () => {
+    const wrapper = mountFlawLabelsTable();
+    const { areLabelsUpdated } = useFlawLabels();
+    await flushPromises();
+
+    await wrapper.find('.table-new-row td').trigger('click');
+    const editRow = wrapper.findComponent(FlawLabelTableEditingRow);
+    editRow.vm.$emit('save', {
+      type: FlawLabelTypeEnum.BU,
+      label: 'core_bu',
+      contributor: '',
+      state: StateEnum.New,
+    });
+    await flushPromises();
+
+    expect(areLabelsUpdated.value).toBe(true);
   });
 
   it('should handle undo delete label', async () => {

--- a/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTableEditingRow.spec.ts.snap
+++ b/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTableEditingRow.spec.ts.snap
@@ -9,8 +9,9 @@ exports[`flawLabelsTableEditingRow > should render 1`] = `
   </select></td>
 <td data-v-627548cb="">
   <!-- Type is only editable for new labels --><select data-v-627548cb="" class="form-select" title="Label type">
-    <option data-v-627548cb="" value="context_based">context_based</option>
     <option data-v-627548cb="" value="alias">alias</option>
+    <option data-v-627548cb="" value="bu">bu</option>
+    <option data-v-627548cb="" value="context_based">context_based</option>
   </select>
 </td>
 <td data-v-627548cb="" class="text-decoration-line-through">

--- a/src/components/IssueQueue/IssueQueueItem.vue
+++ b/src/components/IssueQueue/IssueQueueItem.vue
@@ -44,9 +44,20 @@ const sortedLabels = computed(() => issue.labels?.toSorted((a, b) => {
   return a.label.localeCompare(b.label);
 }) ?? []);
 
+function hashLabelColor(label: string): string {
+  let hash = 0;
+  for (let i = 0; i < label.length; i++) {
+    hash = label.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return `hsl(${Math.abs(hash) % 360}, 55%, 82%)`;
+}
+
 function getLabelColor(label: string, type: string): string {
   if (type === 'context_based') {
     return '#B9BCCB';
+  }
+  if (type === 'bu') {
+    return hashLabelColor(label);
   }
   return labelColorMap[label] || '#FFFFFF';
 }

--- a/src/composables/__tests__/useFlawLabels.spec.ts
+++ b/src/composables/__tests__/useFlawLabels.spec.ts
@@ -93,4 +93,19 @@ describe('useFlawLabels', () => {
 
     expect(labels).toEqual(['context-label']);
   });
+
+  it('loads BU labels correctly', async () => {
+    const { useFlawLabels } = await useMocks();
+    const { loadBuLabels } = useFlawLabels();
+    const mockLabels = [
+      { ...baseLabel, name: 'core_bu', type: FlawLabelTypeEnum.BU },
+      { ...baseLabel, name: 'context-label', type: FlawLabelTypeEnum.CONTEXT_BASED },
+    ];
+
+    vi.mocked(fetchLabels).mockResolvedValue(mockLabels);
+
+    const labels = await loadBuLabels();
+
+    expect(labels).toEqual(['core_bu']);
+  });
 });

--- a/src/composables/useFlawLabels.ts
+++ b/src/composables/useFlawLabels.ts
@@ -57,6 +57,7 @@ export function useFlawLabels(initialLabels?: MaybeRef<ZodFlawLabelType[]>) {
     updatedLabels,
     deletedLabels,
     areLabelsUpdated,
+    loadBuLabels,
     loadContextLabels,
     isNewLabel,
     isUpdatedLabel,
@@ -74,6 +75,22 @@ async function loadContextLabels(): Promise<string[]> {
 
   const labels = (await fetchLabels())
     .filter(({ type }) => type === FlawLabelTypeEnum.CONTEXT_BASED)
+    .map(({ name }) => name);
+
+  sessionStorage.setItem(storageKey, JSON.stringify(labels));
+
+  return labels;
+}
+
+async function loadBuLabels(): Promise<string[]> {
+  const storageKey = 'osim-bu-labels';
+  const storedLabels = sessionStorage.getItem(storageKey);
+  if (storedLabels) {
+    return JSON.parse(storedLabels);
+  }
+
+  const labels = (await fetchLabels())
+    .filter(({ type }) => type === FlawLabelTypeEnum.BU)
     .map(({ name }) => name);
 
   sessionStorage.setItem(storageKey, JSON.stringify(labels));

--- a/src/generated-client/aegis-ai/models/index.ts
+++ b/src/generated-client/aegis-ai/models/index.ts
@@ -3,19 +3,43 @@
 /**
  * 
  * @export
+ * @interface AegisAiWebSrcMainComponentFeatureName
+ */
+export interface AegisAiWebSrcMainComponentFeatureName {
+}
+/**
+ * 
+ * @export
  * @interface AegisAiWebSrcMainComponentFeatureName1
  */
 export interface AegisAiWebSrcMainComponentFeatureName1 {
 }
 /**
+ * Feature KPI model for CVE analysis feedback.
  * 
+ * Contains the acceptance score percentage and filtered log entries.
  * @export
- * @interface AegisAiWebSrcMainComponentFeatureName2
+ * @interface FeatureKPI
  */
-export interface AegisAiWebSrcMainComponentFeatureName2 {
+export interface FeatureKPI {
+    /**
+     * Acceptance score as a percentage (0.0 to 100.0, e.g., 75.0 for 75%)
+     * @type {any}
+     * @memberof FeatureKPI
+     */
+    acceptancePercentage: any | null;
+    /**
+     * List of log entries filtered by feature, sorted by datetime
+     * @type {any}
+     * @memberof FeatureKPI
+     */
+    entries: any | null;
 }
 /**
  * Data structure for feedback.
+ * 
+ * All fields are stored without modification to preserve original data.
+ * CSV escaping is handled automatically by the csv library during logging.
  * @export
  * @interface Feedback
  */
@@ -25,13 +49,7 @@ export interface Feedback {
      * @type {any}
      * @memberof Feedback
      */
-    accept?: any | null;
-    /**
-     * 
-     * @type {any}
-     * @memberof Feedback
-     */
-    actual?: any | null;
+    feature: any | null;
     /**
      * 
      * @type {any}
@@ -49,19 +67,31 @@ export interface Feedback {
      * @type {any}
      * @memberof Feedback
      */
+    requestTime?: any | null;
+    /**
+     * 
+     * @type {any}
+     * @memberof Feedback
+     */
+    actual?: any | null;
+    /**
+     * 
+     * @type {any}
+     * @memberof Feedback
+     */
     expected?: any | null;
     /**
      * 
      * @type {any}
      * @memberof Feedback
      */
-    feature: any | null;
+    accept?: any | null;
     /**
      * 
      * @type {any}
      * @memberof Feedback
      */
-    requestTime?: any | null;
+    rejectionComment?: any | null;
 }
 /**
  * 
@@ -75,6 +105,40 @@ export interface HTTPValidationError {
      * @memberof HTTPValidationError
      */
     detail?: any | null;
+}
+/**
+ * Individual KPI entry model.
+ * 
+ * Contains datetime, acceptance status, and AEGIS version for a feedback entry.
+ * @export
+ * @interface KPIEntry
+ */
+export interface KPIEntry {
+    /**
+     * Timestamp of the feedback entry
+     * @type {any}
+     * @memberof KPIEntry
+     */
+    datetime: any | null;
+    /**
+     * Whether the feedback was accepted
+     * @type {any}
+     * @memberof KPIEntry
+     */
+    accepted: any | null;
+    /**
+     * AEGIS version at time of feedback
+     * @type {any}
+     * @memberof KPIEntry
+     */
+    aegisVersion: any | null;
+}
+/**
+ * Sort order for datetime field.
+ * @export
+ * @interface SortOrder
+ */
+export interface SortOrder {
 }
 /**
  * 

--- a/src/generated-client/osidb/models/index.ts
+++ b/src/generated-client/osidb/models/index.ts
@@ -2910,10 +2910,10 @@ export interface FlawCollaborator {
     relevant?: boolean;
     /**
      * 
-     * @type {string}
+     * @type {FlawLabelType}
      * @memberof FlawCollaborator
      */
-    readonly type: string;
+    type?: FlawLabelType;
 }
 /**
  * FlawCollaborator serializer
@@ -2939,7 +2939,24 @@ export interface FlawCollaboratorPostRequest {
      * @memberof FlawCollaboratorPostRequest
      */
     contributor?: string;
+    /**
+     * 
+     * @type {FlawCollaboratorPostTypeEnum}
+     * @memberof FlawCollaboratorPostRequest
+     */
+    type?: FlawCollaboratorPostTypeEnum;
 }
+
+/**
+ * 
+ * @export
+ */
+export const FlawCollaboratorPostTypeEnum = {
+    Alias: 'alias',
+    ContextBased: 'context_based'
+} as const;
+export type FlawCollaboratorPostTypeEnum = typeof FlawCollaboratorPostTypeEnum[keyof typeof FlawCollaboratorPostTypeEnum];
+
 /**
  * FlawCollaborator serializer
  * @export
@@ -2976,6 +2993,12 @@ export interface FlawCollaboratorRequest {
      * @memberof FlawCollaboratorRequest
      */
     relevant?: boolean;
+    /**
+     * 
+     * @type {FlawLabelType}
+     * @memberof FlawCollaboratorRequest
+     */
+    type?: FlawLabelType;
 }
 /**
  * FlawComment serializer for use by flaw_comments endpoint
@@ -3094,6 +3117,19 @@ export interface FlawLabel {
      */
     readonly type: string;
 }
+
+/**
+ * 
+ * @export
+ */
+export const FlawLabelType = {
+    Alias: 'alias',
+    ContextBased: 'context_based',
+    ProductFamily: 'product_family',
+    Bu: 'bu'
+} as const;
+export type FlawLabelType = typeof FlawLabelType[keyof typeof FlawLabelType];
+
 /**
  * @type FlawMajorIncidentState
  * 
@@ -5688,10 +5724,10 @@ export interface OsidbApiV1FlawsLabelsCreate201Response {
     relevant?: boolean;
     /**
      * 
-     * @type {string}
+     * @type {FlawLabelType}
      * @memberof OsidbApiV1FlawsLabelsCreate201Response
      */
-    readonly type: string;
+    type?: FlawLabelType;
     /**
      * 
      * @type {string}

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -149,6 +149,7 @@ export const ZodHistoryItemSchema = z.object({
 
 export enum FlawLabelTypeEnum {
   ALIAS = 'alias',
+  BU = 'bu',
   CONTEXT_BASED = 'context_based',
   PRODUCT_FAMILY = 'product_family',
 }


### PR DESCRIPTION
# OSIDB-4982 BU label type

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated

## Summary

Add support for the new `bu` label type (OSIDB-4982) to allow analysts to tag flaws with their responsible Business Unit pillar for triage and filtering.

## Changes

- Added `BU` to `FlawLabelTypeEnum` and `loadBuLabels` composable function
- Extended label editing UI to support BU type with a dropdown (mirrors context-based behaviour)
- BU labels in the issue queue get a unique hash-derived pastel color per label name
- Synced `openapi-osidb.yml` and regenerated client

## Demo

https://github.com/user-attachments/assets/5e51bd4d-a08c-4a0a-8b1f-fa9c122b5ba1

