### PR TITLE
✨ OSIDB-5092 SRP reporting detail UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Show ecosystem information in Aegis component suggestion tooltips (`OSIDB-5252`)
 * Add SRP (Single Reporting Platform) summary section to flaw detail page for CRA compliance (`OSIDB-5091`)
 * Add SRP status column and filtering in flaw list for CRA compliance (`OSIDB-5125`)
+* Add expandable SRP report table with Add/Edit dialogs for managing reports and milestones (`OSIDB-5092`)
 
 ### Fixed
 * Make workflow labels not editable (`OSIDB-5310`)

--- a/src/components/CRA/SRPMilestoneDialog.vue
+++ b/src/components/CRA/SRPMilestoneDialog.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+
+import Modal from '@/widgets/Modal/Modal.vue';
+import type { SRPReportMilestone } from '@/types/cra';
+import { formatDate } from '@/utils/helpers';
+
+const props = defineProps<{
+  milestone?: SRPReportMilestone;
+  show: boolean;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  save: [milestone: Partial<SRPReportMilestone>];
+}>();
+
+const formData = ref({
+  due_at: props.milestone?.due_at || '',
+  manual_completion_notes: props.milestone?.manual_completion_notes || '',
+  milestone_type: props.milestone?.milestone_type || '24h',
+  status: props.milestone?.status || 'prepared',
+});
+
+watch(() => props.show, (newShow) => {
+  if (newShow && props.milestone) {
+    formData.value = {
+      due_at: props.milestone.due_at || '',
+      manual_completion_notes: props.milestone.manual_completion_notes || '',
+      milestone_type: props.milestone.milestone_type || '24h',
+      status: props.milestone.status || 'prepared',
+    };
+  }
+});
+
+function handleSave() {
+  emit('save', formData.value);
+  emit('close');
+}
+
+function handleClose() {
+  emit('close');
+}
+</script>
+
+<template>
+  <Modal :show="show" @close="handleClose">
+    <template #title>
+      {{ milestone ? 'Edit' : 'Add' }} Milestone
+    </template>
+    <template #body>
+      <div
+        v-if="milestone?.milestone_type === 'additional_information_response'"
+        class="mb-3 p-3 border rounded bg-light"
+      >
+        <h6 class="mb-2">Request Details</h6>
+        <div class="mb-2">
+          <small class="text-muted">Received:</small>
+          <div>{{ milestone.request_received_at ? formatDate(milestone.request_received_at, false) : 'N/A' }}</div>
+        </div>
+        <div class="mb-2">
+          <small class="text-muted">Source:</small>
+          <div>{{ milestone.request_source || 'N/A' }}</div>
+        </div>
+        <div v-if="milestone.request_text" class="mb-0">
+          <small class="text-muted">Request Text:</small>
+          <div class="text-break">{{ milestone.request_text }}</div>
+        </div>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Milestone Type</label>
+        <select v-model="formData.milestone_type" class="form-select">
+          <option value="24h">24h</option>
+          <option value="72h">72h</option>
+          <option value="additional_information_response">Additional Information Response</option>
+          <option value="final">Final</option>
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Status</label>
+        <select v-model="formData.status" class="form-select">
+          <option value="prepared">Prepared</option>
+          <option value="submitted">Submitted</option>
+          <option value="not_required">Not Required</option>
+          <option value="blocked">Blocked</option>
+          <option value="deferred">Deferred</option>
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Due Date</label>
+        <input v-model="formData.due_at" type="datetime-local" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Notes</label>
+        <textarea v-model="formData.manual_completion_notes" class="form-control" rows="3"></textarea>
+      </div>
+    </template>
+    <template #footer>
+      <button type="button" class="btn btn-secondary" @click="handleClose">Cancel</button>
+      <button type="button" class="btn btn-primary" @click="handleSave">Save</button>
+    </template>
+  </Modal>
+</template>

