### PR TITLE
🐛 Use email instead username for my issues filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 * Disable "Save Changes" and "Reset Changes" buttons when no flaw changes have been made (`OSIDB-4973`)
+* Fix my issues flaw list filter to use email instead username (`OSIDB-5143`)
 
 ### Changed
 * Update error message on failed logging (`OSIDB-5011`)

--- a/src/components/FlawLabels/FlawLabelsContributor.vue
+++ b/src/components/FlawLabels/FlawLabelsContributor.vue
@@ -22,9 +22,11 @@ const { flaw } = useFlaw();
 const userStore = useUserStore();
 
 async function selfAssign() {
-  await userStore.updateJiraUsername();
-  modelValue.value = userStore.jiraUsername;
-  contributor.value = userStore.jiraUsername;
+  if (!userStore.userEmail) {
+    return;
+  }
+  modelValue.value = userStore.userEmail;
+  contributor.value = userStore.userEmail;
 }
 
 const cacheJiraUsers = useMemoize(async (query: string) => {
@@ -49,7 +51,10 @@ const onQueryChange = async (query: string) => {
 };
 
 const handleSuggestionClick = (user: ZodJiraUserAssignableType) => {
-  contributor.value = toValue(user.emailAddress ?? user.name ?? '');
+  contributor.value = toValue(user.emailAddress ?? '');
+  if (!contributor.value) {
+    return;
+  }
   modelValue.value = contributor.value;
   results.value = [];
 };

--- a/src/components/FlawLabels/__tests__/FlawLabelsContributor.spec.ts
+++ b/src/components/FlawLabels/__tests__/FlawLabelsContributor.spec.ts
@@ -8,14 +8,15 @@ import FlawLabelsContributor from '../FlawLabelsContributor.vue';
 
 vi.mock('@/stores/UserStore', () => ({
   useUserStore: () => ({
-    jiraUsername: 'skynet',
-    updateJiraUsername: vi.fn(),
+    userEmail: 'skynet@example.com',
   }),
 }));
 
 vi.mock('@/services/JiraService', () => ({
   searchJiraUsers: () => {
-    return Promise.resolve({ data: [{ accountId: 'skynet-id', displayName: 'SkyNet', name: 'skynet' }] });
+    return Promise.resolve({
+      data: [{ accountId: 'skynet-id', displayName: 'SkyNet', name: 'skynet', emailAddress: 'skynet@example.com' }],
+    });
   },
 }));
 
@@ -58,7 +59,7 @@ describe('flawLabelsContributor', () => {
 
     await wrapper.find('button').trigger('click');
 
-    expect(wrapper.props('modelValue')).toBe('skynet');
+    expect(wrapper.props('modelValue')).toBe('skynet@example.com');
   });
 
   it('should assign the contributor on click', async () => {
@@ -70,7 +71,7 @@ describe('flawLabelsContributor', () => {
     await flushPromises();
     await wrapper.find('div.item').trigger('click');
 
-    expect(wrapper.props('modelValue')).toBe('skynet');
+    expect(wrapper.props('modelValue')).toBe('skynet@example.com');
   });
 
   it('should not allow arbitrary input', async () => {

--- a/src/components/IssueQueue/IssueQueue.vue
+++ b/src/components/IssueQueue/IssueQueue.vue
@@ -57,8 +57,8 @@ const filteredStates = computed(() => {
 const params = computed(() => {
   const paramsObj: Record<string, any> = {};
 
-  if (isMyIssuesSelected.value && userStore.jiraUsername !== '') {
-    paramsObj.owner = userStore.jiraUsername;
+  if (isMyIssuesSelected.value && userStore.userEmail !== '') {
+    paramsObj.owner = userStore.userEmail;
   }
 
   if (isOpenIssuesSelected.value) {

--- a/src/components/__tests__/IssueQueue.spec.ts
+++ b/src/components/__tests__/IssueQueue.spec.ts
@@ -12,7 +12,7 @@ import { useSettingsStore } from '@/stores/SettingsStore';
 
 vi.mock('@/stores/UserStore', () => ({
   useUserStore: () => ({
-    jiraUsername: 'skynet',
+    userEmail: 'skynet@example.com',
   }),
 }));
 
@@ -82,7 +82,7 @@ describe('issueQueue', () => {
     expect(fetchEvents).toHaveProperty('flaws:fetch');
     expect(fetchEvents['flaws:fetch'][0]).toEqual([
       expect.objectContaining({
-        _value: { order: '-created_dt', owner: 'skynet' },
+        _value: { order: '-created_dt', owner: 'skynet@example.com' },
       }),
     ]);
     expect(issues.length).toBe(1);


### PR DESCRIPTION
# OSIDB-5143 Use email instead username for my issues filter

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated

## Summary:

After Jira migration Owner field must be an email, therefore the my-issues filter needs to work accordingly

## Changes:

- Use email for my issues filter
- Update test

