### PR TITLE
Fix/osidb 5011 update logging error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 * Add manual component suggestions for Source Component field (`OSIDB-4996`)
 
+### Changed
+* Update error message on failed logging (`OSIDB-5011`)
+
 ## [2026.5.1]
 ### Added
 * Add support for Business Unit (BU) label type for flaw triage (`OSIDB-4982`)

--- a/src/components/Login/Login.vue
+++ b/src/components/Login/Login.vue
@@ -67,12 +67,16 @@ function login() {
       console.error('Login::login() Error logging in', e);
       if (osimRuntime.value.backends.osidbAuth === 'kerberos') {
         error.value = [
-          'Error logging in.',
-          'Ensure that your system has krb5 configured.',
-          'Ensure that your browser has the correct trusted URIs for Negotiate authentication.',
-          'Ensure that you have logged into Kerberos on your system.',
-          'More info: <a class="alert-link" target="_blank" rel="noopener noreferrer nofollow"href="https://people.redhat.com/mikeb/negotiate/">https://people.redhat.com/mikeb/negotiate/</a>',
-        ].join('\n');
+          '<strong>Kerberos authentication failed.</strong>',
+          '<strong>Troubleshooting steps:</strong>',
+          '1. Run <code>kinit</code> to refresh/ensure you have a valid Kerberos token.',
+          '2. Verify your browser trusts this site for Negotiate authentication:',
+          '   • <strong>CSB users:</strong> Verify your CSB configuration is correct. '
+          + 'If settings appear incorrect, contact the IT Endpoint team for support.',
+          '   • <strong>Firefox:</strong> Ensure <code>network.negotiate-auth.trusted-uris</code> '
+          + 'in <code>about:config</code> includes "redhat.com".',
+          '   • <strong>Chrome:</strong> Launch with <code>--auth-server-whitelist="*.redhat.com"</code>',
+        ].join('<br>');
       } else if (osimRuntime.value.backends.osidbAuth === 'credentials') {
         password.value = '';
         error.value = 'Error logging in. Wrong username or password.';


### PR DESCRIPTION
# OSIDB-5011

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [-] Test cases added/updated
- [-] Integration tests updated

## Summary:

Updates the Kerberos authentication failure message with actionable troubleshooting steps.

## Changes:

- Removed outdated link
- Added practical CLI commands: klist and kinit
- Included browser-specific trusted URI configuration instructions

## Considerations:

The previous error message referenced decommissioned infrastructure (Kerberos.corp) and lacked actionable troubleshooting steps for users.

## Demo:
<img width="1359" height="780" alt="image" src="https://github.com/user-attachments/assets/bd5d8f51-5d25-46a9-8c73-9a9e64f1ae08" />

