### PR TITLE
🐛 Disable reset/save buttons when no flaw changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 * Add manual component suggestions for Source Component field (`OSIDB-4996`)
 
+### Fixed
+* Disable "Save Changes" and "Reset CHanges" buttons when no flaw changes have been made (`OSIDB-4973`)
+
 ### Changed
 * Update error message on failed logging (`OSIDB-5011`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Add manual component suggestions for Source Component field (`OSIDB-4996`)
 
 ### Fixed
-* Disable "Save Changes" and "Reset CHanges" buttons when no flaw changes have been made (`OSIDB-4973`)
+* Disable "Save Changes" and "Reset Changes" buttons when no flaw changes have been made (`OSIDB-4973`)
 
 ### Changed
 * Update error message on failed logging (`OSIDB-5011`)

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -102,16 +102,28 @@ const {
   isFetchingAffects,
   totalAffectCount,
 } = useFetchFlaw();
-const { flaw, initialFlaw } = useFlaw();
+const { flaw, initialFlaw, isFlawUpdated } = useFlaw();
 
 const {
   highlightedNvdCvssString,
   nvdCvssString,
   rhCvssString,
   shouldDisplayEmailNistForm,
+  wasFlawCvssModified,
 } = useCvssScores();
 
 const { draftFlaw } = useDraftFlawStore();
+
+const {
+  state: { removedAffects, wereAffectsEditedOrAdded },
+} = useAffectsModel();
+
+const hasAnyChanges = computed(() => {
+  return isFlawUpdated.value
+    || wereAffectsEditedOrAdded.value
+    || wasFlawCvssModified.value
+    || removedAffects.size > 0;
+});
 
 onMounted(() => {
   if (flaw.value.cve_id) {
@@ -124,7 +136,7 @@ onMounted(() => {
   }
 });
 
-watch(() => flaw.value, () => { // Shallow watch so as to avoid reseting on any change (though that shouldn't happen)
+watch(() => flaw.value, () => {
   isEmbargoed.value = initialFlaw.value?.embargoed;
   shouldCreateJiraTask.value = false;
 });
@@ -616,12 +628,21 @@ const isArrayFieldValueAIBot = (fieldName: string, currentValue: null | string[]
     </div>
     <div class="osim-action-buttons sticky-bottom d-flex justify-content-end">
       <template v-if="mode === 'edit'">
-        <button type="button" class="btn btn-secondary" @click="onReset">Reset Changes</button>
+        <button
+          type="button"
+          class="btn btn-secondary"
+          :disabled="!hasAnyChanges"
+          :title="hasAnyChanges ? '' : 'No changes to reset'"
+          @click="onReset"
+        >
+          Reset Changes
+        </button>
         <button
           v-osim-loading.grow="isSaving"
           type="submit"
           class="btn btn-primary ms-3"
-          :disabled="isSaving"
+          :disabled="isSaving || !hasAnyChanges"
+          :title="isSaving ? 'Saving...' : (!hasAnyChanges ? 'No changes to save' : '')"
         >
           Save Changes
         </button>

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -73,6 +73,7 @@ const {
   addBlankAcknowledgment,
   addBlankReference,
   addFlawComment,
+  areLabelsUpdated,
   bugzillaLink,
   cancelAddAcknowledgment,
   cancelAddReference,
@@ -122,7 +123,8 @@ const hasAnyChanges = computed(() => {
   return isFlawUpdated.value
     || wereAffectsEditedOrAdded.value
     || wasFlawCvssModified.value
-    || removedAffects.size > 0;
+    || removedAffects.size > 0
+    || areLabelsUpdated.value;
 });
 
 onMounted(() => {
@@ -641,8 +643,8 @@ const isArrayFieldValueAIBot = (fieldName: string, currentValue: null | string[]
           v-osim-loading.grow="isSaving"
           type="submit"
           class="btn btn-primary ms-3"
-          :disabled="isSaving || !hasAnyChanges"
-          :title="isSaving ? 'Saving...' : (!hasAnyChanges ? 'No changes to save' : '')"
+          :disabled="isSaving || (!hasAnyChanges && !shouldCreateJiraTask)"
+          :title="isSaving ? 'Saving...' : ((!hasAnyChanges && !shouldCreateJiraTask) ? 'No changes to save' : '')"
         >
           Save Changes
         </button>

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -32,6 +32,7 @@ import { useFlawModel } from '@/composables/useFlawModel';
 import { useFlaw } from '@/composables/useFlaw';
 import { useFetchFlaw } from '@/composables/useFetchFlaw';
 import { useCvssScores } from '@/composables/useCvssScores';
+import { useFlawLabels } from '@/composables/useFlawLabels';
 import {
   aegisSuggestionRequestBody,
   type AegisSuggestionContextRefs,
@@ -165,10 +166,19 @@ const onSubmit = async () => {
 };
 
 const onReset = () => {
-  // is deepCopyFromRaw needed?
+  // Reset flaw data
   flaw.value = deepCopyFromRaw(initialFlaw.value) as ZodFlawType;
+
+  // Reset affects
   useAffectsModel().actions.initializeAffects(flaw.value.affects);
 
+  // Reset CVSS changes
+  useCvssScores().reset();
+
+  // Reset label changes
+  useFlawLabels(initialFlaw.value?.labels ? [...initialFlaw.value.labels] : []);
+
+  // Reset Jira task flag
   shouldCreateJiraTask.value = false;
 };
 

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -661,7 +661,7 @@ exports[`flawForm > mounts and renders 1`] = `
     </div>
   </div>
   </div>
-  <div data-v-76e7a15d="" class="osim-action-buttons sticky-bottom d-flex justify-content-end"><button data-v-76e7a15d="" type="button" class="btn btn-secondary">Reset Changes</button><button data-v-76e7a15d="" type="submit" class="btn btn-primary ms-3">
+  <div data-v-76e7a15d="" class="osim-action-buttons sticky-bottom d-flex justify-content-end"><button data-v-76e7a15d="" type="button" class="btn btn-secondary" disabled="" title="No changes to reset"> Reset Changes </button><button data-v-76e7a15d="" type="submit" class="btn btn-primary ms-3" disabled="" title="No changes to save">
       <div style="max-height: 1rem; max-width: 1rem;" role="status"></div> Save Changes
     </button></div>
 </form>"

--- a/src/composables/useFlawLabels.ts
+++ b/src/composables/useFlawLabels.ts
@@ -11,11 +11,16 @@ const updatedLabels = ref<Set<string>>(new Set<string>());
 const deletedLabels = ref<Set<string>>(new Set<string>());
 
 export function useFlawLabels(initialLabels?: MaybeRef<ZodFlawLabelType[]>) {
-  if (initialLabels && toValue(initialLabels)?.length) {
-    labels.value = toValue(initialLabels).reduce((acc: Record<string, ZodFlawLabelType>, label) => {
-      acc[label.label] = label;
-      return acc;
-    }, {});
+  if (initialLabels !== undefined) {
+    const labelArray = toValue(initialLabels);
+    if (labelArray && labelArray.length > 0) {
+      labels.value = labelArray.reduce((acc: Record<string, ZodFlawLabelType>, label) => {
+        acc[label.label] = label;
+        return acc;
+      }, {});
+    } else {
+      labels.value = {};
+    }
     newLabels.value = new Set();
     updatedLabels.value = new Set();
     deletedLabels.value = new Set();

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -383,6 +383,7 @@ export function useFlawModel() {
     flawIncidentStates,
     osimLink,
     bugzillaLink,
+    areLabelsUpdated,
     shouldCreateJiraTask,
     toggleShouldCreateJiraTask,
     createFlaw,


### PR DESCRIPTION
# OSIDB-4973 Disable reset/save buttons when no flaw changes

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated

## Summary

Prevents users from saving or resetting flaws when no changes have been made, avoiding unnecessary API calls and potential programmatic feedback issues.

## Changes

- Disabled "Save Changes" button when no modifications detected
- Disabled "Reset Changes" button when no modifications detected  
- Added tooltips explaining why buttons are disabled
- Detects changes across flaw fields, affects, and CVSS scores

Closes `OSIDB-4973`