### PR TITLE
adding error message for mandatory NOTAFFECTED fields

### DIFF
--- a/src/types/zodAffect.ts
+++ b/src/types/zodAffect.ts
@@ -143,6 +143,17 @@ export const ZodAffectSchema = z.object({
   ps_update_stream: z.string(),
   tracker: TrackerSchema.nullable(),
   labels: z.array(z.string()),
+}).superRefine((affect, ctx) => {
+  if (
+    affect.affectedness === AffectednessEnum.Notaffected
+    && !affect.not_affected_justification
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'A justification is required when the affect status is NOTAFFECTED.',
+      path: ['not_affected_justification'],
+    });
+  }
 });
 
 export type StreamComponent = {


### PR DESCRIPTION
# [OSIDB-ID] [Title]

## Checklist:

- [ ] Commits consolidated
- [ ] Changelog updated
- [ ] Test cases added/updated
- [ ] Integration tests updated

## Summary:

give user an error if trying to save an affect as NOTAFFECTED without providing a "Not Affected Justification". Currently an error comes server side but the user doesn't see it client side leading to confusion. 

## Changes:

File changed: /github/osim/src/types/zodAffect.ts

 Added a .superRefine() cross-field validation to ZodAffectSchema that checks if affectedness is NOTAFFECTED and not_affected_justification is empty/falsy. When  triggered, it adds a Zod issue on the not_affected_justification path with the message: "A justification is required when the affect status is NOTAFFECTED."

## Considerations:

just a suggestion on how to fix it with claude generated code base. 
