### PR TITLE
🐛 Bot processing labels incorrectly shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * Disable "Save Changes" and "Reset Changes" buttons when no flaw changes have been made (`OSIDB-4973`)
 * Fix my issues flaw list filter to use email instead username (`OSIDB-5143`)
+* Fix "Pending Bot Processing" label incorrectly shown on processed flaws (`OSIDB-5216`)
 
 ### Changed
 * Update error message on failed logging (`OSIDB-5011`)

--- a/src/components/IssueQueue/IssueQueue.vue
+++ b/src/components/IssueQueue/IssueQueue.vue
@@ -24,14 +24,20 @@ const emit = defineEmits(['flaws:fetch', 'flaws:load-more']);
 const userStore = useUserStore();
 const { settings } = storeToRefs(useSettingsStore());
 
-export type FilteredIssue = ReturnType<typeof relevantFields>;
+export type FilteredIssue = {
+  formattedDate: string;
+} & ZodFlawType;
 
 // Temporarily hiding 'Source' column to avoid displaying incorrect information.
 // TODO: unhide it once final issue sources are defined. [OSIDB-2424]
 // type ColumnField = 'id' | 'impact' | 'source' | 'created_dt' | 'title' | 'state' | 'owner';
 type ColumnField = 'created_dt' | 'id' | 'impact' | 'owner' | 'state' | 'title';
 
-const issues = computed<FilteredIssue[]>(() => props.issues.map(relevantFields));
+const issues = computed<FilteredIssue[]>(() => props.issues.map(issue => ({
+  formattedDate: DateTime.fromISO(issue.created_dt!).toUTC().toFormat('yyyy-MM-dd HH:mm'),
+  ...issue,
+})));
+
 const selectedSortField = ref<ColumnField | null>('created_dt');
 const isSortedByAscending = ref(false);
 const isMyIssuesSelected = ref(false);
@@ -102,23 +108,6 @@ function selectSortField(field: ColumnField) {
   }
 }
 
-function relevantFields(issue: ZodFlawType) {
-  return {
-    id: issue.cve_id || issue.uuid,
-    impact: issue.impact,
-    // source: issue.source,
-    created_dt: issue.created_dt,
-    title: issue.title,
-    workflowState: issue.classification?.state,
-    unembargo_dt: issue.unembargo_dt,
-    embargoed: issue.embargoed,
-    owner: issue.owner,
-    formattedDate: DateTime.fromISO(issue.created_dt!).toUTC().toFormat('yyyy-MM-dd HH:mm'),
-    labels: issue.labels,
-    flaw: issue, // Include full flaw object for UnprocessedFlawLabel
-  };
-}
-
 function emitLoadMore() {
   emit('flaws:load-more', params);
 }
