### PR TITLE
🐛 Fix large line breaks from Jira internal comments

### DIFF
--- a/src/components/FlawComments/CommentList.vue
+++ b/src/components/FlawComments/CommentList.vue
@@ -48,8 +48,13 @@ watch(() => props.commentList, async (comments) => {
 
   parsedComments.value = comments.map((c) => {
     if (c.type === CommentType.Internal) {
-      // renderedBody is pre-rendered HTML from Jira — only sanitize
-      return sanitizeHtml(c.text ?? '');
+      // Convert <p> tags to simple line breaks
+      const html = sanitizeHtml(c.text ?? '')
+        .replace(/<\/p>\s*<p[^>]*>/gi, '<br>')  // Convert paragraph breaks to <br>
+        .replace(/<\/?p[^>]*>/gi, '')             // Strip remaining <p> tags
+        .replace(/(<br\s*\/?>[\s\n]*)+/gi, '<br>') // Collapse multiple <br>
+        .trim();
+      return html;
     }
     return linkify(sanitizeHtml(c.text ?? ''));
   });

--- a/src/components/FlawComments/FlawComments.vue
+++ b/src/components/FlawComments/FlawComments.vue
@@ -180,6 +180,7 @@ const tabsTooltips = computed(() => {
 
   :deep(.osim-flaw-comment) {
     white-space: pre-wrap;
+    line-height: 1.4;
   }
 }
 </style>


### PR DESCRIPTION
# OSIDB-5017 Fix large line breaks from Jira internal comments

## Checklist:

- [x] Commits consolidated
- [ ] Changelog updated
- [-] Test cases added/updated
- [-] Integration tests updated

## Summary:

Jira parsing makes an html paragraph each line which implicitly creates large spaces between lines.

## Changes:

Remove paragraph tags from Jira html comments