--- a/src/components/CRA/SRPPayloadDialog.vue
+++ b/src/components/CRA/SRPPayloadDialog.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import Modal from '@/widgets/Modal/Modal.vue';
+import type { SRPReport } from '@/types/cra';
+import { formatDate } from '@/utils/helpers';
+
+defineProps<{
+  report?: SRPReport;
+  show: boolean;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+}>();
+
+function formatValue(value: any): string {
+  if (value === null || value === undefined || value === '') return 'N/A';
+  if (Array.isArray(value)) return value.length ? value.join(', ') : 'N/A';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  return String(value);
+}
+
+function isSafeUrl(url: string): boolean {
+  return url.startsWith('http://') || url.startsWith('https://');
+}
+</script>
+
+<template>
+  <Modal class="modal-lg" :show="show" @close="emit('close')">
+    <template #title>
+      ENISA Payload Preview
+    </template>
+    <template #body>
+      <div v-if="!report" class="text-muted">No report data available.</div>
+      <div v-else>
+        <div class="row mb-2">
+          <div class="col-4 fw-bold">Field</div>
+          <div class="col-8 fw-bold">Value</div>
+        </div>
+        <div class="row mb-1 border-top pt-2">
+          <div class="col-4 text-muted">Title</div>
+          <div class="col-8">{{ formatValue(report.title) }}</div>
+        </div>
+        <div class="row mb-1">
+          <div class="col-4 text-muted">Event Type</div>
+          <div class="col-8">{{ formatValue(report.reportable_event_type) }}</div>
+        </div>
+        <div class="row mb-1">
+          <div class="col-4 text-muted">Responsibility Scope</div>
+          <div class="col-8">{{ formatValue(report.responsibility_scope) }}</div>
+        </div>
+        <div class="row mb-1">
+          <div class="col-4 text-muted">Status</div>
+          <div class="col-8">{{ formatValue(report.status) }}</div>
+        </div>
+        <div class="row mb-1">
+          <div class="col-4 text-muted">SRP Reference ID</div>
+          <div class="col-8">{{ formatValue(report.srp_reference_id) }}</div>
+        </div>
+        <div class="row mb-1">
+          <div class="col-4 text-muted">SRP Reference URL</div>
+          <div class="col-8">
+            <a
+              v-if="report.srp_reference_url && isSafeUrl(report.srp_reference_url)"
+              :href="report.srp_reference_url"
+              target="_blank"
+            >
+              {{ report.srp_reference_url }}
+            </a>
+            <span v-else-if="report.srp_reference_url" class="text-muted">
+              {{ report.srp_reference_url }} (unsafe URL scheme)
+            </span>
+            <span v-else>N/A</span>
+          </div>
+        </div>
+        <div class="row mb-1">
+          <div class="col-4 text-muted">Manufacturer/Steward</div>
+          <div class="col-8">{{ formatValue(report.manufacturer_or_steward_name) }}</div>
+        </div>
+        <div class="row mb-1">
+          <div class="col-4 text-muted">CSIRT Country</div>
+          <div class="col-8">{{ formatValue(report.designated_csirt_country) }}</div>
+        </div>
+        <div class="row mb-1">
+          <div class="col-4 text-muted">CSIRT Source</div>
+          <div class="col-8">{{ formatValue(report.designated_csirt_source) }}</div>
+        </div>
+        <div class="row mb-1">
+          <div class="col-4 text-muted">Member States Available</div>
+          <div class="col-8">{{ formatValue(report.member_states_available) }}</div>
+        </div>
+        <div class="row mb-1">
+          <div class="col-4 text-muted">Timer Started</div>
+          <div class="col-8">
+            {{ report.timer_started_at ? formatDate(report.timer_started_at, false) : 'N/A' }}
+          </div>
+        </div>
+        <div v-if="report.missing_required_fields" class="alert alert-warning mt-3">
+          <strong>Missing Required Fields:</strong> {{ report.missing_required_fields }}
+        </div>
+      </div>
+    </template>
+    <template #footer>
+      <button type="button" class="btn btn-secondary" @click="emit('close')">Close</button>
+    </template>
+  </Modal>
+</template>

