### PR TITLE
✨ Add next flaw state UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 ### Added
 * Add manual component suggestions for Source Component field (`OSIDB-4996`)
+* Add workflow label type support in Labels section (`OSIDB-5019`)
 
 ### Fixed
 * Disable "Save Changes" and "Reset Changes" buttons when no flaw changes have been made (`OSIDB-4973`)
@@ -9,6 +10,7 @@
 
 ### Changed
 * Update error message on failed logging (`OSIDB-5011`)
+* Rename 'Contributors' section to 'Labels' and remove workflow state change buttons (`OSIDB-5019`)
 
 ## [2026.5.1]
 ### Added

--- a/openapi-osidb.yml
+++ b/openapi-osidb.yml
@@ -12774,6 +12774,7 @@ components:
       enum:
       - alias
       - context_based
+      - workflow
       type: string
     FlawCollaboratorRequest:
       type: object
@@ -12889,6 +12890,7 @@ components:
       - context_based
       - product_family
       - bu
+      - workflow
       type: string
     FlawPackageVersion:
       type: object

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -414,7 +414,7 @@ const isArrayFieldValueAIBot = (fieldName: string, currentValue: null | string[]
         <div class="col-6">
           <FlawWorkflowState
             v-if="mode === 'edit'"
-            :classification="flaw.classification!"
+            :classification="flaw.classification"
             :labels="flaw.labels"
             :shouldCreateJiraTask
             @create:jiraTask="toggleShouldCreateJiraTask()"

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -415,9 +415,7 @@ const isArrayFieldValueAIBot = (fieldName: string, currentValue: null | string[]
           <FlawWorkflowState
             v-if="mode === 'edit'"
             :classification="flaw.classification"
-            :flawId="flaw.uuid"
             :shouldCreateJiraTask
-            @refresh:flaw="emit('refresh:flaw')"
             @create:jiraTask="toggleShouldCreateJiraTask()"
           />
           <div class="osim-incident-state-container mb-2">

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -414,7 +414,8 @@ const isArrayFieldValueAIBot = (fieldName: string, currentValue: null | string[]
         <div class="col-6">
           <FlawWorkflowState
             v-if="mode === 'edit'"
-            :classification="flaw.classification"
+            :classification="flaw.classification!"
+            :labels="flaw.labels"
             :shouldCreateJiraTask
             @create:jiraTask="toggleShouldCreateJiraTask()"
           />

--- a/src/components/FlawForm/FlawForm.vue
+++ b/src/components/FlawForm/FlawForm.vue
@@ -415,6 +415,7 @@ const isArrayFieldValueAIBot = (fieldName: string, currentValue: null | string[]
           <FlawWorkflowState
             v-if="mode === 'edit'"
             :classification="flaw.classification"
+            :flawUuid="flaw.uuid!"
             :labels="flaw.labels"
             :shouldCreateJiraTask
             @create:jiraTask="toggleShouldCreateJiraTask()"

--- a/src/components/FlawLabels/FlawLabelTableEditingRow.vue
+++ b/src/components/FlawLabels/FlawLabelTableEditingRow.vue
@@ -29,6 +29,7 @@ const [labelType, hasTypeChanged] = watchedRef<FlawLabelTypeEnum>(
 const isNewLabel = computed(() => !initalLabel);
 const isAliasType = computed(() => labelType.value === FlawLabelTypeEnum.ALIAS);
 const isBuType = computed(() => labelType.value === FlawLabelTypeEnum.BU);
+const isWorkflowType = computed(() => labelType.value === FlawLabelTypeEnum.WORKFLOW);
 
 const emitSave = () => {
   // if nothing changed, do not emit save
@@ -78,6 +79,7 @@ const emitSave = () => {
       <option :value="FlawLabelTypeEnum.ALIAS">alias</option>
       <option :value="FlawLabelTypeEnum.BU">bu</option>
       <option :value="FlawLabelTypeEnum.CONTEXT_BASED">context_based</option>
+      <option :value="FlawLabelTypeEnum.WORKFLOW">workflow</option>
     </select>
     <template v-else>
       {{ initalLabel?.type }}
@@ -93,13 +95,13 @@ const emitSave = () => {
     <template v-if="initalLabel?.type === FlawLabelTypeEnum.PRODUCT_FAMILY">
       {{ initalLabel?.label }}
     </template>
-    <!-- Alias labels use free text input -->
-    <template v-else-if="isAliasType">
+    <!-- Alias and workflow labels use free text input -->
+    <template v-else-if="isAliasType || isWorkflowType">
       <input
         v-model="labelName"
         type="text"
         class="form-control"
-        placeholder="Enter alias name"
+        :placeholder="isWorkflowType ? 'Enter workflow label name' : 'Enter alias name'"
         required
       >
     </template>

--- a/src/components/FlawLabels/FlawLabelsTable.vue
+++ b/src/components/FlawLabels/FlawLabelsTable.vue
@@ -72,7 +72,7 @@ function handleUndoDelete(label: ZodFlawLabelType) {
 <template>
   <LabelCollapsible :isExpanded @toggle-expanded="toggleExpanded()">
     <template #label>
-      <span class="section-label">Contributors</span>
+      <span class="section-label">Labels</span>
     </template>
     <table class="table table-striped table-hover">
       <thead class="table-dark">

--- a/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTable.spec.ts.snap
+++ b/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTable.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`flawLabelsTable > should handle add label 1`] = `
-"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
+"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Labels</span></button>
   <div data-v-4715e8e2="" class="ps-3 border-start">
     <div data-v-4715e8e2="" class="">
       <table data-v-5d530569="" class="table table-striped table-hover">
@@ -49,7 +49,7 @@ exports[`flawLabelsTable > should handle add label 1`] = `
 `;
 
 exports[`flawLabelsTable > should handle delete label 1`] = `
-"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
+"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Labels</span></button>
   <div data-v-4715e8e2="" class="ps-3 border-start">
     <div data-v-4715e8e2="" class="">
       <table data-v-5d530569="" class="table table-striped table-hover">
@@ -87,7 +87,7 @@ exports[`flawLabelsTable > should handle delete label 1`] = `
 `;
 
 exports[`flawLabelsTable > should handle edit label 1`] = `
-"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
+"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Labels</span></button>
   <div data-v-4715e8e2="" class="ps-3 border-start">
     <div data-v-4715e8e2="" class="">
       <table data-v-5d530569="" class="table table-striped table-hover">
@@ -135,7 +135,7 @@ exports[`flawLabelsTable > should handle edit label 1`] = `
 `;
 
 exports[`flawLabelsTable > should handle undo delete label 1`] = `
-"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
+"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Labels</span></button>
   <div data-v-4715e8e2="" class="ps-3 border-start">
     <div data-v-4715e8e2="" class="">
       <table data-v-5d530569="" class="table table-striped table-hover">
@@ -172,7 +172,7 @@ exports[`flawLabelsTable > should handle undo delete label 1`] = `
 `;
 
 exports[`flawLabelsTable > should render flaw labels table 1`] = `
-"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
+"<div data-v-4715e8e2="" data-v-5d530569="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-5d530569="" class="section-label">Labels</span></button>
   <div data-v-4715e8e2="" class="ps-3 border-start">
     <div data-v-4715e8e2="" class="">
       <table data-v-5d530569="" class="table table-striped table-hover">

--- a/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTableEditingRow.spec.ts.snap
+++ b/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTableEditingRow.spec.ts.snap
@@ -12,6 +12,7 @@ exports[`flawLabelsTableEditingRow > should render 1`] = `
     <option data-v-627548cb="" value="alias">alias</option>
     <option data-v-627548cb="" value="bu">bu</option>
     <option data-v-627548cb="" value="context_based">context_based</option>
+    <option data-v-627548cb="" value="workflow">workflow</option>
   </select>
 </td>
 <td data-v-627548cb="" class="text-decoration-line-through">

--- a/src/components/FlawWorkflowState/FlawNextStatePanel.vue
+++ b/src/components/FlawWorkflowState/FlawNextStatePanel.vue
@@ -19,14 +19,15 @@ const {
 
 onMounted(fetchNextState);
 
-const CONDITION_LABELS: Record<string, string> = {
+type BoolOp = 'AND' | 'OR';
+const CONDITION_LABELS: Record<BoolOp, string> = {
   AND: 'All of:',
   OR: 'Any of:',
 };
 
 function requirementLabel(req: WorkflowRequirement): string {
   if (isWorkflowCondition(req)) {
-    return CONDITION_LABELS[req.condition.toUpperCase()] ?? req.condition;
+    return CONDITION_LABELS[req.condition.toUpperCase() as BoolOp] ?? req.condition;
   }
   return req.name;
 }
@@ -57,16 +58,16 @@ function requirementLabel(req: WorkflowRequirement): string {
 
       <ul v-if="unsatisfiedRequirements.length" class="osim-requirements-list mt-1">
         <li
-          v-for="req in unsatisfiedRequirements"
-          :key="requirementLabel(req)"
+          v-for="(req, index) in unsatisfiedRequirements"
+          :key="`${requirementLabel(req)}-${index}`"
           class="osim-requirement osim-requirement--unmet"
         >
           <i class="bi bi-x-circle-fill me-1 text-danger" />
           <span>{{ requirementLabel(req) }}</span>
           <ul v-if="isWorkflowCondition(req)" class="osim-requirements-list mt-1">
             <li
-              v-for="child in req.requirements"
-              :key="requirementLabel(child)"
+              v-for="(child, childIndex) in req.requirements"
+              :key="`${requirementLabel(child)}-${childIndex}`"
               class="osim-requirement"
               :class="child.accepts ? 'osim-requirement--met' : 'osim-requirement--unmet'"
             >
@@ -84,12 +85,28 @@ function requirementLabel(req: WorkflowRequirement): string {
 
       <ul v-if="satisfiedRequirements.length" class="osim-requirements-list mt-1">
         <li
-          v-for="req in satisfiedRequirements"
-          :key="requirementLabel(req)"
+          v-for="(req, index) in satisfiedRequirements"
+          :key="`${requirementLabel(req)}-${index}`"
           class="osim-requirement osim-requirement--met"
         >
           <i class="bi bi-check-circle-fill me-1 text-success" />
           <span>{{ requirementLabel(req) }}</span>
+          <ul v-if="isWorkflowCondition(req)" class="osim-requirements-list mt-1">
+            <li
+              v-for="(child, childIndex) in req.requirements"
+              :key="`${requirementLabel(child)}-${childIndex}`"
+              class="osim-requirement"
+              :class="child.accepts ? 'osim-requirement--met' : 'osim-requirement--unmet'"
+            >
+              <i
+                class="me-1"
+                :class="child.accepts
+                  ? 'bi bi-check-circle-fill text-success'
+                  : 'bi bi-x-circle-fill text-danger'"
+              />
+              {{ requirementLabel(child) }}
+            </li>
+          </ul>
         </li>
       </ul>
     </template>

--- a/src/components/FlawWorkflowState/FlawNextStatePanel.vue
+++ b/src/components/FlawWorkflowState/FlawNextStatePanel.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+
+import { useWorkflowNextState, type WorkflowRequirement } from '@/composables/useWorkflowNextState';
+
+import { isWorkflowCondition } from '@/services/WorkflowService';
+
+const props = defineProps<{ flawUuid: string }>();
+
+const {
+  allRequirementsMet,
+  error,
+  fetchNextState,
+  isLoading,
+  nextState,
+  satisfiedRequirements,
+  unsatisfiedRequirements,
+} = useWorkflowNextState(props.flawUuid);
+
+onMounted(fetchNextState);
+
+const CONDITION_LABELS: Record<string, string> = {
+  AND: 'All of:',
+  OR: 'Any of:',
+};
+
+function requirementLabel(req: WorkflowRequirement): string {
+  if (isWorkflowCondition(req)) {
+    return CONDITION_LABELS[req.condition.toUpperCase()] ?? req.condition;
+  }
+  return req.name;
+}
+</script>
+
+<template>
+  <div class="osim-next-state-panel mt-2">
+    <div v-if="isLoading" class="osim-next-state-loading">
+      <span class="spinner-border spinner-border-sm me-1" role="status" />
+      Loading…
+    </div>
+    <div v-else-if="error" class="osim-next-state-error">
+      <i class="bi bi-exclamation-circle me-1" />{{ error }}
+    </div>
+    <div v-else-if="!nextState" class="osim-next-state-empty text-muted fst-italic">
+      No further states — flaw is at the end of its workflow.
+    </div>
+    <template v-else>
+      <div class="osim-next-state-header">
+        <span class="osim-next-state-label">Next state:</span>
+        <span class="badge rounded-pill osim-next-state-badge ms-1">
+          {{ nextState.name }}
+        </span>
+        <span v-if="allRequirementsMet" class="osim-next-state-ready ms-2">
+          <i class="bi bi-check-circle-fill text-success" /> All requirements met
+        </span>
+      </div>
+
+      <ul v-if="unsatisfiedRequirements.length" class="osim-requirements-list mt-1">
+        <li
+          v-for="req in unsatisfiedRequirements"
+          :key="requirementLabel(req)"
+          class="osim-requirement osim-requirement--unmet"
+        >
+          <i class="bi bi-x-circle-fill me-1 text-danger" />
+          <span>{{ requirementLabel(req) }}</span>
+          <ul v-if="isWorkflowCondition(req)" class="osim-requirements-list mt-1">
+            <li
+              v-for="child in req.requirements"
+              :key="requirementLabel(child)"
+              class="osim-requirement"
+              :class="child.accepts ? 'osim-requirement--met' : 'osim-requirement--unmet'"
+            >
+              <i
+                class="me-1"
+                :class="child.accepts
+                  ? 'bi bi-check-circle-fill text-success'
+                  : 'bi bi-x-circle-fill text-danger'"
+              />
+              {{ requirementLabel(child) }}
+            </li>
+          </ul>
+        </li>
+      </ul>
+
+      <ul v-if="satisfiedRequirements.length" class="osim-requirements-list mt-1">
+        <li
+          v-for="req in satisfiedRequirements"
+          :key="requirementLabel(req)"
+          class="osim-requirement osim-requirement--met"
+        >
+          <i class="bi bi-check-circle-fill me-1 text-success" />
+          <span>{{ requirementLabel(req) }}</span>
+        </li>
+      </ul>
+    </template>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.osim-next-state-panel {
+  font-size: 0.875rem;
+  padding: 0.5rem 0.75rem;
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 0 0.375rem 0.375rem 0;
+}
+
+.osim-next-state-header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  font-weight: 500;
+}
+
+.osim-next-state-label {
+  color: #6c757d;
+  font-weight: normal;
+}
+
+.osim-next-state-badge {
+  font-size: 0.8em;
+  background-color: #f1f3f5;
+  color: #212529;
+  border: 1px solid #212529;
+}
+
+.osim-next-state-ready {
+  font-size: 0.85em;
+  color: #198754;
+}
+
+.osim-next-state-loading,
+.osim-next-state-error,
+.osim-next-state-empty {
+  font-size: 0.875rem;
+}
+
+.osim-requirements-list {
+  list-style: none;
+  padding-left: 0.5rem;
+  margin-bottom: 0;
+
+  .osim-requirement {
+    padding: 0.1rem 0;
+  }
+
+  // nested list indent
+  .osim-requirements-list {
+    padding-left: 1.25rem;
+  }
+}
+</style>

--- a/src/components/FlawWorkflowState/FlawWorkflowState.vue
+++ b/src/components/FlawWorkflowState/FlawWorkflowState.vue
@@ -9,15 +9,15 @@ import type { ZodFlawClassification } from '@/types/zodShared';
 import { FlawClassificationStateEnum } from '@/generated-client';
 
 const props = defineProps<{
-  classification: z.infer<typeof ZodFlawClassification>;
+  classification?: null | z.infer<typeof ZodFlawClassification>;
   labels?: null | ZodFlawLabelType[];
   shouldCreateJiraTask: boolean;
 }>();
 
 const emit = defineEmits<{ 'create:jiraTask': [] }>();
 
-const workflowPrefix = computed(() => props.classification.workflow ?? null);
-const stateValue = computed(() => props.classification.state || null);
+const workflowPrefix = computed(() => props.classification?.workflow ?? null);
+const stateValue = computed(() => props.classification?.state || null);
 
 const workflowLabels = computed(() =>
   (props.labels ?? []).filter(
@@ -26,7 +26,7 @@ const workflowLabels = computed(() =>
 );
 
 const shouldShowCreateJiraTaskButton = computed(
-  () => props.classification.state === FlawClassificationStateEnum.Empty,
+  () => props.classification?.state === FlawClassificationStateEnum.Empty,
 );
 
 function toggleCreateJiraTask() {

--- a/src/components/FlawWorkflowState/FlawWorkflowState.vue
+++ b/src/components/FlawWorkflowState/FlawWorkflowState.vue
@@ -1,20 +1,25 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 
 import type { z } from 'zod';
 
-import LabelDiv from '@/widgets/LabelDiv/LabelDiv.vue';
+import { FlawClassificationStateEnum } from '@/generated-client';
 import { FlawLabelTypeEnum, type ZodFlawLabelType } from '@/types/zodFlaw';
 import type { ZodFlawClassification } from '@/types/zodShared';
-import { FlawClassificationStateEnum } from '@/generated-client';
+import LabelDiv from '@/widgets/LabelDiv/LabelDiv.vue';
+
+import FlawNextStatePanel from './FlawNextStatePanel.vue';
 
 const props = defineProps<{
   classification?: null | z.infer<typeof ZodFlawClassification>;
+  flawUuid: string;
   labels?: null | ZodFlawLabelType[];
   shouldCreateJiraTask: boolean;
 }>();
 
 const emit = defineEmits<{ 'create:jiraTask': [] }>();
+
+const isNextStateOpen = ref(false);
 
 const workflowPrefix = computed(() => props.classification?.workflow ?? null);
 const stateValue = computed(() => props.classification?.state || null);
@@ -28,10 +33,6 @@ const workflowLabels = computed(() =>
 const shouldShowCreateJiraTaskButton = computed(
   () => props.classification?.state === FlawClassificationStateEnum.Empty,
 );
-
-function toggleCreateJiraTask() {
-  emit('create:jiraTask');
-}
 </script>
 
 <template>
@@ -57,18 +58,29 @@ function toggleCreateJiraTask() {
           </template>
           <template v-else>Legacy Flaw without Jira task</template>
         </span>
+        <button
+          type="button"
+          class="btn btn-sm osim-next-state-btn"
+          :class="{ active: isNextStateOpen }"
+          title="Next state requirements"
+          @click="isNextStateOpen = !isNextStateOpen"
+        >
+          <i class="bi bi-info-circle" />
+        </button>
         <div v-if="shouldShowCreateJiraTaskButton" class="flex-shrink-0">
           <button
             type="button"
             class="btn btn-warning osim-last-field-button"
             title="Creates Jira task when flaw is saved"
-            @click="toggleCreateJiraTask"
+            @click="emit('create:jiraTask')"
           >
             <i :class="{ 'bi-square': !shouldCreateJiraTask, 'bi-check-square': shouldCreateJiraTask }" />
             Create Jira task
           </button>
         </div>
       </div>
+
+      <FlawNextStatePanel v-if="isNextStateOpen" :flawUuid />
     </LabelDiv>
   </div>
 </template>
@@ -120,6 +132,22 @@ function toggleCreateJiraTask() {
     background-color: #6c757d;
     color: #fff;
     border-radius: 0.25rem !important;
+  }
+
+  .osim-next-state-btn {
+    flex-shrink: 0;
+    color: #6c757d;
+    font-size: 1rem;
+    padding: 0.25rem 0.55rem;
+    border: 1px solid #ced4da;
+    border-radius: 0.25rem;
+
+    &:hover,
+    &.active {
+      color: #0d6efd;
+      background-color: #e7f1ff;
+      border-color: #b6d4fe;
+    }
   }
 }
 </style>

--- a/src/components/FlawWorkflowState/FlawWorkflowState.vue
+++ b/src/components/FlawWorkflowState/FlawWorkflowState.vue
@@ -16,11 +16,8 @@ const props = defineProps<{
 
 const emit = defineEmits<{ 'create:jiraTask': [] }>();
 
-const workflowStateLabel = computed(() => {
-  const { state, workflow } = props.classification;
-  if (!state) return 'Legacy Flaw without Jira task';
-  return workflow ? `${workflow} / ${state}` : state;
-});
+const workflowPrefix = computed(() => props.classification.workflow ?? null);
+const stateValue = computed(() => props.classification.state || null);
 
 const workflowLabels = computed(() =>
   (props.labels ?? []).filter(
@@ -42,13 +39,23 @@ function toggleCreateJiraTask() {
     <LabelDiv label="State" class="osim-workflow-state-display mb-2">
       <div class="d-flex align-items-center gap-2">
         <span class="form-control osim-state-field">
-          {{ workflowStateLabel }}
-          <span
-            v-for="wfLabel in workflowLabels"
-            :key="wfLabel.label"
-            class="badge osim-workflow-label-badge ms-1"
-            title="workflow label"
-          >{{ wfLabel.label }}</span>
+          <template v-if="stateValue">
+            <span class="osim-state-line">
+              <span class="osim-workflow-prefix">State: <span class="osim-state-value">{{ stateValue }}</span></span>
+              <span v-if="workflowPrefix" class="osim-workflow-prefix">
+                / Workflow: <span class="osim-workflow-value">{{ workflowPrefix }}</span>
+              </span>
+            </span>
+            <span v-if="workflowLabels.length" class="osim-badges-line">
+              <span
+                v-for="wfLabel in workflowLabels"
+                :key="wfLabel.label"
+                class="badge osim-workflow-label-badge me-1"
+                title="workflow label"
+              >{{ wfLabel.label }}</span>
+            </span>
+          </template>
+          <template v-else>Legacy Flaw without Jira task</template>
         </span>
         <div v-if="shouldShowCreateJiraTaskButton" class="flex-shrink-0">
           <button
@@ -76,7 +83,33 @@ function toggleCreateJiraTask() {
     flex: 1 1 auto;
     width: auto;
     display: flex;
-    align-items: center;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .osim-state-line {
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+  }
+
+  .osim-state-value {
+    font-weight: 600;
+  }
+
+  .osim-workflow-prefix {
+    color: #000;
+    font-size: 0.85em;
+
+    .osim-state-value,
+    .osim-workflow-value {
+      font-weight: 600;
+      color: #000;
+    }
+  }
+
+  .osim-badges-line {
+    display: flex;
     flex-wrap: wrap;
     gap: 0.25rem;
   }
@@ -86,6 +119,7 @@ function toggleCreateJiraTask() {
     font-weight: 500;
     background-color: #6c757d;
     color: #fff;
+    border-radius: 0.25rem !important;
   }
 }
 </style>

--- a/src/components/FlawWorkflowState/FlawWorkflowState.vue
+++ b/src/components/FlawWorkflowState/FlawWorkflowState.vue
@@ -1,16 +1,24 @@
 <script setup lang="ts">
 import { computed } from 'vue';
+import type { z } from 'zod';
 
 import LabelDiv from '@/widgets/LabelDiv/LabelDiv.vue';
+import type { ZodFlawClassification } from '@/types/zodShared';
 
 const props = defineProps<{
-  classification: any;
+  classification: z.infer<typeof ZodFlawClassification>;
   shouldCreateJiraTask: boolean;
 }>();
 
 const emit = defineEmits<{ 'create:jiraTask': [] }>();
 
 const EMPTY_STATE = 'EMPTY';
+
+const workflowStateLabel = computed(() => {
+  const { workflow, state } = props.classification;
+  if (!state) return 'Legacy Flaw without Jira task';
+  return workflow ? `${workflow} / ${state}` : state;
+});
 
 const shouldShowCreateJiraTaskButton = computed(
   () => props.classification.state === EMPTY_STATE,
@@ -25,7 +33,7 @@ function toggleCreateJiraTask() {
   <div class="osim-workflow-state-container mb-2">
     <LabelDiv label="State" class="osim-workflow-state-display mb-2">
       <div class="d-flex align-items-center gap-2">
-        <span class="form-control osim-state-field">{{ classification.state || 'Legacy Flaw without Jira task' }}</span>
+        <span class="form-control osim-state-field">{{ workflowStateLabel }}</span>
         <div v-if="shouldShowCreateJiraTaskButton" class="flex-shrink-0">
           <button
             type="button"

--- a/src/components/FlawWorkflowState/FlawWorkflowState.vue
+++ b/src/components/FlawWorkflowState/FlawWorkflowState.vue
@@ -1,27 +1,35 @@
 <script setup lang="ts">
 import { computed } from 'vue';
+
 import type { z } from 'zod';
 
 import LabelDiv from '@/widgets/LabelDiv/LabelDiv.vue';
+import { FlawLabelTypeEnum, type ZodFlawLabelType } from '@/types/zodFlaw';
 import type { ZodFlawClassification } from '@/types/zodShared';
+import { FlawClassificationStateEnum } from '@/generated-client';
 
 const props = defineProps<{
   classification: z.infer<typeof ZodFlawClassification>;
+  labels?: null | ZodFlawLabelType[];
   shouldCreateJiraTask: boolean;
 }>();
 
 const emit = defineEmits<{ 'create:jiraTask': [] }>();
 
-const EMPTY_STATE = 'EMPTY';
-
 const workflowStateLabel = computed(() => {
-  const { workflow, state } = props.classification;
+  const { state, workflow } = props.classification;
   if (!state) return 'Legacy Flaw without Jira task';
   return workflow ? `${workflow} / ${state}` : state;
 });
 
+const workflowLabels = computed(() =>
+  (props.labels ?? []).filter(
+    l => l.type === FlawLabelTypeEnum.WORKFLOW && l.relevant,
+  ),
+);
+
 const shouldShowCreateJiraTaskButton = computed(
-  () => props.classification.state === EMPTY_STATE,
+  () => props.classification.state === FlawClassificationStateEnum.Empty,
 );
 
 function toggleCreateJiraTask() {
@@ -33,7 +41,15 @@ function toggleCreateJiraTask() {
   <div class="osim-workflow-state-container mb-2">
     <LabelDiv label="State" class="osim-workflow-state-display mb-2">
       <div class="d-flex align-items-center gap-2">
-        <span class="form-control osim-state-field">{{ workflowStateLabel }}</span>
+        <span class="form-control osim-state-field">
+          {{ workflowStateLabel }}
+          <span
+            v-for="wfLabel in workflowLabels"
+            :key="wfLabel.label"
+            class="badge osim-workflow-label-badge ms-1"
+            title="workflow label"
+          >{{ wfLabel.label }}</span>
+        </span>
         <div v-if="shouldShowCreateJiraTaskButton" class="flex-shrink-0">
           <button
             type="button"
@@ -59,6 +75,17 @@ function toggleCreateJiraTask() {
   .osim-state-field {
     flex: 1 1 auto;
     width: auto;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+
+  .osim-workflow-label-badge {
+    font-size: 0.75em;
+    font-weight: 500;
+    background-color: #6c757d;
+    color: #fff;
   }
 }
 </style>

--- a/src/components/FlawWorkflowState/FlawWorkflowState.vue
+++ b/src/components/FlawWorkflowState/FlawWorkflowState.vue
@@ -59,6 +59,7 @@ const shouldShowCreateJiraTaskButton = computed(
           <template v-else>Legacy Flaw without Jira task</template>
         </span>
         <button
+          v-if="stateValue"
           type="button"
           class="btn btn-sm osim-next-state-btn"
           :class="{ active: isNextStateOpen }"
@@ -80,7 +81,7 @@ const shouldShowCreateJiraTaskButton = computed(
         </div>
       </div>
 
-      <FlawNextStatePanel v-if="isNextStateOpen" :flawUuid />
+      <FlawNextStatePanel v-if="isNextStateOpen" :key="stateValue ?? ''" :flawUuid />
     </LabelDiv>
   </div>
 </template>

--- a/src/components/FlawWorkflowState/FlawWorkflowState.vue
+++ b/src/components/FlawWorkflowState/FlawWorkflowState.vue
@@ -1,219 +1,56 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { computed } from 'vue';
 
 import LabelDiv from '@/widgets/LabelDiv/LabelDiv.vue';
-import Modal from '@/widgets/Modal/Modal.vue';
-import { promoteFlawWorkflow, rejectFlawWorkflow, resetFlawWorkflow, revertFlawWorkflow } from '@/services/FlawService';
-import { ZodFlawClassification } from '@/types/zodShared';
-import DropDownMenu from '@/widgets/DropDownMenu/DropDownMenu.vue';
-import LoadingSpinner from '@/widgets/LoadingSpinner/LoadingSpinner.vue';
 
 const props = defineProps<{
   classification: any;
-  flawId: string;
   shouldCreateJiraTask: boolean;
 }>();
 
-const emit = defineEmits<{ 'create:jiraTask': []; 'refresh:flaw': [] }>();
+const emit = defineEmits<{ 'create:jiraTask': [] }>();
 
-const shouldShowRejectionModal = ref(false);
-const rejectionReason = ref('');
-const isRequesting = ref(false);
-const dropdownMenuRef = ref<InstanceType<typeof DropDownMenu>>();
-
-const workflowStates = ZodFlawClassification.shape.state.enum;
-
-type WorkflowPhases = (typeof workflowStates)[keyof typeof workflowStates];
-
-const DONE_STATE = workflowStates.Done as string;
-const REJECTED_STATE = workflowStates.Rejected as string;
-const EMPTY_STATE = workflowStates.Empty as string;
-
-const shouldShowWorkflowButtons = computed(
-  () => ![EMPTY_STATE].includes(props.classification.state),
-);
+const EMPTY_STATE = 'EMPTY';
 
 const shouldShowCreateJiraTaskButton = computed(
   () => props.classification.state === EMPTY_STATE,
 );
 
-const canPromote = computed(() => {
-  return ![DONE_STATE, REJECTED_STATE].includes(props.classification.state);
-});
-
-const canRevert = computed(() => {
-  return props.classification.state !== REJECTED_STATE;
-});
-
 function toggleCreateJiraTask() {
   emit('create:jiraTask');
-}
-
-function openRejectionModal() {
-  shouldShowRejectionModal.value = true;
-  dropdownMenuRef.value?.close();
-}
-
-function closeRejectionModal() {
-  shouldShowRejectionModal.value = false;
-}
-
-function onReject(flawId: string) {
-  isRequesting.value = true;
-  closeRejectionModal();
-  rejectFlawWorkflow(flawId, { reason: rejectionReason.value }).then(() => {
-    emit('refresh:flaw');
-  }).finally(() => {
-    isRequesting.value = false;
-  });
-}
-
-function onPromote(flawId: string) {
-  dropdownMenuRef.value?.close();
-  isRequesting.value = true;
-  promoteFlawWorkflow(flawId).then(() => {
-    emit('refresh:flaw');
-  }).finally(() => {
-    isRequesting.value = false;
-  });
-}
-
-function nextPhase(workflowState: WorkflowPhases) {
-  const [labels, phases] = [Object.keys(workflowStates), Object.values(workflowStates)];
-  const index = phases.indexOf(workflowState);
-  return labels[index + 1] || labels.slice(-1)[0];
-}
-
-function previousPhase(workflowState: WorkflowPhases) {
-  const [labels, phases] = [Object.keys(workflowStates), Object.values(workflowStates)];
-  const index = phases.indexOf(workflowState);
-  return labels[index - 1] || labels[0];
-}
-
-async function onRevert(flawId: string) {
-  dropdownMenuRef.value?.close();
-  isRequesting.value = true;
-  revertFlawWorkflow(flawId).then(() => {
-    emit('refresh:flaw');
-  }).finally(() => {
-    isRequesting.value = false;
-  });
-}
-
-async function onReset(flawId: string) {
-  dropdownMenuRef.value?.close();
-  isRequesting.value = true;
-  resetFlawWorkflow(flawId).then(() => {
-    emit('refresh:flaw');
-  }).finally(() => {
-    isRequesting.value = false;
-  });
 }
 </script>
 
 <template>
   <div class="osim-workflow-state-container mb-2">
     <LabelDiv label="State" class="osim-workflow-state-display mb-2">
-      <div class="d-flex">
-        <span class="form-control rounded-0">{{ classification.state || 'Legacy Flaw without Jira task' }}</span>
-        <div class="col-auto">
-          <div v-if="shouldShowWorkflowButtons" class="osim-workflow-state-buttons">
-            <DropDownMenu ref="dropdownMenuRef">
-              <template #trigger>
-                <button type="button" class="btn btn-secondary dropdown-toggle" :disabled="isRequesting">
-                  Change State
-                  <LoadingSpinner v-if="isRequesting" type="grow" />
-                </button>
-              </template>
-              <template #content>
-                <div v-if="!isRequesting" class="workflow-dropdown-menu">
-                  <li v-if="canPromote" class="dropdown-item">
-                    <button
-                      type="button"
-                      class="btn"
-                      :title="`Promote to ${nextPhase(classification.state as WorkflowPhases)}`"
-                      @click="onPromote(flawId)"
-                    >
-                      <i class="bi bi-chevron-double-right" />
-                      Promote to {{ nextPhase(classification.state as WorkflowPhases) }}
-                    </button>
-                  </li>
-                  <li v-if="canRevert" class="dropdown-item">
-                    <button
-                      type="button"
-                      class="btn"
-                      @click="onRevert(flawId)"
-                    >
-                      <i class="bi bi-chevron-double-left" />
-                      Revert to {{ previousPhase(classification.state as WorkflowPhases) }}
-                    </button>
-                  </li>
-                  <li v-if="classification.state !== REJECTED_STATE" class="dropdown-item">
-                    <button
-                      type="button"
-                      class="btn"
-                      @click="openRejectionModal"
-                    >
-                      <i class="bi bi-chevron-bar-down"></i>
-                      Reject
-                    </button>
-                  </li>
-                  <li class="dropdown-item">
-                    <button
-                      type="button"
-                      class="btn"
-                      @click="onReset(flawId)"
-                    >
-                      <i class="bi bi-arrow-counterclockwise"></i>
-                      Reset
-                    </button>
-                  </li>
-                </div>
-              </template>
-            </DropDownMenu>
-          </div>
-          <div v-else-if="shouldShowCreateJiraTaskButton" class="osim-workflow-state-buttons">
-            <button
-              type="button"
-              class="btn btn-warning osim-last-field-button"
-              title="Creates Jira task when flaw is saved"
-              @click="toggleCreateJiraTask"
-            >
-              <i
-                :class="{ 'bi-square': !shouldCreateJiraTask, 'bi-check-square': shouldCreateJiraTask }"
-              />
-              Create Jira task
-            </button>
-          </div>
+      <div class="d-flex align-items-center gap-2">
+        <span class="form-control osim-state-field">{{ classification.state || 'Legacy Flaw without Jira task' }}</span>
+        <div v-if="shouldShowCreateJiraTaskButton" class="flex-shrink-0">
+          <button
+            type="button"
+            class="btn btn-warning osim-last-field-button"
+            title="Creates Jira task when flaw is saved"
+            @click="toggleCreateJiraTask"
+          >
+            <i :class="{ 'bi-square': !shouldCreateJiraTask, 'bi-check-square': shouldCreateJiraTask }" />
+            Create Jira task
+          </button>
         </div>
       </div>
-      <Modal :show="shouldShowRejectionModal" @close="closeRejectionModal">
-        <template #title> Reject Flaw </template>
-        <template #body>
-          <label class="osim-modal-label mb-3">
-            <span>Please provide a reason for rejecting the flaw</span>
-            <textarea v-model="rejectionReason" class="form-control"></textarea>
-          </label>
-        </template>
-        <template #footer>
-          <button type="button" class="btn btn-primary" @click="onReject(flawId)">
-            Reject Flaw
-          </button>
-          <button type="button" class="btn btn-secondary" @click="closeRejectionModal">Cancel</button>
-        </template>
-      </Modal>
     </LabelDiv>
   </div>
 </template>
 
 <style lang="scss" scoped>
 .osim-workflow-state-container {
-  label.osim-modal-label {
-    display: block;
-  }
-
   .osim-workflow-state-display {
     margin-bottom: 0 !important;
+  }
+
+  .osim-state-field {
+    flex: 1 1 auto;
+    width: auto;
   }
 }
 </style>

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -322,14 +322,14 @@ describe('flawForm', () => {
     const subject = mountWithProps(flaw, { mode: 'edit' });
     const workflowStateField = subject.findComponent(FlawWorkflowState);
     expect(workflowStateField?.findComponent(LabelDiv).props().label).toBe('State');
-    expect(workflowStateField?.props().classification.state).toBe('NEW');
+    expect(workflowStateField?.props().classification?.state).toBe('NEW');
   });
 
   osimFullFlawTest('displays with impact nudge when workflow state is after triage', async ({ flaw }) => {
     flaw.classification!.state = FlawClassificationStateEnum.PreSecondaryAssessment;
     const subject = mountWithProps(flaw, { mode: 'edit' });
     const workflowStateField = subject.findComponent(FlawWorkflowState);
-    expect(workflowStateField?.props().classification.state).toBe('PRE_SECONDARY_ASSESSMENT');
+    expect(workflowStateField?.props().classification?.state).toBe('PRE_SECONDARY_ASSESSMENT');
     (subject.vm as any).flaw.impact = 'CRITICAL';
     await flushPromises();
     expect(subject.findComponent(Nudge)).toBeTruthy();

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -339,7 +339,9 @@ describe('flawForm', () => {
     const subject = mountWithProps(flaw, { mode: 'edit' });
     const workflowState = subject.findComponent(FlawWorkflowState);
     expect(workflowState.findComponent(DropDownMenu).exists()).toBe(false);
-    expect(workflowState.find('span.form-control').text()).toBe(flaw.classification?.state);
+    const { workflow, state } = flaw.classification!;
+    const expectedLabel = workflow ? `${workflow} / ${state}` : state;
+    expect(workflowState.find('span.form-control').text()).toBe(expectedLabel);
   });
 
   osimFullFlawTest('shows an explanation message when nvd score and Rh score mismatch', async ({ flaw }) => {

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -340,8 +340,9 @@ describe('flawForm', () => {
     const workflowState = subject.findComponent(FlawWorkflowState);
     expect(workflowState.findComponent(DropDownMenu).exists()).toBe(false);
     const { state, workflow } = flaw.classification!;
-    const expectedLabel = workflow ? `${workflow} / ${state}` : state;
-    expect(workflowState.find('span.form-control').text()).toBe(expectedLabel);
+    const stateField = workflowState.find('span.form-control');
+    expect(stateField.text()).toContain(state ?? '');
+    if (workflow) expect(stateField.text()).toContain(workflow);
   });
 
   osimFullFlawTest('shows an explanation message when nvd score and Rh score mismatch', async ({ flaw }) => {

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -1,5 +1,3 @@
-import { nextTick } from 'vue';
-
 import { describe, it, expect, vi } from 'vitest';
 import { DateTime } from 'luxon';
 import { flushPromises } from '@vue/test-utils';
@@ -337,41 +335,11 @@ describe('flawForm', () => {
     expect(subject.findComponent(Nudge)).toBeTruthy();
   });
 
-  osimFullFlawTest('displays promote and reject buttons for state', async ({ flaw }) => {
+  osimFullFlawTest('displays state as read-only with no change-state buttons', async ({ flaw }) => {
     const subject = mountWithProps(flaw, { mode: 'edit' });
-    const menu = subject
-      .findComponent(FlawWorkflowState)
-      .findComponent(DropDownMenu);
-
-    const menuButton = menu.find('button[type="button"]');
-    await menuButton.trigger('click');
-    await nextTick();
-
-    for (const button of menu.findAll('button')) {
-      expect(([
-        'Change State',
-        'Promote to Triage',
-        'Reject',
-        'Reset',
-        'Revert to Empty',
-      ]).includes(button.text().trim())).toBe(true);
-    }
-  });
-
-  osimFullFlawTest('shows a modal for reject button clicks', async ({ flaw }) => {
-    const subject = mountWithProps(flaw, { mode: 'edit' });
-    const menu = subject
-      .findComponent(FlawWorkflowState)
-      .findComponent(DropDownMenu);
-
-    const menuButton = menu.find('button[type="button"]');
-    await menuButton.trigger('click');
-    await nextTick();
-
-    const rejectButton = menu?.findAll('button')?.find(el => el.text() === 'Reject');
-    await rejectButton?.trigger('click');
-    await flushPromises();
-    expect(subject.find('.modal-dialog').exists()).toBe(true);
+    const workflowState = subject.findComponent(FlawWorkflowState);
+    expect(workflowState.findComponent(DropDownMenu).exists()).toBe(false);
+    expect(workflowState.find('span.form-control').text()).toBe(flaw.classification?.state);
   });
 
   osimFullFlawTest('shows an explanation message when nvd score and Rh score mismatch', async ({ flaw }) => {

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -339,7 +339,7 @@ describe('flawForm', () => {
     const subject = mountWithProps(flaw, { mode: 'edit' });
     const workflowState = subject.findComponent(FlawWorkflowState);
     expect(workflowState.findComponent(DropDownMenu).exists()).toBe(false);
-    const { workflow, state } = flaw.classification!;
+    const { state, workflow } = flaw.classification!;
     const expectedLabel = workflow ? `${workflow} / ${state}` : state;
     expect(workflowState.find('span.form-control').text()).toBe(expectedLabel);
   });

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -43,6 +43,15 @@ vi.mock('@/composables/useTrackers', () => {
 
 vi.mock('@/services/LabelsService');
 
+vi.mock('@/services/WorkflowService', () => ({
+  getFlawWorkflowClassification: vi.fn(() => Promise.resolve({
+    flaw: 'test-uuid',
+    classification: { workflow: 'DEFAULT', state: 'NEW' },
+    workflows: [],
+  })),
+  isWorkflowCondition: vi.fn((req: any) => 'condition' in req),
+}));
+
 vi.mock('@/composables/useJiraContributors', () => {
   return {
     default: vi.fn(() => ({

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -329,7 +329,7 @@ exports[`flawForm > mounts and renders 1`] = `
         <div data-v-0e2ae48e="" data-v-79158bda="" class="osim-input ps-3 osim-workflow-state-display mb-2">
           <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--> State <!--attrs: {{ $attrs }}--></span>
             <div data-v-0e2ae48e="" class="col-9">
-              <div data-v-79158bda="" class="d-flex align-items-center gap-2"><span data-v-79158bda="" class="form-control osim-state-field">NEW</span>
+              <div data-v-79158bda="" class="d-flex align-items-center gap-2"><span data-v-79158bda="" class="form-control osim-state-field">DEFAULT / NEW </span>
                 <!--v-if-->
               </div>
             </div>

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -329,7 +329,8 @@ exports[`flawForm > mounts and renders 1`] = `
         <div data-v-0e2ae48e="" data-v-79158bda="" class="osim-input ps-3 osim-workflow-state-display mb-2">
           <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--> State <!--attrs: {{ $attrs }}--></span>
             <div data-v-0e2ae48e="" class="col-9">
-              <div data-v-79158bda="" class="d-flex align-items-center gap-2"><span data-v-79158bda="" class="form-control osim-state-field">DEFAULT / NEW </span>
+              <div data-v-79158bda="" class="d-flex align-items-center gap-2"><span data-v-79158bda="" class="form-control osim-state-field"><span data-v-79158bda="" class="osim-state-line"><span data-v-79158bda="" class="osim-workflow-prefix">State: <span data-v-79158bda="" class="osim-state-value">NEW</span></span><span data-v-79158bda="" class="osim-workflow-prefix"> / Workflow: <span data-v-79158bda="" class="osim-workflow-value">DEFAULT</span></span></span>
+                <!--v-if--></span>
                 <!--v-if-->
               </div>
             </div>

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -330,9 +330,10 @@ exports[`flawForm > mounts and renders 1`] = `
           <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--> State <!--attrs: {{ $attrs }}--></span>
             <div data-v-0e2ae48e="" class="col-9">
               <div data-v-79158bda="" class="d-flex align-items-center gap-2"><span data-v-79158bda="" class="form-control osim-state-field"><span data-v-79158bda="" class="osim-state-line"><span data-v-79158bda="" class="osim-workflow-prefix">State: <span data-v-79158bda="" class="osim-state-value">NEW</span></span><span data-v-79158bda="" class="osim-workflow-prefix"> / Workflow: <span data-v-79158bda="" class="osim-workflow-value">DEFAULT</span></span></span>
-                <!--v-if--></span>
+                <!--v-if--></span><button data-v-79158bda="" type="button" class="btn btn-sm osim-next-state-btn" title="Next state requirements"><i data-v-79158bda="" class="bi bi-info-circle"></i></button>
                 <!--v-if-->
               </div>
+              <!--v-if-->
             </div>
           </div>
         </div>

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -329,27 +329,9 @@ exports[`flawForm > mounts and renders 1`] = `
         <div data-v-0e2ae48e="" data-v-79158bda="" class="osim-input ps-3 osim-workflow-state-display mb-2">
           <div data-v-0e2ae48e="" class="row"><span data-v-0e2ae48e="" class="form-label col-3 position-relative"><!--v-if--> State <!--attrs: {{ $attrs }}--></span>
             <div data-v-0e2ae48e="" class="col-9">
-              <div data-v-79158bda="" class="d-flex"><span data-v-79158bda="" class="form-control rounded-0">NEW</span>
-                <div data-v-79158bda="" class="col-auto">
-                  <div data-v-79158bda="" class="osim-workflow-state-buttons">
-                    <div data-v-846ac2ce="" data-v-79158bda="" class="dropdown-container">
-                      <div data-v-846ac2ce="" class="dropdown-trigger px-1"><button data-v-79158bda="" type="button" class="btn btn-secondary dropdown-toggle"> Change State
-                          <!--v-if-->
-                        </button></div>
-                      <teleport-stub data-v-846ac2ce="" to="#app">
-                        <!--v-if-->
-                      </teleport-stub>
-                      <!--v-if-->
-                    </div>
-                  </div>
-                </div>
+              <div data-v-79158bda="" class="d-flex align-items-center gap-2"><span data-v-79158bda="" class="form-control osim-state-field">NEW</span>
+                <!--v-if-->
               </div>
-              <transition-stub data-v-296c460d="" name="modal" appear="false" persisted="false" css="true">
-                <!--v-if-->
-              </transition-stub>
-              <transition-stub data-v-296c460d="" name="modal-bg" appear="false" persisted="false" css="true">
-                <!--v-if-->
-              </transition-stub>
             </div>
           </div>
         </div>
@@ -590,7 +572,7 @@ exports[`flawForm > mounts and renders 1`] = `
     </div>
   </div>
   <div data-v-76e7a15d="" class="row osim-flaw-form-section">
-    <div data-v-4715e8e2="" data-v-5d530569="" data-v-76e7a15d="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-plus-square-dotted"></i><span data-v-5d530569="" class="section-label">Contributors</span></button>
+    <div data-v-4715e8e2="" data-v-5d530569="" data-v-76e7a15d="" class="osim-collapsible-label"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-plus-square-dotted"></i><span data-v-5d530569="" class="section-label">Labels</span></button>
       <div data-v-4715e8e2="" class="ps-3 border-start">
         <div data-v-4715e8e2="" class="visually-hidden">
           <table data-v-5d530569="" class="table table-striped table-hover">

--- a/src/composables/__tests__/useWorkflowNextState.spec.ts
+++ b/src/composables/__tests__/useWorkflowNextState.spec.ts
@@ -1,0 +1,71 @@
+import { useWorkflowNextState } from '@/composables/useWorkflowNextState';
+
+import { getFlawWorkflowClassification } from '@/services/WorkflowService';
+
+vi.mock('@/services/WorkflowService');
+
+const baseWorkflow = {
+  accepts: true,
+  conditions: [],
+  description: '',
+  name: 'Default',
+  priority: 1,
+  states: [
+    { accepts: true, name: 'NEW', requirements: [] },
+    { accepts: false, name: 'DONE', requirements: [] },
+  ],
+};
+
+const mockData = (state: string, workflow = 'Default') => ({
+  classification: { state, workflow },
+  flaw: 'uuid',
+  workflows: [baseWorkflow],
+});
+
+describe('useWorkflowNextState', () => {
+  it('resolves next state', async () => {
+    vi.mocked(getFlawWorkflowClassification).mockResolvedValue(mockData('NEW'));
+    const { error, fetchNextState, nextState } = useWorkflowNextState('uuid');
+
+    await fetchNextState();
+
+    expect(error.value).toBeNull();
+    expect(nextState.value?.name).toBe('DONE');
+  });
+
+  it('returns null for terminal state', async () => {
+    vi.mocked(getFlawWorkflowClassification).mockResolvedValue(mockData('DONE'));
+    const { fetchNextState, nextState } = useWorkflowNextState('uuid');
+
+    await fetchNextState();
+
+    expect(nextState.value).toBeNull();
+  });
+
+  it('sets error when workflow not found', async () => {
+    vi.mocked(getFlawWorkflowClassification).mockResolvedValue(mockData('NEW', 'Unknown'));
+    const { error, fetchNextState } = useWorkflowNextState('uuid');
+
+    await fetchNextState();
+
+    expect(error.value).toBe('Current workflow not found');
+  });
+
+  it('sets error when state not found in workflow', async () => {
+    vi.mocked(getFlawWorkflowClassification).mockResolvedValue(mockData('INVALID'));
+    const { error, fetchNextState } = useWorkflowNextState('uuid');
+
+    await fetchNextState();
+
+    expect(error.value).toContain('Unknown state "INVALID"');
+  });
+
+  it('sets error on fetch failure', async () => {
+    vi.mocked(getFlawWorkflowClassification).mockRejectedValue(new Error('Network error'));
+    const { error, fetchNextState } = useWorkflowNextState('uuid');
+
+    await fetchNextState();
+
+    expect(error.value).toBe('Failed to load next state requirements');
+  });
+});

--- a/src/composables/useWorkflowNextState.ts
+++ b/src/composables/useWorkflowNextState.ts
@@ -29,13 +29,17 @@ export function useWorkflowNextState(flawUuid: string) {
     try {
       const data = await getFlawWorkflowClassification(flawUuid);
       const { state, workflow } = data.classification;
-      const currentWorkflow = data.workflows.find(w => w.name === workflow);
+      const currentWorkflow = data.workflows.find(({ name }) => name === workflow);
       if (!currentWorkflow) {
         error.value = 'Current workflow not found';
         return;
       }
-      const currentIndex = currentWorkflow.states.findIndex(s => s.name === state);
-      nextState.value = currentIndex >= 0 && currentIndex < currentWorkflow.states.length - 1
+      const currentIndex = currentWorkflow.states.findIndex(({ name }) => name === state);
+      if (currentIndex === -1) {
+        error.value = `Unknown state "${state}" in workflow "${workflow}"`;
+        return;
+      }
+      nextState.value = currentIndex < currentWorkflow.states.length - 1
         ? currentWorkflow.states[currentIndex + 1]
         : null;
       isFetched.value = true;

--- a/src/composables/useWorkflowNextState.ts
+++ b/src/composables/useWorkflowNextState.ts
@@ -1,0 +1,60 @@
+import { computed, ref } from 'vue';
+
+import {
+  getFlawWorkflowClassification,
+  type WorkflowRequirement,
+  type WorkflowStateDetail,
+} from '@/services/WorkflowService';
+
+export function useWorkflowNextState(flawUuid: string) {
+  const isLoading = ref(false);
+  const error = ref<null | string>(null);
+  const nextState = ref<null | WorkflowStateDetail>(null);
+  const isFetched = ref(false);
+
+  const unsatisfiedRequirements = computed(() =>
+    (nextState.value?.requirements ?? []).filter(req => !req.accepts),
+  );
+
+  const satisfiedRequirements = computed(() =>
+    (nextState.value?.requirements ?? []).filter(req => req.accepts),
+  );
+
+  const allRequirementsMet = computed(() => nextState.value?.accepts ?? false);
+
+  async function fetchNextState() {
+    if (isFetched.value) return;
+    isLoading.value = true;
+    error.value = null;
+    try {
+      const data = await getFlawWorkflowClassification(flawUuid);
+      const { state, workflow } = data.classification;
+      const currentWorkflow = data.workflows.find(w => w.name === workflow);
+      if (!currentWorkflow) {
+        error.value = 'Current workflow not found';
+        return;
+      }
+      const currentIndex = currentWorkflow.states.findIndex(s => s.name === state);
+      nextState.value = currentIndex >= 0 && currentIndex < currentWorkflow.states.length - 1
+        ? currentWorkflow.states[currentIndex + 1]
+        : null;
+      isFetched.value = true;
+    } catch {
+      error.value = 'Failed to load next state requirements';
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  return {
+    allRequirementsMet,
+    error,
+    fetchNextState,
+    isLoading,
+    nextState,
+    satisfiedRequirements,
+    unsatisfiedRequirements,
+  };
+}
+
+export type { WorkflowRequirement };

--- a/src/generated-client/osidb/models/index.ts
+++ b/src/generated-client/osidb/models/index.ts
@@ -2953,7 +2953,8 @@ export interface FlawCollaboratorPostRequest {
  */
 export const FlawCollaboratorPostTypeEnum = {
     Alias: 'alias',
-    ContextBased: 'context_based'
+    ContextBased: 'context_based',
+    Workflow: 'workflow'
 } as const;
 export type FlawCollaboratorPostTypeEnum = typeof FlawCollaboratorPostTypeEnum[keyof typeof FlawCollaboratorPostTypeEnum];
 
@@ -3124,9 +3125,10 @@ export interface FlawLabel {
  */
 export const FlawLabelType = {
     Alias: 'alias',
+    Bu: 'bu',
     ContextBased: 'context_based',
     ProductFamily: 'product_family',
-    Bu: 'bu'
+    Workflow: 'workflow'
 } as const;
 export type FlawLabelType = typeof FlawLabelType[keyof typeof FlawLabelType];
 

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -2,11 +2,9 @@ import { createCatchHandler, createSuccessHandler } from '@/composables/service-
 
 import type { ZodFlawCVSSType, ZodFlawType } from '@/types';
 import { osidbFetch } from '@/services/OsidbAuthService';
-import { useToastStore } from '@/stores/ToastStore';
 import router from '@/router';
 import { osimRuntime } from '@/stores/osimRuntime';
 import type { OsidbFetchOptions } from '@/services/OsidbAuthService';
-import { getDisplayedOsidbError } from '@/services/osidb-errors-helpers';
 
 export async function beforeFetch(options: OsidbFetchOptions) {
   if (options.data && ['PUT'].includes(options.method.toUpperCase())) {
@@ -157,107 +155,6 @@ export async function postFlawComment(
   }).then(createSuccessHandler({ title: 'Success!', body: `${type} comment saved.` }))
     .then(response => response.data)
     .catch(createCatchHandler(`Error saving ${type} comment`));
-}
-
-// Source openapi.yaml schema definition for `/osidb/api/v1/flaws/{flaw_id}/promote`
-export async function promoteFlawWorkflow(uuid: string) {
-  const { addToast } = useToastStore();
-  return osidbFetch({
-    method: 'post',
-    url: `/osidb/api/v1/flaws/${uuid}/promote`,
-  })
-    .then((response) => {
-      addToast({
-        title: 'Flaw Promoted',
-        body: `Flaw promoted to ${response.data.classification.state}`,
-        css: 'success',
-      });
-      return response.data;
-    })
-    .catch((error) => {
-      const displayedError = getDisplayedOsidbError(error);
-      addToast({
-        title: 'Error Promoting Flaw',
-        body: displayedError,
-        css: 'warning',
-      });
-      console.error('FlawService::promoteFlawWorkflow() Problem promoting flaw:', error);
-      throw error;
-    });
-}
-// Source openapi.yaml schema definition for `/osidb/api/v1/flaws/{flaw_id}/reject`
-export async function rejectFlawWorkflow(uuid: string, data: Record<'reason', string>) {
-  const { addToast } = useToastStore();
-  return osidbFetch({
-    method: 'post',
-    url: `/osidb/api/v1/flaws/${uuid}/reject`,
-    data,
-  })
-    .then((response) => {
-      addToast({
-        title: 'Flaw Rejected',
-        body: response.data.classification.state,
-        css: 'success',
-      });
-      return response.data;
-    })
-    .catch((error) => {
-      const { addToast } = useToastStore();
-      const displayedError = getDisplayedOsidbError(error);
-      addToast({
-        title: 'Error Rejecting Flaw',
-        body: displayedError,
-        css: 'warning',
-      });
-      console.error('FlawService::rejectFlawWorkflow() Problem rejecting flaw:', error);
-      throw error;
-    });
-}
-
-export async function revertFlawWorkflow(uuid: string) {
-  const { addToast } = useToastStore();
-  try {
-    const response = await osidbFetch({
-      method: 'post',
-      url: `/osidb/api/v1/flaws/${uuid}/revert`,
-    });
-    addToast({
-      title: 'Workflow State Reverted',
-      body: response.data.classification.state,
-      css: 'success',
-    });
-    return response.data;
-  } catch (error) {
-    addToast({
-      title: 'Error Reverting Workflow State',
-      body: getDisplayedOsidbError(error),
-      css: 'warning',
-    });
-    throw error;
-  }
-}
-
-export async function resetFlawWorkflow(uuid: string) {
-  const { addToast } = useToastStore();
-  try {
-    const response = await osidbFetch({
-      method: 'post',
-      url: `/osidb/api/v1/flaws/${uuid}/reset`,
-    });
-    addToast({
-      title: 'Workflow State Reset',
-      body: response.data.classification.state,
-      css: 'success',
-    });
-    return response.data;
-  } catch (error) {
-    addToast({
-      title: 'Error Resetting Workflow State',
-      body: getDisplayedOsidbError(error),
-      css: 'warning',
-    });
-    throw error;
-  }
 }
 
 // TODO paginate search results page

--- a/src/services/WorkflowService.ts
+++ b/src/services/WorkflowService.ts
@@ -1,0 +1,52 @@
+import { osidbFetch } from '@/services/OsidbAuthService';
+
+export type WorkflowCheck = {
+  accepts: boolean;
+  description: string;
+  name: string;
+};
+
+export type WorkflowCondition = {
+  accepts: boolean;
+  condition: string;
+  requirements: WorkflowRequirement[];
+};
+
+export type WorkflowRequirement = WorkflowCheck | WorkflowCondition;
+
+export type WorkflowStateDetail = {
+  accepts: boolean;
+  name: string;
+  requirements: WorkflowRequirement[];
+};
+
+export type WorkflowDetail = {
+  accepts: boolean;
+  conditions: WorkflowCheck[];
+  description: string;
+  name: string;
+  priority: number;
+  states: WorkflowStateDetail[];
+};
+
+export type VerboseWorkflowClassification = {
+  classification: {
+    state: string;
+    workflow: string;
+  };
+  flaw: string;
+  workflows: WorkflowDetail[];
+};
+
+export function isWorkflowCondition(req: WorkflowRequirement): req is WorkflowCondition {
+  return 'condition' in req;
+}
+
+export async function getFlawWorkflowClassification(flawUuid: string): Promise<VerboseWorkflowClassification> {
+  const { data } = await osidbFetch({
+    method: 'get',
+    url: `/workflows/api/v1/workflows/${flawUuid}`,
+    params: { verbose: true },
+  });
+  return data as VerboseWorkflowClassification;
+}

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -152,6 +152,7 @@ export enum FlawLabelTypeEnum {
   BU = 'bu',
   CONTEXT_BASED = 'context_based',
   PRODUCT_FAMILY = 'product_family',
+  WORKFLOW = 'workflow',
 }
 export type ZodFlawLabelType = NonNullable<ZodFlawType['labels']>[number];
 export type ZodFlawType = z.infer<typeof ZodFlawSchema>;


### PR DESCRIPTION
OSIDB-5194 Add next flaw state UI

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [-] Integration tests updated

## Summary:

New UI to track requirements needed for flaw state transitions 

## Changes:

- Add new component for collapsible state details
- Add composables to handle logic of the next state and fetching flaw info
- Update tests 

<img width="950" height="374" alt="image" src="https://github.com/user-attachments/assets/c8bafe50-e65d-48df-a06e-6489453037eb" />

## Considerations:

Requires: https://github.com/RedHatProductSecurity/osim/pull/790
