### PR TITLE
✨ OSIDB-5125 CRA Flaw list integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add workflow label type support in Labels section (`OSIDB-5019`)
 * Show ecosystem information in Aegis component suggestion tooltips (`OSIDB-5252`)
 * Add SRP (Single Reporting Platform) summary section to flaw detail page for CRA compliance (`OSIDB-5091`)
+* Add SRP status column and filtering in flaw list for CRA compliance (`OSIDB-5125`)
 
 ### Fixed
 * Disable "Save Changes" and "Reset Changes" buttons when no flaw changes have been made (`OSIDB-4973`)

--- a/src/components/CRA/SRPStatusBadge.vue
+++ b/src/components/CRA/SRPStatusBadge.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import type { SRPReportStatus } from '@/types/cra';
+
+defineProps<{
+  overdueMilestones?: null | number | undefined;
+  status: null | SRPReportStatus | undefined;
+}>();
+
+const STATUS_BADGE_MAP: Record<SRPReportStatus, string> = {
+  blocked: 'bg-danger text-white',
+  deferred: 'bg-secondary text-white',
+  failed: 'bg-danger text-white',
+  not_applicable: 'bg-light text-dark',
+  not_required: 'bg-light text-dark',
+  prepared: 'bg-info text-dark',
+  required: 'bg-warning text-dark',
+  submitted: 'bg-success text-white',
+};
+
+function getBadgeClass(status: null | SRPReportStatus | undefined): string {
+  if (!status) return '';
+  // Fallback for unknown statuses
+  return STATUS_BADGE_MAP[status] ?? 'bg-secondary text-white';
+}
+
+function formatStatus(status: null | SRPReportStatus | undefined): string {
+  return status?.replace(/_/g, ' ') ?? '';
+}
+</script>
+
+<template>
+  <div v-if="status" class="d-flex gap-1 align-items-center">
+    <span class="badge" :class="getBadgeClass(status)">
+      {{ formatStatus(status) }}
+    </span>
+    <span v-if="overdueMilestones && overdueMilestones > 0" class="badge bg-danger">
+      {{ overdueMilestones }} Overdue
+    </span>
+  </div>
+  <span v-else class="text-muted">—</span>
+</template>

--- a/src/components/CRA/__tests__/SRPStatusBadge.spec.ts
+++ b/src/components/CRA/__tests__/SRPStatusBadge.spec.ts
@@ -1,0 +1,29 @@
+import { mount } from '@vue/test-utils';
+
+import SRPStatusBadge from '@/components/CRA/SRPStatusBadge.vue';
+
+describe('srpStatusBadge', () => {
+  it('renders status badge', () => {
+    const wrapper = mount(SRPStatusBadge, {
+      props: { status: 'required' },
+    });
+
+    expect(wrapper.find('.badge').text()).toBe('required');
+  });
+
+  it('renders overdue badge', () => {
+    const wrapper = mount(SRPStatusBadge, {
+      props: { overdueMilestones: 2, status: 'required' },
+    });
+
+    expect(wrapper.text()).toContain('2 Overdue');
+  });
+
+  it('renders placeholder when no status', () => {
+    const wrapper = mount(SRPStatusBadge, {
+      props: { status: null },
+    });
+
+    expect(wrapper.text()).toBe('—');
+  });
+});