@@ -183,7 +172,7 @@ watch(isButtonVisible, (isVisible) => {
           </tr>
         </thead>
         <tbody class="table-group-divider">
-          <template v-for="(relevantIssue, index) of issues" :key="relevantIssue.id">
+          <template v-for="(relevantIssue, index) of issues" :key="relevantIssue.cve_id || relevantIssue.uuid">
             <IssueQueueItem
               :issue="relevantIssue"
               :showLabels="!settings.isHidingLabels"

--- a/src/components/IssueQueue/IssueQueueItem.vue
+++ b/src/components/IssueQueue/IssueQueueItem.vue
@@ -18,14 +18,14 @@ const { issue, showLabels } = defineProps<{
 // TODO: unhide it once final issue sources are defined. [OSIDB-2424]
 //       and update the CSS for the column width in IssueQueue
 
-const nonIdFields: Exclude<keyof FilteredIssue, 'flaw' | 'id'>[] =
-  ['impact', 'formattedDate', 'title', 'workflowState', 'owner'];
+const nonIdFields: Exclude<keyof FilteredIssue, 'cve_id' | 'uuid'>[] =
+  ['impact', 'formattedDate', 'title', 'classification', 'owner'];
 
 const { isFlawUnprocessed } = useUnprocessedFlawDetection();
 
 const hasBadges = computed(() =>
   issue.embargoed
-  || (showLabels && (!!issue.labels?.length || (issue.flaw && isFlawUnprocessed(issue.flaw)))),
+  || (showLabels && (!!issue.labels?.length || isFlawUnprocessed(issue))),
 );
 const sortedLabels = computed(() => issue.labels?.toSorted((a, b) => {
   if (
@@ -72,8 +72,8 @@ function getLabelColor(label: string, type: string): string {
       class="osim-issue-title"
       :class="{ 'pb-0': hasBadges }"
     >
-      <RouterLink :to="{ name: 'flaw-details', params: { id: issue.id } }">
-        {{ issue.id }}
+      <RouterLink :to="{ name: 'flaw-details', params: { id: issue.cve_id || issue.uuid } }">
+        {{ issue.cve_id || issue.uuid }}
       </RouterLink>
     </td>
     <td
@@ -81,7 +81,7 @@ function getLabelColor(label: string, type: string): string {
       :key="field"
       :class="{ 'pb-0': hasBadges }"
     >
-      {{ issue[field] }}
+      {{ field === 'classification' ? issue[field]?.state : issue[field] }}
     </td>
     <!--<td>{{ issue.assigned }}</td>-->
   </tr>
@@ -97,7 +97,7 @@ function getLabelColor(label: string, type: string): string {
           class="badge rounded-pill text-bg-danger border border-primary"
         >Embargoed</span>
         <template v-if="showLabels">
-          <UnprocessedFlawLabel v-if="issue.flaw" :flaw="issue.flaw" variant="badge" />
+          <UnprocessedFlawLabel v-if="isFlawUnprocessed(issue)" :flaw="issue" variant="badge" />
           <template
             v-for="label in sortedLabels"
             :key="label.label"

--- a/src/components/UnprocessedFlawLabel/UnprocessedFlawLabel.vue
+++ b/src/components/UnprocessedFlawLabel/UnprocessedFlawLabel.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
+import type { FilteredIssue } from '@/components/IssueQueue/IssueQueue.vue';
+
 import { useUnprocessedFlawDetection } from '@/composables/unprocessedFlawCheck';
 
 import type { ZodFlawType } from '@/types';
 
 const props = defineProps<{
-  flaw: ZodFlawType;
+  flaw: FilteredIssue | ZodFlawType;
   variant?: 'badge' | 'inline';
 }>();
 

--- a/src/components/__tests__/IssueQueue.spec.ts
+++ b/src/components/__tests__/IssueQueue.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Settings } from 'luxon';
+import { DateTime, Settings } from 'luxon';
 import { flushPromises } from '@vue/test-utils';
 
 import IssueQueueItem from '@/components/IssueQueue/IssueQueueItem.vue';
@@ -194,6 +194,21 @@ describe('issueQueue', () => {
     const dateEl = wrapper.findAll('td')[2];
     expect(dateEl.exists()).toBeTruthy();
     expect(dateEl.text()).toBe('2021-07-29 22:50');
+  });
+
+  it('should render unprocessed label for a bare flaw with no content fields', () => {
+    const wrapper = mountIssueQueue({
+      issues: [{
+        uuid: 'bare-uuid',
+        cve_id: 'CVE-2024-9999',
+        classification: { workflow: 'DEFAULT', state: 'NEW' },
+        created_dt: DateTime.now().minus({ hours: 1 }).toISO(),
+        aegis_meta: null,
+      } as unknown as ZodFlawType],
+    });
+
+    const label = wrapper.findComponent(IssueQueueItem).find('.unprocessed-flaw-label');
+    expect(label.exists()).toBe(true);
   });
 
   it('should render flaw labels', () => {

--- a/src/composables/__tests__/unprocessedFlawCheck.spec.ts
+++ b/src/composables/__tests__/unprocessedFlawCheck.spec.ts
@@ -200,4 +200,42 @@ describe('useUnprocessedFlawDetection', () => {
 
     expect(isFlawUnprocessed(flaw)).toBe(true);
   });
+
+  it('returns false for flaw with manual-triage label', () => {
+    const flaw = {
+      uuid: 'test-uuid',
+      classification: { state: FlawClassificationStateEnum.New, workflow: 'test' },
+      cve_id: 'CVE-2024-1234',
+      created_dt: DateTime.now().minus({ hours: 1 }).toISO(),
+      aegis_meta: null,
+      labels: [{ label: 'manual-triage', state: 'NEW', contributor: '' }],
+    } as ZodFlawType;
+
+    expect(isFlawUnprocessed(flaw)).toBe(false);
+  });
+
+  it('returns true for flaw with whitespace-only cve_description', () => {
+    const flaw = {
+      uuid: 'test-uuid',
+      classification: { state: FlawClassificationStateEnum.New, workflow: 'test' },
+      cve_id: 'CVE-2024-1234',
+      created_dt: DateTime.now().minus({ hours: 1 }).toISO(),
+      aegis_meta: null,
+      cve_description: '   ',
+    } as ZodFlawType;
+
+    expect(isFlawUnprocessed(flaw)).toBe(true);
+  });
+
+  it('returns true for flaw in EMPTY classification state', () => {
+    const flaw = {
+      uuid: 'test-uuid',
+      classification: { state: FlawClassificationStateEnum.Empty, workflow: 'test' },
+      cve_id: 'CVE-2024-1234',
+      created_dt: DateTime.now().minus({ hours: 1 }).toISO(),
+      aegis_meta: null,
+    } as ZodFlawType;
+
+    expect(isFlawUnprocessed(flaw)).toBe(true);
+  });
 });

--- a/src/composables/unprocessedFlawCheck.ts
+++ b/src/composables/unprocessedFlawCheck.ts
@@ -45,7 +45,8 @@ export function useUnprocessedFlawDetection() {
       || flaw.classification?.state === FlawClassificationStateEnum.Empty)
       && !!flaw.cve_id && isCveValid(flaw.cve_id)
       && !isOlderThanThreshold(flaw.created_dt)
-      && areRequiredFieldsEmpty(flaw);
+      && areRequiredFieldsEmpty(flaw)
+      && !flaw.labels?.some(label => label.label === 'manual-triage');
   }
 
   return {

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -38,6 +38,13 @@ const FLAW_LIST_FIELDS = [
   'owner',
   'labels',
   'aegis_meta',
+  // Required fields for UnprocessedFlawLabel logic
+  'cve_description',
+  'affects',
+  'statement',
+  'mitigation',
+  'cwe_id',
+  'cvss_scores',
 ];
 
 export async function getFlaws(offset = 0, limit = 20, args = {}) {


### PR DESCRIPTION
OSIDB-5216 Bot processing labels incorrectly shown

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [ ] Test cases added/updated
- [ ] Integration tests updated

**Summary:**
Fixed "Pending Bot Processing" labels shown on flaws with existing content due to missing `cve_description` field in API requests.

**Changes:**
- Add missing fields to `FLAW_LIST_FIELDS` for proper label detection
- Simplify IssueQueue data handling by removing redundant transformation function

**Considerations:**
Added comment noting some fields are needed for label logic rather than display.