### PR TITLE
🐛 Make workflow labels not editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add SRP status column and filtering in flaw list for CRA compliance (`OSIDB-5125`)
 
 ### Fixed
+* Make workflow labels not editable (`OSIDB-5310`)
 * Disable "Save Changes" and "Reset Changes" buttons when no flaw changes have been made (`OSIDB-4973`)
 * Fix my issues flaw list filter to use email instead username (`OSIDB-5143`)
 * Fix "Pending Bot Processing" label incorrectly shown on processed flaws (`OSIDB-5216`)

--- a/src/components/FlawLabels/FlawLabelTableEditingRow.vue
+++ b/src/components/FlawLabels/FlawLabelTableEditingRow.vue
@@ -91,11 +91,11 @@ const emitSave = () => {
       'text-decoration-line-through': !initalLabel?.relevant,
     }"
   >
-    <!-- Product family labels are read-only -->
-    <template v-if="initalLabel?.type === FlawLabelTypeEnum.PRODUCT_FAMILY">
+    <!-- Existing labels: name is immutable in OSIDB -->
+    <template v-if="!isNewLabel">
       {{ initalLabel?.label }}
     </template>
-    <!-- Alias and workflow labels use free text input -->
+    <!-- New alias and workflow labels use free text input -->
     <template v-else-if="isAliasType || isWorkflowType">
       <input
         v-model="labelName"
@@ -105,7 +105,7 @@ const emitSave = () => {
         required
       >
     </template>
-    <!-- BU labels use dropdown -->
+    <!-- New BU labels use dropdown -->
     <template v-else-if="isBuType">
       <select
         v-model="labelName"
@@ -119,7 +119,7 @@ const emitSave = () => {
         >{{ label }}</option>
       </select>
     </template>
-    <!-- Context-based labels use dropdown -->
+    <!-- New context-based labels use dropdown -->
     <template v-else>
       <select
         v-model="labelName"

--- a/src/components/FlawLabels/FlawLabelsTable.vue
+++ b/src/components/FlawLabels/FlawLabelsTable.vue
@@ -119,15 +119,29 @@ function handleUndoDelete(label: ZodFlawLabelType) {
             <td>{{ label.contributor }}</td>
             <td>
               <div class="actions">
-                <button
-                  v-if="!isDeletedLabel(label)"
-                  type="button"
-                  title="Edit label"
-                  class="btn btn-sm btn-dark"
-                  @click="isUpdatingLabel = label.label"
-                >
-                  <i class="bi bi-pencil" />
-                </button>
+                <template v-if="!isDeletedLabel(label)">
+                  <span
+                    v-if="label.type === FlawLabelTypeEnum.WORKFLOW && !isNewLabel(label)"
+                    title="Workflow labels are not editable"
+                  >
+                    <button
+                      type="button"
+                      class="btn btn-sm btn-dark"
+                      disabled
+                    >
+                      <i class="bi bi-pencil" />
+                    </button>
+                  </span>
+                  <button
+                    v-else
+                    type="button"
+                    title="Edit label"
+                    class="btn btn-sm btn-dark"
+                    @click="isUpdatingLabel = label.label"
+                  >
+                    <i class="bi bi-pencil" />
+                  </button>
+                </template>
                 <button
                   v-if="isDeletedLabel(label)"
                   type="button"

--- a/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTableEditingRow.spec.ts.snap
+++ b/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTableEditingRow.spec.ts.snap
@@ -16,8 +16,8 @@ exports[`flawLabelsTableEditingRow > should render 1`] = `
   </select>
 </td>
 <td data-v-627548cb="" class="text-decoration-line-through">
-  <!-- Product family labels are read-only -->
-  <!-- Context-based labels use dropdown --><select data-v-627548cb="" class="form-select" required=""></select>
+  <!-- Existing labels: name is immutable in OSIDB -->
+  <!-- New context-based labels use dropdown --><select data-v-627548cb="" class="form-select" required=""></select>
 </td>
 <td data-v-627548cb="">
   <flaw-labels-contributor-stub data-v-627548cb="" modelvalue=""></flaw-labels-contributor-stub>


### PR DESCRIPTION
# OSIDB-5310 Make workflow labels not editable

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [ ] Test cases added/updated
- [ ] Integration tests updated

## Summary:

Prevent editing of workflow labels by disabling the pencil button, as they are trigger flaw state changes they must be deleted/recreated

## Changes:

- Disabled edit button for existing workflow labels
- Added tooltip "Workflow labels are not editable"
- Made label names immutable for all existing labels (aligned with OSIDB behavior)

## Considerations:

Only affects existing workflow labels; new workflow labels can still be added
