### PR TITLE
🐛 Disable aegis suggestion buttons when feature flags are off

### DIFF
--- a/src/components/Aegis/AegisComponentActions.vue
+++ b/src/components/Aegis/AegisComponentActions.vue
@@ -8,6 +8,8 @@ import type { AegisSuggestionContextRefs } from '@/composables/aegis/useAegisSug
 import { useAegisMetadataTracking } from '@/composables/aegis/useAegisMetadataTracking';
 import { useSimpleFeedback } from '@/composables/aegis/useUnifiedAegisFeedback';
 
+import { osimRuntime } from '@/stores/osimRuntime';
+
 const props = withDefaults(defineProps<{
   aegisContext?: AegisSuggestionContextRefs | null;
 }>(), {
@@ -89,7 +91,7 @@ const suggestionTooltip = computed(() => {
 
 <template>
   <AegisActions
-    :canSuggest="canSuggest"
+    :canSuggest="canSuggest && !!osimRuntime.flags?.aiComponentSuggestions"
     :hasAppliedSuggestion="hasAppliedSuggestion"
     :hasMultipleSuggestions="false"
     :isFetchingSuggestion="isFetchingSuggestion"

--- a/src/components/Aegis/AegisCvssActions.vue
+++ b/src/components/Aegis/AegisCvssActions.vue
@@ -9,6 +9,8 @@ import { useCvssScores } from '@/composables/useCvssScores';
 import { useAegisFieldFeedback } from '@/composables/aegis/useAegisFieldFeedback';
 import { useAegisMetadataTracking } from '@/composables/aegis/useAegisMetadataTracking';
 
+import { osimRuntime } from '@/stores/osimRuntime';
+
 const props = withDefaults(defineProps<{
   aegisContext?: AegisSuggestionContextRefs | null;
 }>(), {
@@ -84,7 +86,7 @@ const suggestionTooltip = computed(() => {
 
 <template>
   <AegisActions
-    :canSuggest="canSuggest"
+    :canSuggest="canSuggest && !!osimRuntime.flags?.aiCvssSuggestions"
     :hasAppliedSuggestion="hasAppliedSuggestion"
     :hasMultipleSuggestions="hasMultipleSuggestions"
     :isFetchingSuggestion="isFetchingSuggestion"

--- a/src/components/Aegis/AegisCweActions.vue
+++ b/src/components/Aegis/AegisCweActions.vue
@@ -92,7 +92,7 @@ onMounted(() => {
 <template>
   <AegisActions
     v-if="osimRuntime.flags?.aiCweSuggestions === true || isCweAIBot"
-    :canSuggest="canSuggest"
+    :canSuggest="canSuggest && !!osimRuntime.flags?.aiCweSuggestions"
     :hasAppliedSuggestion="hasAppliedSuggestion"
     :hasMultipleSuggestions="hasMultipleSuggestions"
     :isFetchingSuggestion="isFetchingSuggestion"

--- a/src/components/Aegis/AegisDescriptionActions.vue
+++ b/src/components/Aegis/AegisDescriptionActions.vue
@@ -7,6 +7,8 @@ import type { UseAegisSuggestDescriptionReturn } from '@/composables/aegis/useAe
 import { useAegisFieldFeedback } from '@/composables/aegis/useAegisFieldFeedback';
 import { useAegisMetadataTracking } from '@/composables/aegis/useAegisMetadataTracking';
 
+import { osimRuntime } from '@/stores/osimRuntime';
+
 const props = defineProps<{
   composable: UseAegisSuggestDescriptionReturn;
   descriptionValue?: null | string;
@@ -60,7 +62,7 @@ const suggestionTooltip = computed(() => {
 
 <template>
   <AegisActions
-    :canSuggest="canSuggest"
+    :canSuggest="canSuggest && !!osimRuntime.flags?.aiDescriptionSuggestions"
     :hasAppliedSuggestion="hasAppliedDescriptionSuggestion"
     :hasMultipleSuggestions="false"
     :isFetchingSuggestion="isSuggesting"

--- a/src/components/Aegis/AegisImpactActions.vue
+++ b/src/components/Aegis/AegisImpactActions.vue
@@ -8,6 +8,7 @@ import type { AegisSuggestionContextRefs } from '@/composables/aegis/useAegisSug
 import { useAegisFieldFeedback } from '@/composables/aegis/useAegisFieldFeedback';
 import { useAegisMetadataTracking } from '@/composables/aegis/useAegisMetadataTracking';
 
+import { osimRuntime } from '@/stores/osimRuntime';
 import type { ImpactEnumWithBlankType } from '@/types/zodShared';
 
 const props = withDefaults(defineProps<{
@@ -83,7 +84,7 @@ const suggestionTooltip = computed(() => {
 
 <template>
   <AegisActions
-    :canSuggest="canSuggest"
+    :canSuggest="canSuggest && !!osimRuntime.flags?.aiImpactSuggestions"
     :hasAppliedSuggestion="hasAppliedSuggestion"
     :hasMultipleSuggestions="hasMultipleSuggestions"
     :isFetchingSuggestion="isFetchingSuggestion"

--- a/src/components/Aegis/AegisMitigationActions.vue
+++ b/src/components/Aegis/AegisMitigationActions.vue
@@ -6,6 +6,8 @@ import AegisActions from '@/components/Aegis/AegisActions.vue';
 import { useAegisSuggestion } from '@/composables/aegis/useAegisSuggestion';
 import type { AegisSuggestionContextRefs } from '@/composables/aegis/useAegisSuggestionContext';
 
+import { osimRuntime } from '@/stores/osimRuntime';
+
 const props = withDefaults(defineProps<{
   aegisContext?: AegisSuggestionContextRefs | null;
 }>(), {
@@ -50,7 +52,7 @@ const suggestionTooltip = computed(() => {
 
 <template>
   <AegisActions
-    :canSuggest="canSuggest"
+    :canSuggest="canSuggest && !!osimRuntime.flags?.aiMitigationSuggestions"
     :hasAppliedSuggestion="hasAppliedSuggestion"
     :hasMultipleSuggestions="hasMultipleSuggestions"
     :isFetchingSuggestion="isFetchingSuggestion"

--- a/src/components/Aegis/AegisStatementActions.vue
+++ b/src/components/Aegis/AegisStatementActions.vue
@@ -72,7 +72,7 @@ const suggestionTooltip = computed(() => {
 <template>
   <AegisActions
     v-if="osimRuntime.flags?.aiStatementSuggestions || isStatementAIBot"
-    :canSuggest="canSuggest"
+    :canSuggest="canSuggest && !!osimRuntime.flags?.aiStatementSuggestions"
     :hasAppliedSuggestion="hasAppliedSuggestion"
     :hasMultipleSuggestions="hasMultipleSuggestions"
     :isFetchingSuggestion="isFetchingSuggestion"

--- a/src/components/Aegis/AegisTitleActions.vue
+++ b/src/components/Aegis/AegisTitleActions.vue
@@ -65,7 +65,7 @@ const suggestionTooltip = computed(() => {
 <template>
   <AegisActions
     v-if="osimRuntime.flags?.aiTitleSuggestions === true || isTitleAIBot"
-    :canSuggest="canSuggest"
+    :canSuggest="canSuggest && !!osimRuntime.flags?.aiTitleSuggestions"
     :hasAppliedSuggestion="hasAppliedTitleSuggestion"
     :hasMultipleSuggestions="false"
     :isFetchingSuggestion="isSuggesting"

--- a/src/components/CweSelector/CweSelector.vue
+++ b/src/components/CweSelector/CweSelector.vue
@@ -6,6 +6,7 @@ import AegisCweActions from '@/components/Aegis/AegisCweActions.vue';
 import type { AegisSuggestionContextRefs } from '@/composables/aegis/useAegisSuggestionContext';
 import { useAegisMetadataTracking } from '@/composables/aegis/useAegisMetadataTracking';
 
+import { osimRuntime } from '@/stores/osimRuntime';
 import { getMitreUrl, loadCweData } from '@/services/CweService';
 import type { CWEMemberType } from '@/types/mitreCwe';
 import EditableTextWithSuggestions from '@/widgets/EditableTextWithSuggestions/EditableTextWithSuggestions.vue';
@@ -119,6 +120,8 @@ function parseDisplayValue(value: null | string) {
         class="bi bi-robot text-primary me-1"
       ></i>
       <AegisCweActions
+        v-if="osimRuntime.flags?.aiCweSuggestions ||
+          isFieldValueAIBot('cwe_id', modelValue)"
         ref="aegisCweActionsRef"
         v-model="modelValue"
         :aegisContext="aegisContext"

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -284,6 +284,8 @@ const isArrayFieldValueAIBot = (fieldName: string, currentValue: null | string[]
                   class="bi bi-robot text-primary me-1"
                 ></i>
                 <AegisTitleActions
+                  v-if="osimRuntime.flags?.aiTitleSuggestions ||
+                    isFieldValueAIBot('title', flaw.title)"
                   :composable="aegisSuggestTitleComposable"
                   :titleValue="flaw.title"
                 />
@@ -483,6 +485,8 @@ const isArrayFieldValueAIBot = (fieldName: string, currentValue: null | string[]
                     class="bi bi-robot text-primary me-1"
                   ></i>
                   <AegisDescriptionActions
+                    v-if="osimRuntime.flags?.aiDescriptionSuggestions ||
+                      isFieldValueAIBot('cve_description', flaw.cve_description)"
                     :composable="aegisSuggestDescriptionComposable"
                     :descriptionValue="flaw.cve_description"
                   />
@@ -513,6 +517,8 @@ const isArrayFieldValueAIBot = (fieldName: string, currentValue: null | string[]
                     class="bi bi-robot text-primary me-1"
                   ></i>
                   <AegisStatementActions
+                    v-if="osimRuntime.flags?.aiStatementSuggestions ||
+                      isFieldValueAIBot('statement', flaw.statement)"
                     v-model="flaw.statement"
                     :aegisContext="aegisContext"
                   />

--- a/src/components/FlawForm/FlawFormImpact.vue
+++ b/src/components/FlawForm/FlawFormImpact.vue
@@ -7,6 +7,7 @@ import AegisImpactActions from '@/components/Aegis/AegisImpactActions.vue';
 import type { AegisSuggestionContextRefs } from '@/composables/aegis/useAegisSuggestionContext';
 import { useAegisMetadataTracking } from '@/composables/aegis/useAegisMetadataTracking';
 
+import { osimRuntime } from '@/stores/osimRuntime';
 import { flawImpactEnum } from '@/types/zodFlaw';
 import { FlawClassificationStateEnum } from '@/generated-client';
 import { ImpactEnumWithBlank } from '@/types/zodShared';
@@ -59,6 +60,8 @@ const { isFieldValueAIBot } = useAegisMetadataTracking();
         class="bi bi-robot text-primary me-1"
       ></i>
       <AegisImpactActions
+        v-if="osimRuntime.flags?.aiImpactSuggestions ||
+          isFieldValueAIBot('impact', modelValue)"
         :aegisContext="aegisContext"
         :modelValue="modelValue"
         @update:impact="handleImpactChange"

--- a/src/components/FlawForm/FlawMitigation.vue
+++ b/src/components/FlawForm/FlawMitigation.vue
@@ -37,7 +37,8 @@ const { isFieldValueAIBot } = useAegisMetadataTracking();
           class="bi bi-robot text-primary me-1"
         ></i>
         <AegisMitigationActions
-          v-if="osimRuntime.flags?.aiMitigationSuggestions"
+          v-if="osimRuntime.flags?.aiMitigationSuggestions ||
+            isFieldValueAIBot('mitigation', modelValue)"
           v-model="modelValue"
           :aegisContext="aegisContext"
         />

--- a/src/components/__tests__/__snapshots__/CweSelector.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/CweSelector.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`cweSelector.vue > renders correctly 1`] = `
 "<div data-v-0e2ae48e="" data-v-478878c2="" class="osim-input ps-3 mb-2">
-  <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--><!--v-if--><!--v-if-->  <!--attrs: {{ $attrs }}--></span>
+  <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if-->  <!--attrs: {{ $attrs }}--></span>
     <div data-v-0e2ae48e="" class="col-9">
       <div data-v-478878c2="" tabindex="0">
         <!-- for invalid-tooltip positioning -->

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -122,7 +122,7 @@ exports[`flawForm > mounts and renders 1`] = `
           </label></div>
         <!--v-if-->
       </div><label data-v-001a00e0="" data-v-1c54faf9="" data-v-76e7a15d="" class="osim-input mb-2 ps-3">
-        <div data-v-001a00e0="" class="row"><span data-v-001a00e0="" class="form-label col-3"><!--v-if--><div data-v-e049df0b="" data-v-c3dcf9f5="" data-v-1c54faf9="" class="d-flex align-items-center"><!-- @ts-ignore: Global directive --><i data-v-e049df0b="" class="bi-stars label-icon me-1" title="Generate AI suggestion"></i><!--v-if--><!--v-if--><!--v-if--><transition-stub data-v-296c460d="" name="modal" appear="false" persisted="false" css="true"><!--v-if--></transition-stub><transition-stub data-v-296c460d="" name="modal-bg" appear="false" persisted="false" css="true"><!--v-if--></transition-stub></div> Impact <!--v-if--></span>
+        <div data-v-001a00e0="" class="row"><span data-v-001a00e0="" class="form-label col-3"><!--v-if--><!--v-if--> Impact <!--v-if--></span>
           <div data-v-001a00e0="" class="col-9"><select data-v-001a00e0="" class="form-select" value="MODERATE">
               <option data-v-001a00e0="" selected="" disabled="" value=""></option>
               <option data-v-001a00e0="" value="CRITICAL">CRITICAL</option>
@@ -205,7 +205,7 @@ exports[`flawForm > mounts and renders 1`] = `
         <!--v-if-->
       </div>
       <div data-v-0e2ae48e="" data-v-478878c2="" data-v-76e7a15d="" class="osim-input ps-3 mb-2">
-        <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--><!--v-if--><!--v-if--> CWE ID <!--attrs: {{ $attrs }}--></span>
+        <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--> CWE ID <!--attrs: {{ $attrs }}--></span>
           <div data-v-0e2ae48e="" class="col-9">
             <div data-v-478878c2="" tabindex="0">
               <!-- for invalid-tooltip positioning -->
@@ -453,7 +453,7 @@ exports[`flawForm > mounts and renders 1`] = `
         </div>
       </label></div>
     <div data-v-76e7a15d="" class="col-6"><label data-v-055401b4="" data-v-76e7a15d="" class="osim-input mb-2">
-        <div data-v-055401b4="" class="row px-0 mx-0"><span data-v-76e7a15d="" class="form-label col-3 osim-folder-tab-label position-relative"><div data-v-76e7a15d="" class="d-flex align-items-center"><!--v-if--><!--v-if--><div data-v-e049df0b="" data-v-76e7a15d="" class="d-flex align-items-center"><!-- @ts-ignore: Global directive --><i data-v-e049df0b="" class="bi-stars label-icon me-1" title="Generate AI suggestion"></i><!--v-if--><!--v-if--><!--v-if--><transition-stub data-v-296c460d="" name="modal" appear="false" persisted="false" css="true"><!--v-if--></transition-stub><transition-stub data-v-296c460d="" name="modal-bg" appear="false" persisted="false" css="true"><!--v-if--></transition-stub></div><span data-v-76e7a15d="">Description</span></div></span><!--    @focus="resizeTextarea"-->
+        <div data-v-055401b4="" class="row px-0 mx-0"><span data-v-76e7a15d="" class="form-label col-3 osim-folder-tab-label position-relative"><div data-v-76e7a15d="" class="d-flex align-items-center"><!--v-if--><!--v-if--><!--v-if--><span data-v-76e7a15d="">Description</span></div></span><!--    @focus="resizeTextarea"-->
         <!--    @keyup="resizeTextarea"--><textarea data-v-055401b4="" placeholder="Description Text ..." class="form-control col-9 d-inline-block" rows="5" value="I am a spooky CVE"></textarea>
         <!--v-if-->
     </div></label>

--- a/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
+++ b/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
@@ -61,7 +61,7 @@ exports[`flawCreateView > should render 1`] = `
               </label></div>
             <!--v-if-->
           </div><label data-v-001a00e0="" data-v-1c54faf9="" data-v-76e7a15d="" class="osim-input mb-2 ps-3">
-            <div data-v-001a00e0="" class="row"><span data-v-001a00e0="" class="form-label col-3"><!--v-if--><div data-v-e049df0b="" data-v-c3dcf9f5="" data-v-1c54faf9="" class="d-flex align-items-center"><!-- @ts-ignore: Global directive --><i data-v-e049df0b="" class="bi-stars label-icon me-1 disabled" title="Generate AI suggestion"></i><!--v-if--><!--v-if--><!--v-if--><transition-stub data-v-296c460d="" name="modal" appear="false" persisted="false" css="true"><!--v-if--></transition-stub><transition-stub data-v-296c460d="" name="modal-bg" appear="false" persisted="false" css="true"><!--v-if--></transition-stub></div> Impact <!--v-if--></span>
+            <div data-v-001a00e0="" class="row"><span data-v-001a00e0="" class="form-label col-3"><!--v-if--><!--v-if--> Impact <!--v-if--></span>
               <div data-v-001a00e0="" class="col-9"><select data-v-001a00e0="" class="form-select is-invalid">
                   <option data-v-001a00e0="" selected="" disabled="" value=""></option>
                   <option data-v-001a00e0="" value="CRITICAL">CRITICAL</option>
@@ -144,7 +144,7 @@ exports[`flawCreateView > should render 1`] = `
             <!--v-if-->
           </div>
           <div data-v-0e2ae48e="" data-v-478878c2="" data-v-76e7a15d="" class="osim-input ps-3 mb-2">
-            <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--><!--v-if--><!--v-if--> CWE ID <!--attrs: {{ $attrs }}--></span>
+            <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--> CWE ID <!--attrs: {{ $attrs }}--></span>
               <div data-v-0e2ae48e="" class="col-9">
                 <div data-v-478878c2="" tabindex="0">
                   <!-- for invalid-tooltip positioning -->
@@ -353,7 +353,7 @@ exports[`flawCreateView > should render 1`] = `
             </div>
           </label></div>
         <div data-v-76e7a15d="" class="col-6"><label data-v-055401b4="" data-v-76e7a15d="" class="osim-input mb-2">
-            <div data-v-055401b4="" class="row px-0 mx-0"><span data-v-76e7a15d="" class="form-label col-3 osim-folder-tab-label position-relative"><div data-v-76e7a15d="" class="d-flex align-items-center"><!--v-if--><!--v-if--><div data-v-e049df0b="" data-v-76e7a15d="" class="d-flex align-items-center"><!-- @ts-ignore: Global directive --><i data-v-e049df0b="" class="bi-stars label-icon me-1 disabled" title="Generate AI suggestion"></i><!--v-if--><!--v-if--><!--v-if--><transition-stub data-v-296c460d="" name="modal" appear="false" persisted="false" css="true"><!--v-if--></transition-stub><transition-stub data-v-296c460d="" name="modal-bg" appear="false" persisted="false" css="true"><!--v-if--></transition-stub></div><span data-v-76e7a15d="">Description</span></div></span><!--    @focus="resizeTextarea"-->
+            <div data-v-055401b4="" class="row px-0 mx-0"><span data-v-76e7a15d="" class="form-label col-3 osim-folder-tab-label position-relative"><div data-v-76e7a15d="" class="d-flex align-items-center"><!--v-if--><!--v-if--><!--v-if--><span data-v-76e7a15d="">Description</span></div></span><!--    @focus="resizeTextarea"-->
             <!--    @keyup="resizeTextarea"--><textarea data-v-055401b4="" placeholder="Description Text ..." class="form-control col-9 d-inline-block" rows="5" value=""></textarea>
             <!--v-if-->
         </div></label>


### PR DESCRIPTION
# AEGIS-459 Disable aegis suggestion buttons when feature flags are off

## Checklist:

- [X] Commits consolidated
- [-] Changelog updated
- [-] Test cases added/updated
- [-] Integration tests updated

## Summary:

Manual suggestions on Aegis fields were available on bot suggestions regardless of the feature flag

## Changes:

Feature flag OFF + No bot suggestion: No Aegis component shown
Feature flag OFF + Bot suggestion present: Aegis component shown but manual suggestion button disabled
Feature flag ON: Manual suggestion button visible and functional

## Considerations:

Bot features: Always work regardless of manual suggestion feature flags