--- a/src/components/IssueQueue/IssueQueue.vue
+++ b/src/components/IssueQueue/IssueQueue.vue
@@ -31,7 +31,7 @@ export type FilteredIssue = {
 // Temporarily hiding 'Source' column to avoid displaying incorrect information.
 // TODO: unhide it once final issue sources are defined. [OSIDB-2424]
 // type ColumnField = 'id' | 'impact' | 'source' | 'created_dt' | 'title' | 'state' | 'owner';
-type ColumnField = 'created_dt' | 'id' | 'impact' | 'owner' | 'state' | 'title';
+type ColumnField = 'created_dt' | 'id' | 'impact' | 'owner' | 'srp_status' | 'state' | 'title';
 
 const issues = computed<FilteredIssue[]>(() => props.issues.map(issue => ({
   formattedDate: DateTime.fromISO(issue.created_dt!).toUTC().toFormat('yyyy-MM-dd HH:mm'),
@@ -84,13 +84,14 @@ const params = computed(() => {
 });
 
 const columnsFieldsMap: Record<string, ColumnField> = {
-  ID: 'id',
-  Impact: 'impact',
+  'ID': 'id',
+  'Impact': 'impact',
   // Source: 'source',
-  Created: 'created_dt',
-  Title: 'title',
-  State: 'state',
-  Owner: 'owner',
+  'Created': 'created_dt',
+  'Title': 'title',
+  'SRP Status': 'srp_status',
+  'State': 'state',
+  'Owner': 'owner',
 };
 
 function selectSortField(field: ColumnField) {
@@ -255,27 +256,31 @@ watch(isButtonVisible, (isVisible) => {
       padding: 1ch;
 
       &:nth-of-type(1) {
-        width: 20%;
+        width: 18%;
       }
 
       &:nth-of-type(2) {
-        width: 8%;
+        width: 7%;
       }
 
       &:nth-of-type(3) {
-        width: 9.5%;
+        width: 9%;
       }
 
       &:nth-of-type(4) {
-        width: 27.5%;
+        width: 22%;
       }
 
       &:nth-of-type(5) {
-        width: 17.5%;
+        width: 15%;
       }
 
       &:nth-of-type(6) {
-        width: 17.5%;
+        width: 14%;
+      }
+
+      &:nth-of-type(7) {
+        width: 15%;
       }
     }
 

--- a/src/components/IssueQueue/IssueQueueItem.vue
+++ b/src/components/IssueQueue/IssueQueueItem.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 
 import UnprocessedFlawLabel from '@/components/UnprocessedFlawLabel/UnprocessedFlawLabel.vue';
+import SRPStatusBadge from '@/components/CRA/SRPStatusBadge.vue';
 
 import { useUnprocessedFlawDetection } from '@/composables/unprocessedFlawCheck';
 
@@ -19,7 +20,7 @@ const { issue, showLabels } = defineProps<{
 //       and update the CSS for the column width in IssueQueue
 
 const nonIdFields: Exclude<keyof FilteredIssue, 'cve_id' | 'uuid'>[] =
-  ['impact', 'formattedDate', 'title', 'classification', 'owner'];
+  ['impact', 'formattedDate', 'title', 'srp_status', 'classification', 'owner'];
 
 const { isFlawUnprocessed } = useUnprocessedFlawDetection();
 
@@ -81,7 +82,14 @@ function getLabelColor(label: string, type: string): string {
       :key="field"
       :class="{ 'pb-0': hasBadges }"
     >
-      {{ field === 'classification' ? issue[field]?.state : issue[field] }}
+      <SRPStatusBadge
+        v-if="field === 'srp_status'"
+        :status="issue.srp_status ?? undefined"
+        :overdueMilestones="issue.srp_overdue_milestones ?? undefined"
+      />
+      <template v-else>
+        {{ field === 'classification' ? issue[field]?.state : issue[field] }}
+      </template>
     </td>
     <!--<td>{{ issue.assigned }}</td>-->
   </tr>

--- a/src/components/IssueSearchAdvanced/IssueSearchAdvanced.vue
+++ b/src/components/IssueSearchAdvanced/IssueSearchAdvanced.vue
@@ -88,6 +88,7 @@ const nameForOption = (fieldName: string) => {
     cve_description: 'CVE Description',
     requires_cve_description: 'CVE Description Review',
     major_incident_state: 'Incident State',
+    srp_status: 'SRP Status',
   };
   let name =
     mappings[fieldName]
@@ -127,6 +128,16 @@ const optionsFor = (field: string) =>
     ],
     major_incident_state: flawIncidentStates,
     affects__affectedness: affectAffectedness,
+    srp_status: [
+      'blocked',
+      'deferred',
+      'failed',
+      'not_applicable',
+      'not_required',
+      'prepared',
+      'required',
+      'submitted',
+    ],
   })[field] || null;
 
 const shouldShowAdvanced = ref(true);

--- a/src/components/__tests__/__snapshots__/IssueQueue.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/IssueQueue.spec.ts.snap
@@ -17,6 +17,7 @@ exports[`issueQueue > should not render flaw labels that are already assigned 1`
           <th data-v-48717bcb="">Impact <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Created <i data-v-48717bcb="" class="bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Title <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
+          <th data-v-48717bcb="">SRP Status <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">State <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Owner <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
         </tr>
@@ -27,6 +28,7 @@ exports[`issueQueue > should not render flaw labels that are already assigned 1`
           <td data-v-15d9c71d="" class="pb-0">MODERATE</td>
           <td data-v-15d9c71d="" class="pb-0">2021-07-29 14:50</td>
           <td data-v-15d9c71d="" class="pb-0">title</td>
+          <td data-v-15d9c71d="" class="pb-0"><span data-v-15d9c71d="" class="text-muted">—</span></td>
           <td data-v-15d9c71d="" class="pb-0">NEW</td>
           <td data-v-15d9c71d="" class="pb-0">test@redhat.com</td>
           <!--<td>{{ issue.assigned }}</td>-->
@@ -69,6 +71,7 @@ exports[`issueQueue > should not render flaw labels when isHidingLabels is true 
           <th data-v-48717bcb="">Impact <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Created <i data-v-48717bcb="" class="bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Title <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
+          <th data-v-48717bcb="">SRP Status <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">State <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Owner <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
         </tr>
@@ -79,6 +82,7 @@ exports[`issueQueue > should not render flaw labels when isHidingLabels is true 
           <td data-v-15d9c71d="" class="">MODERATE</td>
           <td data-v-15d9c71d="" class="">2021-07-29 14:50</td>
           <td data-v-15d9c71d="" class="">title</td>
+          <td data-v-15d9c71d="" class=""><span data-v-15d9c71d="" class="text-muted">—</span></td>
           <td data-v-15d9c71d="" class="">NEW</td>
           <td data-v-15d9c71d="" class="">test@redhat.com</td>
           <!--<td>{{ issue.assigned }}</td>-->
@@ -111,6 +115,7 @@ exports[`issueQueue > should render flaw labels 1`] = `
           <th data-v-48717bcb="">Impact <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Created <i data-v-48717bcb="" class="bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Title <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
+          <th data-v-48717bcb="">SRP Status <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">State <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Owner <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
         </tr>
@@ -121,6 +126,7 @@ exports[`issueQueue > should render flaw labels 1`] = `
           <td data-v-15d9c71d="" class="pb-0">MODERATE</td>
           <td data-v-15d9c71d="" class="pb-0">2021-07-29 14:50</td>
           <td data-v-15d9c71d="" class="pb-0">title</td>
+          <td data-v-15d9c71d="" class="pb-0"><span data-v-15d9c71d="" class="text-muted">—</span></td>
           <td data-v-15d9c71d="" class="pb-0">NEW</td>
           <td data-v-15d9c71d="" class="pb-0">test@redhat.com</td>
           <!--<td>{{ issue.assigned }}</td>-->

--- a/src/components/__tests__/__snapshots__/IssueSearchAdvanced.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/IssueSearchAdvanced.spec.ts.snap
@@ -27,6 +27,7 @@ exports[`issueSearchAdvanced > should add new facet when last facet is populated
         <option data-v-b86992a8="" value="major_incident_state">Incident State</option>
         <option data-v-b86992a8="" value="mitigation">Mitigation</option>
         <option data-v-b86992a8="" value="owner">Owner</option>
+        <option data-v-b86992a8="" value="srp_status">SRP Status</option>
         <option data-v-b86992a8="" value="statement">Statement</option>
         <option data-v-b86992a8="" value="title">Title</option>
         <option data-v-b86992a8="" value="affects__tracker__external_system_id">Tracker External System ID</option>
@@ -53,6 +54,7 @@ exports[`issueSearchAdvanced > should add new facet when last facet is populated
         <option data-v-b86992a8="" value="major_incident_state">Incident State</option>
         <option data-v-b86992a8="" value="mitigation">Mitigation</option>
         <option data-v-b86992a8="" value="owner">Owner</option>
+        <option data-v-b86992a8="" value="srp_status">SRP Status</option>
         <option data-v-b86992a8="" value="statement">Statement</option>
         <option data-v-b86992a8="" value="title">Title</option>
         <option data-v-b86992a8="" value="affects__tracker__external_system_id">Tracker External System ID</option>
@@ -127,6 +129,7 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is false 1`] = `
         <option data-v-b86992a8="" value="major_incident_state">Incident State</option>
         <option data-v-b86992a8="" value="mitigation">Mitigation</option>
         <option data-v-b86992a8="" value="owner">Owner</option>
+        <option data-v-b86992a8="" value="srp_status">SRP Status</option>
         <option data-v-b86992a8="" value="statement">Statement</option>
         <option data-v-b86992a8="" value="title">Title</option>
         <option data-v-b86992a8="" value="affects__tracker__external_system_id">Tracker External System ID</option>
@@ -201,6 +204,7 @@ exports[`issueSearchAdvanced > should render when \`isLoading\` is true 1`] = `
         <option data-v-b86992a8="" value="major_incident_state">Incident State</option>
         <option data-v-b86992a8="" value="mitigation">Mitigation</option>
         <option data-v-b86992a8="" value="owner">Owner</option>
+        <option data-v-b86992a8="" value="srp_status">SRP Status</option>
         <option data-v-b86992a8="" value="statement">Statement</option>
         <option data-v-b86992a8="" value="title">Title</option>
         <option data-v-b86992a8="" value="affects__tracker__external_system_id">Tracker External System ID</option>

--- a/src/constants/flawFields.ts
+++ b/src/constants/flawFields.ts
@@ -41,6 +41,7 @@ const includedFields = [
   'mitigation',
   'statement',
   'major_incident_state',
+  'srp_status',
 ];
 
 export const flawFields = fieldsFor(ZodFlawSchema)

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -36,6 +36,8 @@ const FLAW_LIST_FIELDS = [
   'owner',
   'labels',
   'aegis_meta',
+  'srp_status',
+  'srp_overdue_milestones',
   // Required fields for UnprocessedFlawLabel logic
   'cve_description',
   'affects',

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -209,6 +209,17 @@ export const ZodFlawSchema = z.object({
   affects: z.array(ZodAffectSchema), // read-only
   comments: z.array(ZodFlawCommentSchema),
   cvss_scores: z.array(FlawCVSSSchema),
+  srp_status: z.enum([
+    'blocked',
+    'deferred',
+    'failed',
+    'not_applicable',
+    'not_required',
+    'prepared',
+    'required',
+    'submitted',
+  ]).nullish(), // read-only
+  srp_overdue_milestones: z.number().nullish(), // read-only
   labels: z.array(z.object({
     uuid: z.string().optional(),
     label: z.string(),

--- a/src/views/__tests__/__snapshots__/IndexView.spec.ts.snap
+++ b/src/views/__tests__/__snapshots__/IndexView.spec.ts.snap
@@ -25,6 +25,7 @@ Fields: affects__ps_component: test" class="btn me-2 mt-1 border" type="button">
             <th data-v-48717bcb="">Impact <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
             <th data-v-48717bcb="">Created <i data-v-48717bcb="" class="bi-caret-down-fill bi"></i></th>
             <th data-v-48717bcb="">Title <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
+            <th data-v-48717bcb="">SRP Status <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
             <th data-v-48717bcb="">State <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
             <th data-v-48717bcb="">Owner <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           </tr>


### PR DESCRIPTION
# ✨ OSIDB-5125 CRA Flaw list integration

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated

## Summary:

Integrating SRP status data into flaw list and advance search

## Changes:

	- New reusable `SRPStatusBadge` component for displaying status with overdue indicators
	- SRP Status column added to flaw list table (`IssueQueue`)
	- SRP Status filter added in advanced search
	- Fields added to flaw schema (`srp_status`, `srp_overdue_milestones`)

## Demo:

<img width="1913" height="844" alt="image" src="https://github.com/user-attachments/assets/8674d640-267b-4ae6-815e-1ad79d849b21" />

## Considerations:

	- Includes all changes from [OSIDB-5091](https://github.com/RedHatProductSecurity/osim/pull/808) (base dependency)

[OSIDB-5091]: https://redhat.atlassian.net/browse/OSIDB-5091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