### PR TITLE
🐛 Fix flaw labels for OSIDB v2 API

### DIFF
--- a/src/components/FlawLabels/FlawLabelTableEditingRow.vue
+++ b/src/components/FlawLabels/FlawLabelTableEditingRow.vue
@@ -20,7 +20,7 @@ const emit = defineEmits<{
 }>();
 
 const [labelState, hasStateChanged] = watchedRef<StateEnum>(initalLabel?.state ?? StateEnum.New);
-const [labelName, hasNameChanged] = watchedRef(initalLabel?.label ?? '');
+const [labelName, hasNameChanged] = watchedRef(initalLabel?.name ?? '');
 const [labelContributor, hasContributorChanged] = watchedRef(initalLabel?.contributor ?? '');
 const [labelType, hasTypeChanged] = watchedRef<FlawLabelTypeEnum>(
   initalLabel?.type ?? FlawLabelTypeEnum.CONTEXT_BASED,
@@ -50,7 +50,7 @@ const emitSave = () => {
   emit('save', {
     ...initalLabel,
     state: labelState.value,
-    label: labelName.value,
+    name: labelName.value,
     contributor: labelContributor.value,
     relevant: initalLabel?.relevant ?? true,
     type: labelType.value,
@@ -93,7 +93,7 @@ const emitSave = () => {
   >
     <!-- Existing labels: name is immutable in OSIDB -->
     <template v-if="!isNewLabel">
-      {{ initalLabel?.label }}
+      {{ initalLabel?.name }}
     </template>
     <!-- New alias and workflow labels use free text input -->
     <template v-else-if="isAliasType || isWorkflowType">

--- a/src/components/FlawLabels/FlawLabelsTable.vue
+++ b/src/components/FlawLabels/FlawLabelsTable.vue
@@ -30,12 +30,12 @@ const contextLabels = computedAsync(loadContextLabels, []);
 const buLabels = computedAsync(loadBuLabels, []);
 const availableLabels = computed(() =>
   contextLabels.value.filter(contextLabel =>
-    !Object.values(labels.value).some(({ label }) => label === contextLabel),
+    !Object.values(labels.value).some(({ name }) => name === contextLabel),
   ),
 );
 const availableBuLabels = computed(() =>
   buLabels.value.filter(buLabel =>
-    !Object.values(labels.value).some(({ label }) => label === buLabel),
+    !Object.values(labels.value).some(({ name }) => name === buLabel),
   ),
 );
 
@@ -43,30 +43,30 @@ const isExpandedDefault = labelsFromProps.value.some(label => label.contributor 
 const [isExpanded, toggleExpanded] = useToggle(isExpandedDefault);
 
 function handleNewLabel(label: ZodFlawLabelType) {
-  newLabels.value.add(label.label);
-  labels.value[label.label] = label;
+  newLabels.value.add(label.name);
+  labels.value[label.name] = label;
   isCreatingLabel.value = false;
 }
 
 function handleUpdateLabel(label: ZodFlawLabelType) {
-  updatedLabels.value.add(label.label);
-  labels.value[label.label] = label;
+  updatedLabels.value.add(label.name);
+  labels.value[label.name] = label;
   isUpdatingLabel.value = undefined;
 }
 
 function handleDeleteLabel(label: ZodFlawLabelType) {
   // if label is new, we can just remove it from the newLabels array
-  if (newLabels.value.has(label.label)) {
-    newLabels.value.delete(label.label);
-    delete labels.value[label.label];
+  if (newLabels.value.has(label.name)) {
+    newLabels.value.delete(label.name);
+    delete labels.value[label.name];
     return;
   }
 
-  deletedLabels.value.add(label.label);
+  deletedLabels.value.add(label.name);
 }
 
 function handleUndoDelete(label: ZodFlawLabelType) {
-  deletedLabels.value.delete(label.label);
+  deletedLabels.value.delete(label.name);
 }
 </script>
 <template>
@@ -87,7 +87,7 @@ function handleUndoDelete(label: ZodFlawLabelType) {
       <tbody>
         <tr
           v-for="label in labels"
-          :key="label.label"
+          :key="label.name"
           :class="{
             'new': isNewLabel(label),
             'updated': isUpdatedLabel(label),
@@ -95,7 +95,7 @@ function handleUndoDelete(label: ZodFlawLabelType) {
           }"
         >
           <FlawLabelTableEditingRow
-            v-if="isUpdatingLabel === label.label"
+            v-if="isUpdatingLabel === label.name"
             :buLabels="buLabels"
             :contextLabels="contextLabels"
             :initalLabel="label"
@@ -115,7 +115,7 @@ function handleUndoDelete(label: ZodFlawLabelType) {
                 'text-decoration-line-through': !label.relevant,
               }"
               :title="!label.relevant ? 'Associated affect was removed' : undefined"
-            >{{ label.label }}</td>
+            >{{ label.name }}</td>
             <td>{{ label.contributor }}</td>
             <td>
               <div class="actions">
@@ -137,7 +137,7 @@ function handleUndoDelete(label: ZodFlawLabelType) {
                     type="button"
                     title="Edit label"
                     class="btn btn-sm btn-dark"
-                    @click="isUpdatingLabel = label.label"
+                    @click="isUpdatingLabel = label.name"
                   >
                     <i class="bi bi-pencil" />
                   </button>

--- a/src/components/FlawLabels/__tests__/FlawLabelsTable.spec.ts
+++ b/src/components/FlawLabels/__tests__/FlawLabelsTable.spec.ts
@@ -20,7 +20,7 @@ vi.mock('@/services/LabelsService', () => ({
 const mountFlawLabelsTable = (props = {}) => mountWithConfig(FlawLabelsTable, {
   props: {
     modelValue: [
-      { type: FlawLabelTypeEnum.CONTEXT_BASED, label: 'test', contributor: 'skynet', state: StateEnum.New },
+      { type: FlawLabelTypeEnum.CONTEXT_BASED, name: 'test', contributor: 'skynet', state: StateEnum.New },
     ],
     ...props,
   },
@@ -43,7 +43,7 @@ describe('flawLabelsTable', () => {
     const editRow = wrapper.findComponent(FlawLabelTableEditingRow);
     editRow.vm.$emit('save', {
       type: FlawLabelTypeEnum.CONTEXT_BASED,
-      label: 'test1',
+      name: 'test1',
       contributor: 'skynet',
       state: StateEnum.New,
     });
@@ -62,7 +62,7 @@ describe('flawLabelsTable', () => {
     const editRow = wrapper.findComponent(FlawLabelTableEditingRow);
     editRow.vm.$emit('save', {
       type: FlawLabelTypeEnum.CONTEXT_BASED,
-      label: 'test1',
+      name: 'test1',
       contributor: 'skynet',
       state: StateEnum.New,
     });
@@ -93,7 +93,7 @@ describe('flawLabelsTable', () => {
     const editRow = wrapper.findComponent(FlawLabelTableEditingRow);
     editRow.vm.$emit('save', {
       type: FlawLabelTypeEnum.BU,
-      label: 'core_bu',
+      name: 'core_bu',
       contributor: '',
       state: StateEnum.New,
     });

--- a/src/components/FlawLabels/__tests__/FlawLabelsTableEditingRow.spec.ts
+++ b/src/components/FlawLabels/__tests__/FlawLabelsTableEditingRow.spec.ts
@@ -30,6 +30,6 @@ describe('flawLabelsTableEditingRow', () => {
     await wrapper.find('button[title="Save"]').trigger('click');
 
     expect(wrapper.emitted()).toHaveProperty('save');
-    expect(wrapper.emitted('save')).toEqual([[expect.objectContaining({ label: 'test' })]]);
+    expect(wrapper.emitted('save')).toEqual([[expect.objectContaining({ name: 'test' })]]);
   });
 });

--- a/src/components/FlawWorkflowState/FlawWorkflowState.vue
+++ b/src/components/FlawWorkflowState/FlawWorkflowState.vue
@@ -50,10 +50,10 @@ const shouldShowCreateJiraTaskButton = computed(
             <span v-if="workflowLabels.length" class="osim-badges-line">
               <span
                 v-for="wfLabel in workflowLabels"
-                :key="wfLabel.label"
+                :key="wfLabel.name"
                 class="badge osim-workflow-label-badge me-1"
                 title="workflow label"
-              >{{ wfLabel.label }}</span>
+              >{{ wfLabel.name }}</span>
             </span>
           </template>
           <template v-else>Legacy Flaw without Jira task</template>

--- a/src/components/IssueQueue/IssueQueueItem.vue
+++ b/src/components/IssueQueue/IssueQueueItem.vue
@@ -42,7 +42,7 @@ const sortedLabels = computed(() => issue.labels?.toSorted((a, b) => {
     return 1;
   }
 
-  return a.label.localeCompare(b.label);
+  return a.name.localeCompare(b.name);
 }) ?? []);
 
 function hashLabelColor(label: string): string {
@@ -108,11 +108,11 @@ function getLabelColor(label: string, type: string): string {
           <UnprocessedFlawLabel v-if="isFlawUnprocessed(issue)" :flaw="issue" variant="badge" />
           <template
             v-for="label in sortedLabels"
-            :key="label.label"
+            :key="label.name"
           >
             <span
               v-if="!label.contributor"
-              :style="{ backgroundColor: getLabelColor(label.label, label.type) }"
+              :style="{ backgroundColor: getLabelColor(label.name, label.type) }"
               class="badge rounded-pill border"
               :class="{
                 'text-bg-warning fw-bold border-warning': label.state == 'REQ',
@@ -120,7 +120,7 @@ function getLabelColor(label: string, type: string): string {
                 'text-decoration-line-through text-bg-gray border-secondary': !label.relevant,
               }"
               :title="label.state === 'REQ' ? 'Requested' : ''"
-            >{{ label.label }}</span>
+            >{{ label.name }}</span>
           </template>
         </template>
       </div>

--- a/src/components/__tests__/IssueQueue.spec.ts
+++ b/src/components/__tests__/IssueQueue.spec.ts
@@ -216,9 +216,9 @@ describe('issueQueue', () => {
       issues: [{
         ...mockData[0],
         labels: [
-          { label: 'test', state: 'NEW', contributor: '' },
-          { label: 'test-2', state: 'NEW', contributor: '' },
-          { label: 'test-3', state: 'REQ', contributor: '' },
+          { name: 'test', state: 'NEW', contributor: '' },
+          { name: 'test-2', state: 'NEW', contributor: '' },
+          { name: 'test-3', state: 'REQ', contributor: '' },
         ],
       } as ZodFlawType],
     });
@@ -235,8 +235,8 @@ describe('issueQueue', () => {
       issues: [{
         ...mockData[0],
         labels: [
-          { label: 'test', state: 'REQ', contributor: 'test' },
-          { label: 'test-2', state: 'NEW', contributor: 'test-2' },
+          { name: 'test', state: 'REQ', contributor: 'test' },
+          { name: 'test-2', state: 'NEW', contributor: 'test-2' },
         ],
       } as ZodFlawType],
     });
@@ -251,7 +251,7 @@ describe('issueQueue', () => {
     const wrapper = mountIssueQueue({
       issues: [{
         ...mockData[0],
-        labels: Array.from({ length: 10 }).map((_, i) => ({ label: `test-${i}`, state: 'NEW', contributor: '' })),
+        labels: Array.from({ length: 10 }).map((_, i) => ({ name: `test-${i}`, state: 'NEW', contributor: '' })),
       } as ZodFlawType],
     });
 
@@ -268,7 +268,7 @@ describe('issueQueue', () => {
     const wrapper = mountIssueQueue({
       issues: [{
         ...mockData[0],
-        labels: Array.from({ length: 10 }).map((_, i) => ({ label: `test-${i}`, state: 'NEW', contributor: '' })),
+        labels: Array.from({ length: 10 }).map((_, i) => ({ name: `test-${i}`, state: 'NEW', contributor: '' })),
       } as ZodFlawType],
     });
     const store = useSettingsStore();

--- a/src/composables/__tests__/unprocessedFlawCheck.spec.ts
+++ b/src/composables/__tests__/unprocessedFlawCheck.spec.ts
@@ -195,7 +195,7 @@ describe('useUnprocessedFlawDetection', () => {
       cve_id: 'CVE-2024-1234',
       created_dt: DateTime.now().minus({ hours: 1 }).toISO(),
       aegis_meta: null,
-      labels: [{ label: 'manual-triage', state: 'NEW', contributor: '' }],
+      labels: [{ name: 'manual-triage', state: 'NEW', contributor: '' }],
     } as ZodFlawType;
 
     expect(isFlawUnprocessed(flaw)).toBe(false);

--- a/src/composables/__tests__/useFlawLabels.spec.ts
+++ b/src/composables/__tests__/useFlawLabels.spec.ts
@@ -17,7 +17,7 @@ type UseFlawLabels = MockTypes['useFlawLabels'];
 
 describe('useFlawLabels', () => {
   const baseLabel: ZodFlawLabelType = {
-    label: 'test-label',
+    name: 'test-label',
     type: FlawLabelTypeEnum.CONTEXT_BASED,
     state: StateEnum.New,
     relevant: true,
@@ -28,7 +28,7 @@ describe('useFlawLabels', () => {
     const { useFlawLabels } = await useMocks();
     const { areLabelsUpdated, deletedLabels, labels, newLabels, updatedLabels } = useFlawLabels(initialLabels);
 
-    expect(labels.value).toEqual({ [baseLabel.label]: baseLabel });
+    expect(labels.value).toEqual({ [baseLabel.name]: baseLabel });
     expect(newLabels.value).toEqual(new Set());
     expect(updatedLabels.value).toEqual(new Set());
     expect(deletedLabels.value).toEqual(new Set());
@@ -55,17 +55,17 @@ describe('useFlawLabels', () => {
     updatedLabels.value.add('updated-label');
     deletedLabels.value.add('deleted-label');
 
-    expect(isNewLabel({ ...baseLabel, label: 'new-label' })).toBe(true);
-    expect(isUpdatedLabel({ ...baseLabel, label: 'updated-label' })).toBe(true);
-    expect(isDeletedLabel({ ...baseLabel, label: 'deleted-label' })).toBe(true);
+    expect(isNewLabel({ ...baseLabel, name: 'new-label' })).toBe(true);
+    expect(isUpdatedLabel({ ...baseLabel, name: 'updated-label' })).toBe(true);
+    expect(isDeletedLabel({ ...baseLabel, name: 'deleted-label' })).toBe(true);
   });
 
   it('updates labels correctly', async () => {
     const { useFlawLabels } = await useMocks();
     const { deletedLabels, newLabels, updatedLabels, updateLabels } = useFlawLabels([
-      { ...baseLabel, label: 'new-label' },
-      { ...baseLabel, label: 'updated-label' },
-      { ...baseLabel, label: 'deleted-label' },
+      { ...baseLabel, name: 'new-label' },
+      { ...baseLabel, name: 'updated-label' },
+      { ...baseLabel, name: 'deleted-label' },
     ]);
 
     newLabels.value.add('new-label');
@@ -74,9 +74,9 @@ describe('useFlawLabels', () => {
     const testUuid = sampleFlawRequired.uuid;
     await updateLabels();
 
-    expect(createLabel).toHaveBeenCalledWith(testUuid, { ...baseLabel, label: 'new-label' });
-    expect(updateLabel).toHaveBeenCalledWith(testUuid, { ...baseLabel, label: 'updated-label' });
-    expect(deleteLabel).toHaveBeenCalledWith(testUuid, { ...baseLabel, label: 'deleted-label' });
+    expect(createLabel).toHaveBeenCalledWith(testUuid, { ...baseLabel, name: 'new-label' });
+    expect(updateLabel).toHaveBeenCalledWith(testUuid, { ...baseLabel, name: 'updated-label' });
+    expect(deleteLabel).toHaveBeenCalledWith(testUuid, { ...baseLabel, name: 'deleted-label' });
   });
 
   it('loads context labels correctly', async () => {

--- a/src/composables/__tests__/useFlawModel.spec.ts
+++ b/src/composables/__tests__/useFlawModel.spec.ts
@@ -10,6 +10,7 @@ import sampleFlawFull from '@/__tests__/__fixtures__/sampleFlawFull.json';
 import sampleFlawRequired from '@/__tests__/__fixtures__/sampleFlawRequired.json';
 import { withSetup, router } from '@/__tests__/helpers';
 import type { ZodFlawType, ZodAffectType } from '@/types';
+import { FlawLabelTypeEnum } from '@/types/zodFlaw';
 import { postFlaw, putFlaw } from '@/services/FlawService';
 import { deepCopyFromRaw } from '@/utils/helpers';
 
@@ -214,6 +215,23 @@ describe('useFlawModel', () => {
 
       expect(flaw.value.affects[0].purl).toBe('pkg:rpm/redhat/kernel@5.14.0');
       expect(currentAffects.value[0].purl).toBe('pkg:oci/namespace/image@1.0.0');
+    });
+  });
+
+  describe('labels validation', () => {
+    it('is valid when labels omit optional fields like state and relevant', () => {
+      const { flaw, setFlaw } = useFlaw();
+      const flawData = deepCopyFromRaw(sampleFlawFull as ZodFlawType);
+
+      // OSIDB only guarantees 'uuid' and 'name'; state/relevant/contributor vary per label type.
+      flawData.labels = [{ uuid: 'uuid-1', name: 'core_bu', type: FlawLabelTypeEnum.BU }];
+      setFlaw(flawData);
+
+      const { isValid } = mountFlawModel();
+      const { initializeAffects } = useAffectsModel().actions;
+      initializeAffects(flaw.value.affects);
+
+      expect(isValid()).toBe(true);
     });
   });
 

--- a/src/composables/unprocessedFlawCheck.ts
+++ b/src/composables/unprocessedFlawCheck.ts
@@ -45,7 +45,7 @@ export function useUnprocessedFlawDetection() {
       && !!flaw.cve_id && isCveValid(flaw.cve_id)
       && !isOlderThanThreshold(flaw.created_dt)
       && areRequiredFieldsEmpty(flaw)
-      && !flaw.labels?.some(label => label.label === 'manual-triage');
+      && !flaw.labels?.some(label => label.name === 'manual-triage');
   }
 
   return {

--- a/src/composables/useFlawLabels.ts
+++ b/src/composables/useFlawLabels.ts
@@ -13,7 +13,7 @@ const deletedLabels = ref<Set<string>>(new Set<string>());
 function initLabels(labelArray: null | undefined | ZodFlawLabelType[]) {
   labels.value = Array.isArray(labelArray)
     ? labelArray.reduce((acc: Record<string, ZodFlawLabelType>, label) => {
-      acc[label.label] = label;
+      acc[label.name] = label;
       return acc;
     }, {})
     : {};
@@ -35,9 +35,9 @@ export function useFlawLabels(initialLabels?: MaybeRef<ZodFlawLabelType[]>) {
     newLabels.value.size > 0 || updatedLabels.value.size > 0 || deletedLabels.value.size > 0,
   );
 
-  const isNewLabel = (label: ZodFlawLabelType) => newLabels.value.has(label.label);
-  const isUpdatedLabel = (label: ZodFlawLabelType) => updatedLabels.value.has(label.label);
-  const isDeletedLabel = (label: ZodFlawLabelType) => deletedLabels.value.has(label.label);
+  const isNewLabel = (label: ZodFlawLabelType) => newLabels.value.has(label.name);
+  const isUpdatedLabel = (label: ZodFlawLabelType) => updatedLabels.value.has(label.name);
+  const isDeletedLabel = (label: ZodFlawLabelType) => deletedLabels.value.has(label.name);
 
   const updateLabels = async () => {
     if (!flaw.value) {

--- a/src/mock-server/handlers.js
+++ b/src/mock-server/handlers.js
@@ -188,35 +188,35 @@ export const handlers = [
 
     return HttpResponse.json(...resultArray[next() % resultArray.length]);
   }),
-  http.get(`${baseURL}/osidb/api/v1/flaws/*/labels`, async () => {
+  http.get(`${baseURL}/osidb/api/v2/flaws/*/labels`, async () => {
     const resultArray = [
       [await getOsidbApiV1FlawsLabelsList200Response(), { status: 200 }],
     ];
 
     return HttpResponse.json(...resultArray[next() % resultArray.length]);
   }),
-  http.post(`${baseURL}/osidb/api/v1/flaws/*/labels`, async () => {
+  http.post(`${baseURL}/osidb/api/v2/flaws/*/labels`, async () => {
     const resultArray = [
       [await getOsidbApiV1FlawsLabelsCreate201Response(), { status: 201 }],
     ];
 
     return HttpResponse.json(...resultArray[next() % resultArray.length]);
   }),
-  http.get(`${baseURL}/osidb/api/v1/flaws/*/labels/*`, async () => {
+  http.get(`${baseURL}/osidb/api/v2/flaws/*/labels/*`, async () => {
     const resultArray = [
       [await getOsidbApiV1FlawsLabelsRetrieve200Response(), { status: 200 }],
     ];
 
     return HttpResponse.json(...resultArray[next() % resultArray.length]);
   }),
-  http.put(`${baseURL}/osidb/api/v1/flaws/*/labels/*`, async () => {
+  http.put(`${baseURL}/osidb/api/v2/flaws/*/labels/*`, async () => {
     const resultArray = [
       [await getOsidbApiV1FlawsLabelsUpdate200Response(), { status: 200 }],
     ];
 
     return HttpResponse.json(...resultArray[next() % resultArray.length]);
   }),
-  http.delete(`${baseURL}/osidb/api/v1/flaws/*/labels/*`, async () => {
+  http.delete(`${baseURL}/osidb/api/v2/flaws/*/labels/*`, async () => {
     const resultArray = [[undefined, { status: 204 }]];
 
     return HttpResponse.json(...resultArray[next() % resultArray.length]);
@@ -1011,7 +1011,7 @@ export function getOsidbApiV1FlawsList200Response() {
         ).keys(),
       ].map((_) => ({
         uuid: faker.string.uuid(),
-        label: faker.string.alpha({ length: { min: 0, max: 255 } }),
+        name: faker.string.alpha({ length: { min: 0, max: 255 } }),
         state: faker.helpers.arrayElement(["NEW", "REQ", "SKIP", "DONE"]),
         contributor: faker.string.alpha({ length: { min: 0, max: 255 } }),
         relevant: faker.datatype.boolean(),
@@ -1467,7 +1467,7 @@ export function getOsidbApiV1FlawsCreate201Response() {
       ...new Array(faker.number.int({ min: 1, max: MAX_ARRAY_LENGTH })).keys(),
     ].map((_) => ({
       uuid: faker.string.uuid(),
-      label: faker.string.alpha({ length: { min: 0, max: 255 } }),
+      name: faker.string.alpha({ length: { min: 0, max: 255 } }),
       state: faker.helpers.arrayElement(["NEW", "REQ", "SKIP", "DONE"]),
       contributor: faker.string.alpha({ length: { min: 0, max: 255 } }),
       relevant: faker.datatype.boolean(),
@@ -1889,7 +1889,7 @@ export function getOsidbApiV1FlawsLabelsList200Response() {
       ...new Array(faker.number.int({ min: 1, max: MAX_ARRAY_LENGTH })).keys(),
     ].map((_) => ({
       uuid: faker.string.uuid(),
-      label: faker.string.alpha({ length: { min: 0, max: 255 } }),
+      name: faker.string.alpha({ length: { min: 0, max: 255 } }),
       state: faker.helpers.arrayElement(["NEW", "REQ", "SKIP", "DONE"]),
       contributor: faker.string.alpha({ length: { min: 0, max: 255 } }),
       relevant: faker.datatype.boolean(),
@@ -1905,7 +1905,7 @@ export function getOsidbApiV1FlawsLabelsList200Response() {
 export function getOsidbApiV1FlawsLabelsCreate201Response() {
   return {
     uuid: faker.string.uuid(),
-    label: faker.string.alpha({ length: { min: 0, max: 255 } }),
+    name: faker.string.alpha({ length: { min: 0, max: 255 } }),
     state: faker.helpers.arrayElement(["NEW", "REQ", "SKIP", "DONE"]),
     contributor: faker.string.alpha({ length: { min: 0, max: 255 } }),
     relevant: faker.datatype.boolean(),
@@ -1920,7 +1920,7 @@ export function getOsidbApiV1FlawsLabelsCreate201Response() {
 export function getOsidbApiV1FlawsLabelsRetrieve200Response() {
   return {
     uuid: faker.string.uuid(),
-    label: faker.string.alpha({ length: { min: 0, max: 255 } }),
+    name: faker.string.alpha({ length: { min: 0, max: 255 } }),
     state: faker.helpers.arrayElement(["NEW", "REQ", "SKIP", "DONE"]),
     contributor: faker.string.alpha({ length: { min: 0, max: 255 } }),
     relevant: faker.datatype.boolean(),
@@ -1935,7 +1935,7 @@ export function getOsidbApiV1FlawsLabelsRetrieve200Response() {
 export function getOsidbApiV1FlawsLabelsUpdate200Response() {
   return {
     uuid: faker.string.uuid(),
-    label: faker.string.alpha({ length: { min: 0, max: 255 } }),
+    name: faker.string.alpha({ length: { min: 0, max: 255 } }),
     state: faker.helpers.arrayElement(["NEW", "REQ", "SKIP", "DONE"]),
     contributor: faker.string.alpha({ length: { min: 0, max: 255 } }),
     relevant: faker.datatype.boolean(),
@@ -2693,7 +2693,7 @@ export function getOsidbApiV1FlawsRetrieve200Response() {
       ...new Array(faker.number.int({ min: 1, max: MAX_ARRAY_LENGTH })).keys(),
     ].map((_) => ({
       uuid: faker.string.uuid(),
-      label: faker.string.alpha({ length: { min: 0, max: 255 } }),
+      name: faker.string.alpha({ length: { min: 0, max: 255 } }),
       state: faker.helpers.arrayElement(["NEW", "REQ", "SKIP", "DONE"]),
       contributor: faker.string.alpha({ length: { min: 0, max: 255 } }),
       relevant: faker.datatype.boolean(),
@@ -3189,7 +3189,7 @@ export function getOsidbApiV1FlawsUpdate200Response() {
       ...new Array(faker.number.int({ min: 1, max: MAX_ARRAY_LENGTH })).keys(),
     ].map((_) => ({
       uuid: faker.string.uuid(),
-      label: faker.string.alpha({ length: { min: 0, max: 255 } }),
+      name: faker.string.alpha({ length: { min: 0, max: 255 } }),
       state: faker.helpers.arrayElement(["NEW", "REQ", "SKIP", "DONE"]),
       contributor: faker.string.alpha({ length: { min: 0, max: 255 } }),
       relevant: faker.datatype.boolean(),
@@ -3894,7 +3894,7 @@ export function getOsidbApiV2FlawsList200Response() {
         ).keys(),
       ].map((_) => ({
         uuid: faker.string.uuid(),
-        label: faker.string.alpha({ length: { min: 0, max: 255 } }),
+        name: faker.string.alpha({ length: { min: 0, max: 255 } }),
         state: faker.helpers.arrayElement(["NEW", "REQ", "SKIP", "DONE"]),
         contributor: faker.string.alpha({ length: { min: 0, max: 255 } }),
         relevant: faker.datatype.boolean(),
@@ -4393,7 +4393,7 @@ export function getOsidbApiV2FlawsCreate201Response() {
       ...new Array(faker.number.int({ min: 1, max: MAX_ARRAY_LENGTH })).keys(),
     ].map((_) => ({
       uuid: faker.string.uuid(),
-      label: faker.string.alpha({ length: { min: 0, max: 255 } }),
+      name: faker.string.alpha({ length: { min: 0, max: 255 } }),
       state: faker.helpers.arrayElement(["NEW", "REQ", "SKIP", "DONE"]),
       contributor: faker.string.alpha({ length: { min: 0, max: 255 } }),
       relevant: faker.datatype.boolean(),
@@ -5033,7 +5033,7 @@ export function getOsidbApiV2FlawsRetrieve200Response() {
       ...new Array(faker.number.int({ min: 1, max: MAX_ARRAY_LENGTH })).keys(),
     ].map((_) => ({
       uuid: faker.string.uuid(),
-      label: faker.string.alpha({ length: { min: 0, max: 255 } }),
+      name: faker.string.alpha({ length: { min: 0, max: 255 } }),
       state: faker.helpers.arrayElement(["NEW", "REQ", "SKIP", "DONE"]),
       contributor: faker.string.alpha({ length: { min: 0, max: 255 } }),
       relevant: faker.datatype.boolean(),
@@ -5529,7 +5529,7 @@ export function getOsidbApiV2FlawsUpdate200Response() {
       ...new Array(faker.number.int({ min: 1, max: MAX_ARRAY_LENGTH })).keys(),
     ].map((_) => ({
       uuid: faker.string.uuid(),
-      label: faker.string.alpha({ length: { min: 0, max: 255 } }),
+      name: faker.string.alpha({ length: { min: 0, max: 255 } }),
       state: faker.helpers.arrayElement(["NEW", "REQ", "SKIP", "DONE"]),
       contributor: faker.string.alpha({ length: { min: 0, max: 255 } }),
       relevant: faker.datatype.boolean(),

--- a/src/services/LabelsService.ts
+++ b/src/services/LabelsService.ts
@@ -22,28 +22,38 @@ export async function fetchLabels() {
 export async function createLabel(flawUUID: string, label: ZodFlawLabelType) {
   return osidbFetch({
     method: 'post',
-    url: `/osidb/api/v1/flaws/${flawUUID}/labels`,
+    url: `/osidb/api/v2/flaws/${flawUUID}/labels`,
     data: label,
   })
-    .then(createSuccessHandler({ title: 'Success!', body: `Label ${label.label} created.` }))
-    .catch(createCatchHandler(`Error creating label ${label.label}`));
+    .then(createSuccessHandler({ title: 'Success!', body: `Label ${label.name} created.` }))
+    .catch(createCatchHandler(`Error creating label ${label.name}`));
 }
 
 export async function deleteLabel(flawUUID: string, label: ZodFlawLabelType) {
+  if (!label.uuid) {
+    return Promise.reject(new Error(`Label ${label.name} is missing a UUID`))
+      .catch(createCatchHandler(`Error deleting label ${label.name}`));
+  }
+
   return osidbFetch({
     method: 'delete',
-    url: `/osidb/api/v1/flaws/${flawUUID}/labels/${label.uuid}`,
+    url: `/osidb/api/v2/flaws/${flawUUID}/labels/${label.uuid}`,
   })
-    .then(createSuccessHandler({ title: 'Success!', body: `Label ${label.label} deleted.` }))
-    .catch(createCatchHandler(`Error deleting label ${label.label}`));
+    .then(createSuccessHandler({ title: 'Success!', body: `Label ${label.name} deleted.` }))
+    .catch(createCatchHandler(`Error deleting label ${label.name}`));
 }
 
 export async function updateLabel(flawUUID: string, label: ZodFlawLabelType) {
+  if (!label.uuid) {
+    return Promise.reject(new Error(`Label ${label.name} is missing a UUID`))
+      .catch(createCatchHandler(`Error updating label ${label.name}`));
+  }
+
   return osidbFetch({
     method: 'put',
-    url: `/osidb/api/v1/flaws/${flawUUID}/labels/${label.uuid}`,
+    url: `/osidb/api/v2/flaws/${flawUUID}/labels/${label.uuid}`,
     data: label,
   })
-    .then(createSuccessHandler({ title: 'Success!', body: `Label ${label.label} updated.` }))
-    .catch(createCatchHandler(`Error updating label ${label.label}`));
+    .then(createSuccessHandler({ title: 'Success!', body: `Label ${label.name} updated.` }))
+    .catch(createCatchHandler(`Error updating label ${label.name}`));
 }

--- a/src/services/__tests__/LabelsService.spec.ts
+++ b/src/services/__tests__/LabelsService.spec.ts
@@ -31,7 +31,7 @@ describe('labelsService', () => {
   it('can create a label', async () => {
     const flawUUID = '123';
     const label: ZodFlawLabelType = {
-      label: 'test create',
+      name: 'test create',
       state: StateEnum.New,
       type: FlawLabelTypeEnum.CONTEXT_BASED,
       relevant: true,
@@ -44,7 +44,8 @@ describe('labelsService', () => {
   it('can update a label', async () => {
     const flawUUID = '123';
     const label: ZodFlawLabelType = {
-      label: 'test update',
+      uuid: 'test-uuid',
+      name: 'test update',
       state: StateEnum.New,
       type: FlawLabelTypeEnum.CONTEXT_BASED,
       relevant: true,
@@ -57,7 +58,8 @@ describe('labelsService', () => {
   it('can delete a label', async () => {
     const flawUUID = '123';
     const label: ZodFlawLabelType = {
-      label: 'test delete',
+      uuid: 'test-uuid',
+      name: 'test delete',
       state: StateEnum.New,
       type: FlawLabelTypeEnum.CONTEXT_BASED,
       relevant: true,
@@ -67,10 +69,24 @@ describe('labelsService', () => {
     await expect(deleteLabel(flawUUID, label)).resolves.not.toBeUndefined();
   });
 
+  it('rejects updating/deleting a label without a uuid instead of hitting the API', async () => {
+    const flawUUID = '123';
+    const label: ZodFlawLabelType = {
+      name: 'no uuid',
+      state: StateEnum.New,
+      type: FlawLabelTypeEnum.CONTEXT_BASED,
+      relevant: true,
+      contributor: '',
+    };
+
+    await expect(updateLabel(flawUUID, label)).rejects.toThrow('missing a UUID');
+    await expect(deleteLabel(flawUUID, label)).rejects.toThrow('missing a UUID');
+  });
+
   it('handles errors when creating a label', async () => {
     const flawUUID = '123';
     const label: ZodFlawLabelType = {
-      label: 'test error',
+      name: 'test error',
       state: StateEnum.New,
       type: FlawLabelTypeEnum.CONTEXT_BASED,
       relevant: true,
@@ -79,7 +95,7 @@ describe('labelsService', () => {
 
     server.use(
       http.post(
-        `${osimRuntime.value.backends.osidb}/osidb/api/v1/flaws/${flawUUID}/labels`, () => {
+        `${osimRuntime.value.backends.osidb}/osidb/api/v2/flaws/${flawUUID}/labels`, () => {
           return HttpResponse.text('Error', { status: 500 });
         },
         { once: true },
@@ -92,7 +108,8 @@ describe('labelsService', () => {
   it('handles errors when updating a label', async () => {
     const flawUUID = '123';
     const label: ZodFlawLabelType = {
-      label: 'test error',
+      uuid: 'test-uuid',
+      name: 'test error',
       state: StateEnum.New,
       type: FlawLabelTypeEnum.CONTEXT_BASED,
       relevant: true,
@@ -101,7 +118,7 @@ describe('labelsService', () => {
 
     server.use(
       http.put(
-        `${osimRuntime.value.backends.osidb}/osidb/api/v1/flaws/${flawUUID}/labels/${label.uuid}`, () => {
+        `${osimRuntime.value.backends.osidb}/osidb/api/v2/flaws/${flawUUID}/labels/${label.uuid}`, () => {
           return HttpResponse.text('Error', { status: 500 });
         },
         { once: true },
@@ -114,7 +131,8 @@ describe('labelsService', () => {
   it('handles errors when deleting a label', async () => {
     const flawUUID = '123';
     const label: ZodFlawLabelType = {
-      label: 'test error',
+      uuid: 'test-uuid',
+      name: 'test error',
       state: StateEnum.New,
       type: FlawLabelTypeEnum.CONTEXT_BASED,
       relevant: true,
@@ -123,7 +141,7 @@ describe('labelsService', () => {
 
     server.use(
       http.delete(
-        `${osimRuntime.value.backends.osidb}/osidb/api/v1/flaws/${flawUUID}/labels/${label.uuid}`, () => {
+        `${osimRuntime.value.backends.osidb}/osidb/api/v2/flaws/${flawUUID}/labels/${label.uuid}`, () => {
           return HttpResponse.text('Error', { status: 500 });
         },
         { once: true },

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -222,7 +222,7 @@ export const ZodFlawSchema = z.object({
   srp_overdue_milestones: z.number().nullish(), // read-only
   labels: z.array(z.object({
     uuid: z.string().optional(),
-    label: z.string(),
+    name: z.string(),
     state: z.nativeEnum(StateEnum),
     contributor: z.string().optional(),
     relevant: z.boolean(),

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -223,9 +223,10 @@ export const ZodFlawSchema = z.object({
   labels: z.array(z.object({
     uuid: z.string().optional(),
     name: z.string(),
-    state: z.nativeEnum(StateEnum),
+    // Only 'name' and 'uuid' are guaranteed by OSIDB; the rest vary per label type.
+    state: z.nativeEnum(StateEnum).optional(),
     contributor: z.string().optional(),
-    relevant: z.boolean(),
+    relevant: z.boolean().optional(),
     type: z.nativeEnum(FlawLabelTypeEnum),
   })).nullish(),
   references: z.array(FlawReferenceSchema),


### PR DESCRIPTION
## Checklist:

- [x] Commits consolidated
- [ ] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated

## Summary:

OSIDB's latest release split the flaw-labels model in two: the current `Flaw`/`FlawPut` (v2) schema embeds `labels: FlawLabel[]` keyed by `name`, while the old per-flaw label endpoints (`/osidb/api/v1/flaws/{id}/labels`, `/osidb/api/v1/labels`) are now deprecated and back a different model, `FlawCollaborator`, keyed by `label`. OSIM still read/wrote labels using the `label` field and called the deprecated v1 CRUD endpoints, so label names rendered as `undefined` and any create/update/delete went to the wrong (deprecated) resource.

## Changes:

- `LabelsService`: point create/update/delete at `/osidb/api/v2/flaws/{id}/labels`.
- `zodFlaw`, `useFlawLabels`, `FlawLabelsTable`, `FlawLabelTableEditingRow`, `FlawWorkflowState`, `IssueQueueItem`, `unprocessedFlawCheck`: rename the label name field from `label` to `name` to match the v2 `FlawLabel` schema.
- mock-server handlers: match the v2 label routes and use `name` in fixtures.
- `LabelsService.updateLabel`/`deleteLabel`: guard against a missing `uuid` (e.g. a label edited/deleted before its create request resolves) so we never issue a request to `.../labels/undefined`; routed through the existing error handler.

## Considerations:

- `fetchLabels()` still calls the deprecated `/osidb/api/v1/labels` registry endpoint; left as-is since its response shape (`name`/`type`) is still compatible and there's no v2 replacement in the current schema yet.
- The generated OpenAPI client (`openapi-osidb.yml`) was not regenerated (still v4.16 vs backend's v5.14) — out of scope for this fix, worth a separate follow-up.

Assisted-By: Claude Sonnet 5 