### PR TITLE
🚑 Remove affects from include fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OSIM Changelog
 ## [Unreleased]
+### Fixed
+* Remove `affects` from flaw list/search `include_fields` to improve Advanced Search performance (`OSIDB-5314`)
+
+## [2026.8.0]
 ### Added
 * Add manual component suggestions for Source Component field (`OSIDB-4996`)
 * Add workflow label type support in Labels section (`OSIDB-5019`)

--- a/src/composables/__tests__/unprocessedFlawCheck.spec.ts
+++ b/src/composables/__tests__/unprocessedFlawCheck.spec.ts
@@ -97,19 +97,6 @@ describe('useUnprocessedFlawDetection', () => {
     expect(isFlawUnprocessed(flaw)).toBe(false);
   });
 
-  it('returns false for flaw with non-empty affects', () => {
-    const flaw = {
-      uuid: 'test-uuid',
-      classification: { state: FlawClassificationStateEnum.New, workflow: 'test' },
-      cve_id: 'CVE-2024-1234',
-      created_dt: DateTime.now().minus({ hours: 1 }).toISO(),
-      aegis_meta: null,
-      affects: [{ uuid: 'affect-1' }],
-    } as ZodFlawType;
-
-    expect(isFlawUnprocessed(flaw)).toBe(false);
-  });
-
   it('returns false for flaw with non-empty owner', () => {
     const flaw = {
       uuid: 'test-uuid',

--- a/src/composables/unprocessedFlawCheck.ts
+++ b/src/composables/unprocessedFlawCheck.ts
@@ -8,8 +8,7 @@ function areRequiredFieldsEmpty(flaw: ZodFlawType): boolean {
   if (flaw.aegis_meta?.processed === true) return false;
 
   return !(
-    (flaw.affects && flaw.affects.length > 0)
-    || (flaw.owner && flaw.owner.trim().length > 0)
+    (flaw.owner && flaw.owner.trim().length > 0)
     || (flaw.cve_description && flaw.cve_description.trim().length > 0)
     || (flaw.statement && flaw.statement.trim().length > 0)
     || (flaw.mitigation && flaw.mitigation.trim().length > 0)

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -38,9 +38,8 @@ const FLAW_LIST_FIELDS = [
   'aegis_meta',
   'srp_status',
   'srp_overdue_milestones',
-  // Required fields for UnprocessedFlawLabel logic
+  // Required fields for UnprocessedFlawLabel logic (`affects` omitted for list/search perf)
   'cve_description',
-  'affects',
   'statement',
   'mitigation',
   'cwe_id',


### PR DESCRIPTION
# Remove affects from include fields

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated

## Summary:

Fix for performance issues when requesting flaw lists to OSIDB.

## Changes:

- Remove affects from flaw lists requests

## Considerations:

This is already applied in PROD [v2026.8.0-hotfix](https://github.com/RedHatProductSecurity/osim/releases/tag/v2026.8.0-hotfix) this PR is to solve the diffs on main/stage