--- a/src/components/CRA/SRPReportDetails.vue
+++ b/src/components/CRA/SRPReportDetails.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+import SRPStatusBadge from '@/components/CRA/SRPStatusBadge.vue';
+
+import type { SRPReport, SRPReportMilestone } from '@/types/cra';
+import { isMilestoneActionable } from '@/types/cra';
+import { updateSRPMilestone } from '@/services/SRPService';
+import { formatDate } from '@/utils/helpers';
+
+defineProps<{
+  report: SRPReport;
+}>();
+
+const emit = defineEmits<{
+  'add-milestone': [reportUuid: string];
+  'edit-milestone': [milestone: SRPReportMilestone];
+  'refresh': [];
+}>();
+
+function formatTimeRemaining(milestone: any): string {
+  if (milestone.is_overdue) return 'Overdue';
+  if (milestone.days_remaining === null) return '-';
+  const hours = milestone.hours_remaining ? ` ${milestone.hours_remaining % 24}h` : '';
+  return `${milestone.days_remaining}d${hours}`;
+}
+
+async function handleQuickAction(milestone: SRPReportMilestone, action: 'block' | 'defer' | 'submit') {
+  const statusMap = {
+    block: 'blocked',
+    defer: 'deferred',
+    submit: 'submitted',
+  };
+  try {
+    await updateSRPMilestone(milestone.uuid, { status: statusMap[action] as any });
+    emit('refresh');
+  } catch (err) {
+    console.error('Failed to update SRP milestone status:', err);
+  }
+}
+</script>
+
+<template>
+  <div class="p-3 bg-light">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <h6 class="mb-0">Milestones</h6>
+      <button
+        type="button"
+        class="btn btn-sm btn-outline-primary"
+        @click="emit('add-milestone', report.uuid)"
+      >
+        <i class="bi bi-plus-circle me-1"></i>
+        Add Milestone
+      </button>
+    </div>
+    <div v-if="!report.milestones || report.milestones.length === 0" class="text-muted">
+      No milestones defined.
+    </div>
+    <div v-else>
+      <div
+        v-if="
+          report.milestones.some(
+            m => m.milestone_type === '72h' || m.milestone_type === 'final',
+          )
+        "
+        class="alert alert-info alert-sm mb-2"
+      >
+        <i class="bi bi-info-circle me-1"></i>
+        <small>
+          72h and Final milestones copy data from previous stages.
+          Edit to update before submission.
+        </small>
+      </div>
+      <table class="table table-sm table-bordered bg-white mb-0">
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Status</th>
+            <th>Due Date</th>
+            <th>Time Remaining</th>
+            <th style="width: 200px">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="milestone in report.milestones"
+            :key="milestone.uuid"
+            :class="{ 'table-danger': isMilestoneActionable(milestone) }"
+          >
+            <td>{{ milestone.milestone_type }}</td>
+            <td>
+              <SRPStatusBadge :status="milestone.status" />
+            </td>
+            <td>{{ milestone.due_at ? formatDate(new Date(milestone.due_at), false) : 'N/A' }}</td>
+            <td :class="{ 'text-danger': milestone.is_overdue }">
+              {{ formatTimeRemaining(milestone) }}
+            </td>
+            <td>
+              <div class="btn-group btn-group-sm me-1" role="group">
+                <button
+                  v-if="milestone.status !== 'submitted'"
+                  type="button"
+                  class="btn btn-outline-success"
+                  title="Mark Submitted"
+                  @click="handleQuickAction(milestone, 'submit')"
+                >
+                  <i class="bi bi-check-circle"></i>
+                </button>
+                <button
+                  v-if="milestone.status !== 'deferred'"
+                  type="button"
+                  class="btn btn-outline-warning"
+                  title="Defer"
+                  @click="handleQuickAction(milestone, 'defer')"
+                >
+                  <i class="bi bi-clock"></i>
+                </button>
+                <button
+                  v-if="milestone.status !== 'blocked'"
+                  type="button"
+                  class="btn btn-outline-danger"
+                  title="Block"
+                  @click="handleQuickAction(milestone, 'block')"
+                >
+                  <i class="bi bi-slash-circle"></i>
+                </button>
+              </div>
+              <button
+                type="button"
+                class="btn btn-sm btn-outline-secondary"
+                title="Edit"
+                @click="emit('edit-milestone', milestone)"
+              >
+                <i class="bi bi-pencil"></i>
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/src/components/CRA/SRPReportDialog.vue
+++ b/src/components/CRA/SRPReportDialog.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+
+import Modal from '@/widgets/Modal/Modal.vue';
+import type { SRPReport } from '@/types/cra';
+
+const props = defineProps<{
+  report?: SRPReport;
+  show: boolean;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  save: [report: Partial<SRPReport>];
+}>();
+
+// Note: 'status' field is not included in the form because it's a computed property
+// in the backend, derived automatically from the milestone statuses.
+// To change the report status, update individual milestone statuses instead.
+const formData = ref({
+  reportable_event_type: props.report?.reportable_event_type || 'actively_exploited_vulnerability',
+  responsibility_scope: props.report?.responsibility_scope || 'manufacturer',
+  srp_reference_id: props.report?.srp_reference_id || '',
+  srp_reference_url: props.report?.srp_reference_url || '',
+  title: props.report?.title || '',
+});
+
+watch(() => props.show, (newShow) => {
+  if (newShow) {
+    if (props.report) {
+      formData.value = {
+        reportable_event_type: props.report.reportable_event_type,
+        responsibility_scope: props.report.responsibility_scope,
+        srp_reference_id: props.report.srp_reference_id,
+        srp_reference_url: props.report.srp_reference_url,
+        title: props.report.title,
+      };
+    } else {
+      formData.value = {
+        reportable_event_type: 'actively_exploited_vulnerability',
+        responsibility_scope: 'manufacturer',
+        srp_reference_id: '',
+        srp_reference_url: '',
+        title: '',
+      };
+    }
+  }
+});
+
+function handleSave() {
+  emit('save', formData.value);
+  emit('close');
+}
+
+function handleClose() {
+  emit('close');
+}
+</script>
+
+<template>
+  <Modal class="modal-lg" :show="show" @close="handleClose">
+    <template #title>
+      {{ report ? 'Edit' : 'Add' }} SRP Report
+    </template>
+    <template #body>
+      <div class="mb-3">
+        <label class="form-label">Title</label>
+        <input v-model="formData.title" type="text" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Event Type</label>
+        <select v-model="formData.reportable_event_type" class="form-select">
+          <option value="actively_exploited_vulnerability">Actively Exploited Vulnerability</option>
+          <option value="additional_information_request">Additional Information Request</option>
+          <option value="severe_incident">Severe Incident</option>
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Responsibility Scope</label>
+        <select v-model="formData.responsibility_scope" class="form-select">
+          <option value="manufacturer">Manufacturer</option>
+          <option value="steward">Steward</option>
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">SRP Reference ID</label>
+        <input v-model="formData.srp_reference_id" type="text" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">SRP Reference URL</label>
+        <input v-model="formData.srp_reference_url" type="url" class="form-control" />
+      </div>
+    </template>
+    <template #footer>
+      <button type="button" class="btn btn-secondary" @click="handleClose">Cancel</button>
+      <button type="button" class="btn btn-primary" @click="handleSave">Save</button>
+    </template>
+  </Modal>
+</template>

