### PR TITLE
🐛 Make classification type a string

### DIFF
--- a/src/components/FlawForm/FlawFormImpact.vue
+++ b/src/components/FlawForm/FlawFormImpact.vue
@@ -20,7 +20,7 @@ const props = defineProps<{
   aegisContext: AegisSuggestionContextRefs;
   error: null | string;
   initialImpact: ImpactEnumWithBlankType | null;
-  workflowState: FlawClassificationStateEnum;
+  workflowState: string;
 }>();
 
 const modelValue = defineModel<ImpactEnumWithBlankType | null | undefined>('modelValue');
@@ -29,7 +29,7 @@ function handleImpactChange(value: null | string | undefined) {
   modelValue.value = value as ImpactEnumWithBlankType | null | undefined;
 }
 
-const postTriageStates: FlawClassificationStateEnum[] = [
+const postTriageStates: string[] = [
   FlawClassificationStateEnum.Rejected,
   FlawClassificationStateEnum.PreSecondaryAssessment,
   FlawClassificationStateEnum.SecondaryAssessment,

--- a/src/types/zodShared.ts
+++ b/src/types/zodShared.ts
@@ -15,12 +15,11 @@ import type {
   AffectCVSSSchemaType,
 } from './zodAffect';
 import {
-  FlawClassificationStateEnum,
 } from '../generated-client';
 
 export const ZodFlawClassification = z.object({
   workflow: z.string(),
-  state: z.nativeEnum(FlawClassificationStateEnum),
+  state: z.string(),
 });
 
 export const ImpactEnumWithBlank = { None: '', ...ImpactEnum } as const;


### PR DESCRIPTION
# OSIDB-5286 Make classification type a string

## Checklist:

- [x] Commits consolidated
- [-] Changelog updated
- [-] Test cases added/updated
- [-] Integration tests updated

## Summary:

Zod validation was rejecting the flaw payload on save because the classification for the flaws is not an anum anymore but a string, making the flaw uneditable for new values not existing in the previous enum.

## Changes:

- Change `classification.state` from enum to string
- Make `workflowState` prop and `postTriageStates` type from enum to string