--- a/src/components/CRA/SRPSummary.vue
+++ b/src/components/CRA/SRPSummary.vue
@@ -1,8 +1,22 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
 
-import type { SRPReport, SRPReportSummary, SRPReportStatus } from '@/types/cra';
-import { fetchSRPReports } from '@/services/SRPService';
+import SRPMilestoneDialog from '@/components/CRA/SRPMilestoneDialog.vue';
+import SRPPayloadDialog from '@/components/CRA/SRPPayloadDialog.vue';
+import SRPReportDetails from '@/components/CRA/SRPReportDetails.vue';
+import SRPReportDialog from '@/components/CRA/SRPReportDialog.vue';
+import SRPStatusBadge from '@/components/CRA/SRPStatusBadge.vue';
+
+import { useSRPDialogs } from '@/composables/useSRPDialogs';
+
+import type { SRPReport, SRPReportMilestone, SRPReportSummary } from '@/types/cra';
+import { isMilestoneActionable } from '@/types/cra';
+import {
+  createAdditionalInfoMilestone,
+  fetchSRPReports,
+  updateSRPMilestone,
+  updateSRPReport,
+} from '@/services/SRPService';
 import { formatDate } from '@/utils/helpers';
 import LabelCollapsible from '@/widgets/LabelCollapsible/LabelCollapsible.vue';
 import LoadingSpinner from '@/widgets/LoadingSpinner/LoadingSpinner.vue';
@@ -11,21 +25,29 @@ const props = defineProps<{
   flawId: string;
 }>();
 
-const STATUS_BADGE_MAP: Record<SRPReportStatus, string> = {
-  blocked: 'bg-danger text-white',
-  deferred: 'bg-secondary text-white',
-  failed: 'bg-danger text-white',
-  not_applicable: 'bg-light text-dark',
-  not_required: 'bg-light text-dark',
-  prepared: 'bg-info text-white',
-  required: 'bg-warning text-dark',
-  submitted: 'bg-success text-white',
-};
-
 const srpReports = ref<SRPReport[]>([]);
 const isLoading = ref(false);
 const error = ref(false);
 const isExpanded = ref(true);
+const expandedReports = ref<Set<string>>(new Set());
+
+const {
+  closeMilestoneDialog,
+  closePayloadDialog,
+  closeReportDialog,
+  editingMilestone,
+  editingReport,
+  editingReportUuid,
+  openAddMilestoneDialog,
+  openAddReportDialog,
+  openEditMilestoneDialog,
+  openEditReportDialog,
+  openViewPayload,
+  showMilestoneDialog,
+  showPayloadDialog,
+  showReportDialog,
+  viewPayloadReport,
+} = useSRPDialogs();
 
 onMounted(async () => {
   await loadSRPReports();
@@ -62,11 +84,7 @@ const summary = computed<SRPReportSummary>(() => {
 
   for (const report of srpReports.value) {
     if (report.milestones) {
-      totalOverdue += report.milestones.filter(m =>
-        m.is_overdue
-        && m.status !== 'submitted'
-        && m.status !== 'not_required',
-      ).length;
+      totalOverdue += report.milestones.filter(isMilestoneActionable).length;
     }
   }
 
@@ -93,11 +111,7 @@ function getNextDueDate(report: SRPReport): Date | null {
 function getOverdueMilestones(report: SRPReport): number {
   if (!report.milestones) return 0;
 
-  return report.milestones.filter(m =>
-    m.is_overdue
-    && m.status !== 'submitted'
-    && m.status !== 'not_required',
-  ).length;
+  return report.milestones.filter(isMilestoneActionable).length;
 }
 
 function formatDateDisplay(date: Date | null): string {
@@ -112,8 +126,51 @@ function formatEventType(eventType: null | string): string {
   ).join(' ');
 }
 
-function formatStatus(status: null | string | undefined): string {
-  return status?.replace('_', ' ') ?? '';
+function toggleReportExpanded(reportUuid: string) {
+  if (expandedReports.value.has(reportUuid)) {
+    expandedReports.value.delete(reportUuid);
+  } else {
+    expandedReports.value.add(reportUuid);
+  }
+}
+
+function isReportExpanded(reportUuid: string): boolean {
+  return expandedReports.value.has(reportUuid);
+}
+
+function handleReportKeydown(event: KeyboardEvent, reportUuid: string) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    toggleReportExpanded(reportUuid);
+  }
+}
+
+async function handleSaveReport(data: Partial<SRPReport>) {
+  try {
+    if (editingReport.value) {
+      await updateSRPReport(editingReport.value.uuid, data);
+    }
+    await loadSRPReports();
+  } catch (err) {
+    console.error('Failed to save SRP report:', err);
+  }
+}
+
+async function handleSaveMilestone(data: Partial<SRPReportMilestone>) {
+  try {
+    if (editingMilestone.value) {
+      await updateSRPMilestone(editingMilestone.value.uuid, data);
+    } else {
+      await createAdditionalInfoMilestone(editingReportUuid.value, data);
+    }
+    await loadSRPReports();
+  } catch (err) {
+    console.error('Failed to save SRP milestone:', err);
+  }
+}
+
+function hasMissingFields(report: SRPReport): boolean {
+  return Boolean(report.missing_required_fields && report.missing_required_fields.trim());
 }
 </script>
 
@@ -145,41 +202,129 @@ function formatStatus(status: null | string | undefined): string {
     </div>
 
     <div v-else class="p-3">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h6 class="mb-0">SRP Reports</h6>
+        <button type="button" class="btn btn-sm btn-primary" @click="openAddReportDialog">
+          <i class="bi bi-plus-circle me-1"></i>
+          Add Report
+        </button>
+      </div>
       <div class="table-responsive">
         <table class="table table-sm table-hover">
           <thead>
             <tr>
+              <th style="width: 40px"></th>
               <th>Status</th>
               <th>Event Type</th>
               <th>Next Due Date</th>
               <th>Overdue</th>
+              <th style="width: 100px">Actions</th>
             </tr>
           </thead>
           <tbody>
-            <tr v-for="report in srpReports" :key="report.uuid">
-              <td>
-                <span class="badge" :class="STATUS_BADGE_MAP[report.status]">
-                  {{ formatStatus(report.status) }}
-                </span>
-              </td>
-              <td>{{ formatEventType(report.reportable_event_type) }}</td>
-              <td>{{ formatDateDisplay(getNextDueDate(report)) }}</td>
-              <td>
-                <span v-if="getOverdueMilestones(report) > 0" class="badge bg-danger">
-                  {{ getOverdueMilestones(report) }}
-                </span>
-                <span v-else class="text-muted">-</span>
-              </td>
-            </tr>
+            <template v-for="report in srpReports" :key="report.uuid">
+              <tr
+                class="report-row"
+                role="button"
+                tabindex="0"
+                :aria-expanded="isReportExpanded(report.uuid)"
+                @click="toggleReportExpanded(report.uuid)"
+                @keydown="handleReportKeydown($event, report.uuid)"
+              >
+                <td>
+                  <i
+                    class="bi"
+                    :class="isReportExpanded(report.uuid) ? 'bi-chevron-down' : 'bi-chevron-right'"
+                  ></i>
+                </td>
+                <td>
+                  <SRPStatusBadge :status="report.status" />
+                </td>
+                <td>{{ formatEventType(report.reportable_event_type) }}</td>
+                <td>{{ formatDateDisplay(getNextDueDate(report)) }}</td>
+                <td>
+                  <span v-if="getOverdueMilestones(report) > 0" class="badge bg-danger">
+                    {{ getOverdueMilestones(report) }}
+                  </span>
+                  <span v-else class="text-muted">-</span>
+                  <span
+                    v-if="hasMissingFields(report)"
+                    class="badge bg-warning text-dark ms-1"
+                    title="Missing required fields"
+                  >
+                    <i class="bi bi-exclamation-triangle"></i>
+                  </span>
+                </td>
+                <td @click.stop>
+                  <button
+                    type="button"
+                    class="btn btn-sm btn-outline-primary me-1"
+                    title="View Payload"
+                    @click="openViewPayload(report)"
+                  >
+                    <i class="bi bi-eye"></i>
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-sm btn-outline-secondary"
+                    @click="openEditReportDialog(report)"
+                  >
+                    <i class="bi bi-pencil"></i>
+                  </button>
+                </td>
+              </tr>
+              <tr v-if="isReportExpanded(report.uuid)" class="milestone-details">
+                <td colspan="6" class="p-0">
+                  <SRPReportDetails
+                    :report="report"
+                    @add-milestone="openAddMilestoneDialog"
+                    @edit-milestone="openEditMilestoneDialog"
+                    @refresh="loadSRPReports"
+                  />
+                </td>
+              </tr>
+            </template>
           </tbody>
         </table>
       </div>
     </div>
   </LabelCollapsible>
+
+  <SRPReportDialog
+    :report="editingReport"
+    :show="showReportDialog"
+    @close="closeReportDialog"
+    @save="handleSaveReport"
+  />
+
+  <SRPMilestoneDialog
+    :milestone="editingMilestone"
+    :show="showMilestoneDialog"
+    @close="closeMilestoneDialog"
+    @save="handleSaveMilestone"
+  />
+
+  <SRPPayloadDialog
+    :report="viewPayloadReport"
+    :show="showPayloadDialog"
+    @close="closePayloadDialog"
+  />
 </template>
 
 <style scoped>
 .section-label {
   font-weight: 600;
+}
+
+.report-row {
+  cursor: pointer;
+}
+
+.report-row:hover {
+  background-color: rgb(0 0 0 / 2.5%);
+}
+
+.milestone-details td {
+  border-top: none;
 }
 </style>

--- a/src/components/CRA/__tests__/SRPMilestoneDialog.spec.ts
+++ b/src/components/CRA/__tests__/SRPMilestoneDialog.spec.ts
@@ -1,0 +1,29 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import SRPMilestoneDialog from '@/components/CRA/SRPMilestoneDialog.vue';
+
+describe('sRPMilestoneDialog', () => {
+  it('renders when show is true', () => {
+    const wrapper = mount(SRPMilestoneDialog, {
+      props: { show: true },
+    });
+    expect(wrapper.find('.modal').exists()).toBe(true);
+  });
+
+  it('does not render when show is false', () => {
+    const wrapper = mount(SRPMilestoneDialog, {
+      props: { show: false },
+    });
+    expect(wrapper.find('.modal').exists()).toBe(false);
+  });
+
+  it('emits save and close events when save button clicked', async () => {
+    const wrapper = mount(SRPMilestoneDialog, {
+      props: { show: true },
+    });
+    await wrapper.findAll('.btn-primary').at(0)?.trigger('click');
+    expect(wrapper.emitted('save')).toBeTruthy();
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});

--- a/src/components/CRA/__tests__/SRPPayloadDialog.spec.ts
+++ b/src/components/CRA/__tests__/SRPPayloadDialog.spec.ts
@@ -1,0 +1,29 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import SRPPayloadDialog from '@/components/CRA/SRPPayloadDialog.vue';
+import { mockSRPReport } from '@/components/CRA/__tests__/fixtures';
+
+describe('sRPPayloadDialog', () => {
+  it('renders when show is true', () => {
+    const wrapper = mount(SRPPayloadDialog, {
+      props: { report: mockSRPReport, show: true },
+    });
+    expect(wrapper.find('.modal').exists()).toBe(true);
+  });
+
+  it('does not render when show is false', () => {
+    const wrapper = mount(SRPPayloadDialog, {
+      props: { report: mockSRPReport, show: false },
+    });
+    expect(wrapper.find('.modal').exists()).toBe(false);
+  });
+
+  it('emits close event when close button clicked', async () => {
+    const wrapper = mount(SRPPayloadDialog, {
+      props: { report: mockSRPReport, show: true },
+    });
+    await wrapper.find('.btn-close').trigger('click');
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});

--- a/src/components/CRA/__tests__/SRPReportDetails.spec.ts
+++ b/src/components/CRA/__tests__/SRPReportDetails.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import { mockSRPReport } from '@/components/CRA/__tests__/fixtures';
+
+import SRPReportDetails from '../SRPReportDetails.vue';
+
+vi.mock('@/services/SRPService', () => ({
+  updateSRPMilestone: vi.fn(() => Promise.resolve({})),
+}));
+
+describe('sRPReportDetails', () => {
+  it('renders milestone table', () => {
+    const wrapper = mount(SRPReportDetails, {
+      props: {
+        report: mockSRPReport,
+      },
+    });
+
+    expect(wrapper.text()).toContain('Milestones');
+    expect(wrapper.text()).toContain('24h');
+  });
+
+  it('emits add-milestone event', async () => {
+    const wrapper = mount(SRPReportDetails, {
+      props: {
+        report: mockSRPReport,
+      },
+    });
+
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.emitted('add-milestone')).toBeTruthy();
+  });
+
+  it('emits edit-milestone event', async () => {
+    const wrapper = mount(SRPReportDetails, {
+      props: {
+        report: mockSRPReport,
+      },
+    });
+
+    const editButton = wrapper.findAll('button').find(btn => btn.html().includes('bi-pencil'));
+    await editButton?.trigger('click');
+    expect(wrapper.emitted('edit-milestone')).toBeTruthy();
+  });
+});

--- a/src/components/CRA/__tests__/SRPReportDialog.spec.ts
+++ b/src/components/CRA/__tests__/SRPReportDialog.spec.ts
@@ -1,0 +1,29 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import SRPReportDialog from '@/components/CRA/SRPReportDialog.vue';
+
+describe('sRPReportDialog', () => {
+  it('renders when show is true', () => {
+    const wrapper = mount(SRPReportDialog, {
+      props: { show: true },
+    });
+    expect(wrapper.find('.modal').exists()).toBe(true);
+  });
+
+  it('does not render when show is false', () => {
+    const wrapper = mount(SRPReportDialog, {
+      props: { show: false },
+    });
+    expect(wrapper.find('.modal').exists()).toBe(false);
+  });
+
+  it('emits save and close events when save button clicked', async () => {
+    const wrapper = mount(SRPReportDialog, {
+      props: { show: true },
+    });
+    await wrapper.findAll('.btn-primary').at(0)?.trigger('click');
+    expect(wrapper.emitted('save')).toBeTruthy();
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});

--- a/src/components/CRA/__tests__/fixtures.ts
+++ b/src/components/CRA/__tests__/fixtures.ts
@@ -26,6 +26,7 @@ export const mockSRPReport: SRPReport = {
     updated_dt: '2026-01-05T00:00:00Z',
     uuid: 'milestone-1',
   }],
+  missing_required_fields: '',
   reportable_event_type: 'actively_exploited_vulnerability',
   responsibility_scope: 'manufacturer',
   srp_reference_id: 'SRP-123',

--- a/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/FlawForm.spec.ts.snap
@@ -599,7 +599,7 @@ exports[`flawForm > mounts and renders 1`] = `
     </div>
   </div>
   <div data-v-76e7a15d="" class="row border-top osim-flaw-form-section">
-    <div data-v-4715e8e2="" data-v-e7c807d0="" data-v-76e7a15d="" class="osim-collapsible-label my-2"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-e7c807d0="" class="section-label">CRA: SRP Reporting</span>
+    <div data-v-4715e8e2="" data-v-e7c807d0="" class="osim-collapsible-label my-2"><button data-v-4715e8e2="" type="button" class="me-2 osim-collapsible-toggle"><i data-v-4715e8e2="" class="bi me-1 bi-dash-square-dotted"></i><span data-v-e7c807d0="" class="section-label">CRA: SRP Reporting</span>
         <!--v-if-->
       </button>
       <div data-v-4715e8e2="" class="ps-3 border-start">
@@ -608,6 +608,24 @@ exports[`flawForm > mounts and renders 1`] = `
         </div>
       </div>
     </div>
+    <transition-stub data-v-296c460d="" name="modal" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <transition-stub data-v-296c460d="" name="modal-bg" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <transition-stub data-v-296c460d="" name="modal" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <transition-stub data-v-296c460d="" name="modal-bg" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <transition-stub data-v-296c460d="" name="modal" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <transition-stub data-v-296c460d="" name="modal-bg" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
   </div>
   <div data-v-76e7a15d="" class="row border-top osim-flaw-form-section">
     <section data-v-0b679fcf="" data-v-76e7a15d="" class="osim-comments">

--- a/src/composables/__tests__/useSRPDialogs.spec.ts
+++ b/src/composables/__tests__/useSRPDialogs.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SRPReport } from '@/types/cra';
+
+import { useSRPDialogs } from '../useSRPDialogs';
+
+describe('useSRPDialogs', () => {
+  it('initializes with correct default values', () => {
+    const {
+      showMilestoneDialog,
+      showPayloadDialog,
+      showReportDialog,
+    } = useSRPDialogs();
+
+    expect(showReportDialog.value).toBe(false);
+    expect(showMilestoneDialog.value).toBe(false);
+    expect(showPayloadDialog.value).toBe(false);
+  });
+
+  it('opens and closes report dialog', () => {
+    const {
+      closeReportDialog,
+      openAddReportDialog,
+      showReportDialog,
+    } = useSRPDialogs();
+
+    openAddReportDialog();
+    expect(showReportDialog.value).toBe(true);
+
+    closeReportDialog();
+    expect(showReportDialog.value).toBe(false);
+  });
+
+  it('opens and closes milestone dialog', () => {
+    const {
+      closeMilestoneDialog,
+      openAddMilestoneDialog,
+      showMilestoneDialog,
+    } = useSRPDialogs();
+
+    openAddMilestoneDialog('report-uuid');
+    expect(showMilestoneDialog.value).toBe(true);
+
+    closeMilestoneDialog();
+    expect(showMilestoneDialog.value).toBe(false);
+  });
+
+  it('opens and closes payload dialog', () => {
+    const {
+      closePayloadDialog,
+      openViewPayload,
+      showPayloadDialog,
+    } = useSRPDialogs();
+
+    const mockReport = { uuid: 'report-1' } as SRPReport;
+    openViewPayload(mockReport);
+    expect(showPayloadDialog.value).toBe(true);
+
+    closePayloadDialog();
+    expect(showPayloadDialog.value).toBe(false);
+  });
+});

--- a/src/composables/useSRPDialogs.ts
+++ b/src/composables/useSRPDialogs.ts
@@ -1,0 +1,79 @@
+import { ref } from 'vue';
+
+import type { SRPReport, SRPReportMilestone } from '@/types/cra';
+
+export function useSRPDialogs() {
+  // Dialog visibility state
+  const showReportDialog = ref(false);
+  const showMilestoneDialog = ref(false);
+  const showPayloadDialog = ref(false);
+
+  // Editing state
+  const editingReport = ref<SRPReport | undefined>();
+  const editingMilestone = ref<SRPReportMilestone | undefined>();
+  const editingReportUuid = ref<string>('');
+  const viewPayloadReport = ref<SRPReport | undefined>();
+
+  // Report dialog actions
+  function openAddReportDialog() {
+    editingReport.value = undefined;
+    showReportDialog.value = true;
+  }
+
+  function openEditReportDialog(report: SRPReport) {
+    editingReport.value = report;
+    showReportDialog.value = true;
+  }
+
+  function closeReportDialog() {
+    showReportDialog.value = false;
+  }
+
+  // Milestone dialog actions
+  function openAddMilestoneDialog(reportUuid: string) {
+    editingReportUuid.value = reportUuid;
+    editingMilestone.value = undefined;
+    showMilestoneDialog.value = true;
+  }
+
+  function openEditMilestoneDialog(milestone: SRPReportMilestone) {
+    editingMilestone.value = milestone;
+    showMilestoneDialog.value = true;
+  }
+
+  function closeMilestoneDialog() {
+    showMilestoneDialog.value = false;
+  }
+
+  // Payload dialog actions
+  function openViewPayload(report: SRPReport) {
+    viewPayloadReport.value = report;
+    showPayloadDialog.value = true;
+  }
+
+  function closePayloadDialog() {
+    showPayloadDialog.value = false;
+  }
+
+  return {
+    // Close functions
+    closeMilestoneDialog,
+    closePayloadDialog,
+    closeReportDialog,
+    // State
+    editingMilestone,
+    editingReport,
+    editingReportUuid,
+    // Open functions
+    openAddMilestoneDialog,
+    openAddReportDialog,
+    openEditMilestoneDialog,
+    openEditReportDialog,
+    openViewPayload,
+    // Dialog visibility
+    showMilestoneDialog,
+    showPayloadDialog,
+    showReportDialog,
+    viewPayloadReport,
+  };
+}

--- a/src/types/cra.ts
+++ b/src/types/cra.ts
@@ -55,6 +55,7 @@ export interface SRPReport {
   manufacturer_or_steward_name: string;
   member_states_available: string[];
   milestones: SRPReportMilestone[];
+  missing_required_fields: string;
   reportable_event_type: SRPEventType;
   responsibility_scope: SRPResponsibilityScope;
   srp_reference_id: string;
@@ -72,4 +73,11 @@ export interface SRPReportSummary {
   nextDueDate: Date | null;
   overdueMilestones: number;
   status: null | SRPReportStatus;
+}
+
+// Helper function to determine if a milestone should be counted as actionable/overdue
+export function isMilestoneActionable(milestone: SRPReportMilestone): boolean {
+  return milestone.is_overdue
+    && milestone.status !== 'submitted'
+    && milestone.status !== 'not_required';
 }


### PR DESCRIPTION
OSIDB-5092 SRP reporting detail UI

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated

## Summary:

Implements expandable SRP report table with full CRUD functionality for managing CRA compliance reports and milestones independently of flaw saves.

## Changes:

- Expandable rows: Click report rows to view/manage milestones
- Report management: Add/Edit dialogs with form validation
- Milestone management: Add/Edit dialogs for milestone tracking
- Payload viewer: View complete ENISA submission payload
- Visual indicators: Warning badges for incomplete payloads, overdue milestone counts
- Composable logic: `useSRPDialogs` for dialog state management

## Demo:
<img width="1856" height="522" alt="image" src="https://github.com/user-attachments/assets/dcfd992b-e042-4fb3-8164-642bd28dff33" />

## Considerations:
- Report status field removed (computed backend property)
- Depends on https://github.com/RedHatProductSecurity/osim/pull/811
