### PR TITLE
Hotfix/flaw labels v2 review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 ### Fixed
 * Remove `affects` from flaw list/search `include_fields` to improve Advanced Search performance (`OSIDB-5314`)
+* Fix flaw labels for OSIDB v2 API (label names rendering as `undefined`, create/update/delete hitting deprecated endpoints, unsaved/failed edits being silently discarded, duplicate issue queue label badge keys) (`OSIDB-5349`)
 
 ## [2026.8.0]
 ### Added

--- a/src/components/FlawLabels/FlawLabelsContributor.vue
+++ b/src/components/FlawLabels/FlawLabelsContributor.vue
@@ -60,9 +60,7 @@ const handleSuggestionClick = (user: ZodJiraUserAssignableType) => {
 };
 
 const onBlur = () => {
-  if (contributor.value === '') {
-    modelValue.value = '';
-  }
+  modelValue.value = contributor.value;
 };
 
 watchDebounced(contributor, onQueryChange, { debounce: 300 });

--- a/src/components/FlawLabels/FlawLabelsTable.vue
+++ b/src/components/FlawLabels/FlawLabelsTable.vue
@@ -49,7 +49,11 @@ function handleNewLabel(label: ZodFlawLabelType) {
 }
 
 function handleUpdateLabel(label: ZodFlawLabelType) {
-  updatedLabels.value.add(label.name);
+  // a label that hasn't been created yet only needs its local value refreshed;
+  // marking it "updated" too would queue a redundant update request with no uuid
+  if (!newLabels.value.has(label.name)) {
+    updatedLabels.value.add(label.name);
+  }
   labels.value[label.name] = label;
   isUpdatingLabel.value = undefined;
 }

--- a/src/components/FlawLabels/__tests__/FlawLabelsContributor.spec.ts
+++ b/src/components/FlawLabels/__tests__/FlawLabelsContributor.spec.ts
@@ -74,13 +74,13 @@ describe('flawLabelsContributor', () => {
     expect(wrapper.props('modelValue')).toBe('skynet@example.com');
   });
 
-  it('should not allow arbitrary input', async () => {
+  it('should persist typed input that was not selected from suggestions on blur', async () => {
     const wrapper = mountFlawLabelsContributor({ modelValue: 'skynet' });
 
     await wrapper.find('input').setValue('not-skynet');
     await wrapper.find('input').trigger('blur');
 
-    expect(wrapper.props('modelValue')).toBe('skynet');
+    expect(wrapper.props('modelValue')).toBe('not-skynet');
   });
 
   it('should allow empty input', async () => {

--- a/src/components/FlawLabels/__tests__/FlawLabelsTable.spec.ts
+++ b/src/components/FlawLabels/__tests__/FlawLabelsTable.spec.ts
@@ -72,6 +72,39 @@ describe('flawLabelsTable', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
+  it('should not queue a redundant update for a still-unsaved new label', async () => {
+    const wrapper = mountFlawLabelsTable();
+    const { newLabels, updatedLabels } = useFlawLabels();
+    await flushPromises();
+
+    await wrapper.find('.table-new-row td').trigger('click');
+    let editRow = wrapper.findComponent(FlawLabelTableEditingRow);
+    editRow.vm.$emit('save', {
+      type: FlawLabelTypeEnum.CONTEXT_BASED,
+      name: 'test1',
+      contributor: 'skynet',
+      state: StateEnum.New,
+    });
+    await flushPromises();
+
+    expect(newLabels.value.has('test1')).toBe(true);
+
+    // edit the same label before it has ever been persisted (no uuid yet)
+    const newRow = wrapper.findAll('tbody tr').find(row => row.text().includes('test1'))!;
+    await newRow.find('button[title="Edit label"]').trigger('click');
+    editRow = wrapper.findComponent(FlawLabelTableEditingRow);
+    editRow.vm.$emit('save', {
+      type: FlawLabelTypeEnum.CONTEXT_BASED,
+      name: 'test1',
+      contributor: 'agent-smith',
+      state: StateEnum.New,
+    });
+    await flushPromises();
+
+    expect(newLabels.value.has('test1')).toBe(true);
+    expect(updatedLabels.value.has('test1')).toBe(false);
+  });
+
   it('should handle delete label', async () => {
     const wrapper = mountFlawLabelsTable();
     const { areLabelsUpdated } = useFlawLabels();

--- a/src/components/FlawLabels/__tests__/FlawLabelsTableEditingRow.spec.ts
+++ b/src/components/FlawLabels/__tests__/FlawLabelsTableEditingRow.spec.ts
@@ -1,4 +1,6 @@
 import { mountWithConfig } from '@/__tests__/helpers';
+import { FlawLabelTypeEnum } from '@/types/zodFlaw';
+import { StateEnum } from '@/generated-client';
 
 import FlawLabelTableEditingRow from '../FlawLabelTableEditingRow.vue';
 
@@ -31,5 +33,26 @@ describe('flawLabelsTableEditingRow', () => {
 
     expect(wrapper.emitted()).toHaveProperty('save');
     expect(wrapper.emitted('save')).toEqual([[expect.objectContaining({ name: 'test' })]]);
+  });
+
+  it('should save an updated contributor instead of reverting it', async () => {
+    const wrapper = mountWithConfig(FlawLabelTableEditingRow, {
+      props: {
+        initalLabel: {
+          type: FlawLabelTypeEnum.CONTEXT_BASED,
+          name: 'test',
+          contributor: 'skynet',
+          state: StateEnum.New,
+        },
+      },
+    });
+
+    await wrapper.find('input').setValue('agent-smith');
+    await wrapper.find('input').trigger('blur');
+    await wrapper.find('button[title="Save"]').trigger('click');
+
+    expect(wrapper.emitted()).not.toHaveProperty('cancel');
+    expect(wrapper.emitted()).toHaveProperty('save');
+    expect(wrapper.emitted('save')).toEqual([[expect.objectContaining({ contributor: 'agent-smith' })]]);
   });
 });

--- a/src/components/IssueQueue/IssueQueueItem.vue
+++ b/src/components/IssueQueue/IssueQueueItem.vue
@@ -108,7 +108,7 @@ function getLabelColor(label: string, type: string): string {
           <UnprocessedFlawLabel v-if="isFlawUnprocessed(issue)" :flaw="issue" variant="badge" />
           <template
             v-for="label in sortedLabels"
-            :key="label.name"
+            :key="`${label.name}-${label.contributor ?? ''}`"
           >
             <span
               v-if="!label.contributor"

--- a/src/composables/__tests__/useFlawLabels.spec.ts
+++ b/src/composables/__tests__/useFlawLabels.spec.ts
@@ -79,6 +79,31 @@ describe('useFlawLabels', () => {
     expect(deleteLabel).toHaveBeenCalledWith(testUuid, { ...baseLabel, name: 'deleted-label' });
   });
 
+  it('reports hasErrors and only prunes the labels that settled successfully', async () => {
+    const { useFlawLabels } = await useMocks();
+    const { deletedLabels, labels, newLabels, updatedLabels, updateLabels } = useFlawLabels([
+      { ...baseLabel, name: 'new-label' },
+      { ...baseLabel, name: 'updated-label' },
+      { ...baseLabel, name: 'deleted-label' },
+    ]);
+
+    newLabels.value.add('new-label');
+    updatedLabels.value.add('updated-label');
+    deletedLabels.value.add('deleted-label');
+
+    vi.mocked(createLabel).mockResolvedValueOnce(undefined);
+    vi.mocked(updateLabel).mockRejectedValueOnce(new Error('boom'));
+    vi.mocked(deleteLabel).mockResolvedValueOnce(undefined);
+
+    const result = await updateLabels();
+
+    expect(result).toEqual({ hasErrors: true });
+    expect(newLabels.value.has('new-label')).toBe(false);
+    expect(updatedLabels.value.has('updated-label')).toBe(true);
+    expect(deletedLabels.value.has('deleted-label')).toBe(false);
+    expect(labels.value['deleted-label']).toBeUndefined();
+  });
+
   it('loads context labels correctly', async () => {
     const { useFlawLabels } = await useMocks();
     const { loadContextLabels } = useFlawLabels();

--- a/src/composables/useFlawLabels.ts
+++ b/src/composables/useFlawLabels.ts
@@ -41,23 +41,46 @@ export function useFlawLabels(initialLabels?: MaybeRef<ZodFlawLabelType[]>) {
 
   const updateLabels = async () => {
     if (!flaw.value) {
-      return;
+      return { hasErrors: false };
     }
 
-    const requests = [];
+    const operations: { onSuccess: () => void; request: Promise<unknown> }[] = [];
     for (const newLabel of newLabels.value) {
-      requests.push(createLabel(flaw.value.uuid, labels.value[newLabel]));
+      operations.push({
+        request: createLabel(flaw.value.uuid, labels.value[newLabel]),
+        onSuccess: () => newLabels.value.delete(newLabel),
+      });
     }
 
     for (const updatedLabel of updatedLabels.value) {
-      requests.push(updateLabel(flaw.value.uuid, labels.value[updatedLabel]));
+      operations.push({
+        request: updateLabel(flaw.value.uuid, labels.value[updatedLabel]),
+        onSuccess: () => updatedLabels.value.delete(updatedLabel),
+      });
     }
 
     for (const deletedLabel of deletedLabels.value) {
-      requests.push(deleteLabel(flaw.value.uuid, labels.value[deletedLabel]));
+      operations.push({
+        request: deleteLabel(flaw.value.uuid, labels.value[deletedLabel]),
+        onSuccess: () => {
+          deletedLabels.value.delete(deletedLabel);
+          delete labels.value[deletedLabel];
+        },
+      });
     }
 
-    return await Promise.allSettled(requests);
+    const settled = await Promise.allSettled(operations.map(({ request }) => request));
+
+    let hasErrors = false;
+    settled.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        operations[index].onSuccess();
+      } else {
+        hasErrors = true;
+      }
+    });
+
+    return { hasErrors };
   };
 
   return {

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -328,13 +328,16 @@ export function useFlawModel() {
 
     if (areLabelsUpdated.value) {
       queue.push(async () => {
-        const response = await updateLabels();
-        if (response && Array.isArray(response)) {
-          // Re-fetch the full flaw so side-effects on the backend (e.g. classification.state
-          // changing to DONE when approved/rejected label is added) are reflected immediately.
-          const updatedFlaw = await getFlaw(flaw.value.uuid, true);
-          afterSuccessQueue.push(() => setFlaw({ ...updatedFlaw, affects: flaw.value.affects }));
-        }
+        const { hasErrors } = await updateLabels();
+        // Re-fetch the full flaw so side-effects on the backend (e.g. classification.state
+        // changing to DONE when approved/rejected label is added) are reflected immediately.
+        const updatedFlaw = await getFlaw(flaw.value.uuid, true);
+        afterSuccessQueue.push(() => setFlaw({
+          ...updatedFlaw,
+          affects: flaw.value.affects,
+          // On partial failure, keep the local labels so unsaved/failed edits stay queued for retry
+          ...(hasErrors ? { labels: flaw.value.labels } : {}),
+        }));
       });
     }
 

--- a/src/services/LabelsService.ts
+++ b/src/services/LabelsService.ts
@@ -19,6 +19,15 @@ export async function fetchLabels() {
   }
 }
 
+function assertLabelUuid(
+  label: ZodFlawLabelType,
+  action: 'deleting' | 'updating',
+): asserts label is { uuid: string } & ZodFlawLabelType {
+  if (!label.uuid) {
+    createCatchHandler(`Error ${action} label ${label.name}`)(new Error(`Label ${label.name} is missing a UUID`));
+  }
+}
+
 export async function createLabel(flawUUID: string, label: ZodFlawLabelType) {
   return osidbFetch({
     method: 'post',
@@ -30,10 +39,7 @@ export async function createLabel(flawUUID: string, label: ZodFlawLabelType) {
 }
 
 export async function deleteLabel(flawUUID: string, label: ZodFlawLabelType) {
-  if (!label.uuid) {
-    return Promise.reject(new Error(`Label ${label.name} is missing a UUID`))
-      .catch(createCatchHandler(`Error deleting label ${label.name}`));
-  }
+  assertLabelUuid(label, 'deleting');
 
   return osidbFetch({
     method: 'delete',
@@ -44,10 +50,7 @@ export async function deleteLabel(flawUUID: string, label: ZodFlawLabelType) {
 }
 
 export async function updateLabel(flawUUID: string, label: ZodFlawLabelType) {
-  if (!label.uuid) {
-    return Promise.reject(new Error(`Label ${label.name} is missing a UUID`))
-      .catch(createCatchHandler(`Error updating label ${label.name}`));
-  }
+  assertLabelUuid(label, 'updating');
 
   return osidbFetch({
     method: 'put',

--- a/src/services/__tests__/LabelsService.spec.ts
+++ b/src/services/__tests__/LabelsService.spec.ts
@@ -1,6 +1,8 @@
 import { createTestingPinia } from '@pinia/testing';
 import { http, HttpResponse } from 'msw';
 
+import { createCatchHandler } from '@/composables/service-helpers';
+
 import { server } from '@/__tests__/setup';
 import { FlawLabelTypeEnum, type ZodFlawLabelType } from '@/types/zodFlaw';
 import { StateEnum } from '@/generated-client';
@@ -9,7 +11,22 @@ import { handlers } from '@/mock-server/handlers';
 
 import { createLabel, deleteLabel, fetchLabels, updateLabel } from '../LabelsService';
 
-vi.mock('@/composables/service-helpers');
+function passThroughResponse(response: unknown) {
+  return response;
+}
+
+// Mirrors the real createCatchHandler's default (shouldThrow: true) so rejections still
+// propagate, while letting assertions confirm the error actually routed through the handler.
+function rethrowIfShouldThrow(_title: string, shouldThrow = true) {
+  return (error: unknown) => {
+    if (shouldThrow) throw error;
+  };
+}
+
+vi.mock('@/composables/service-helpers', () => ({
+  createSuccessHandler: vi.fn(() => passThroughResponse),
+  createCatchHandler: vi.fn(rethrowIfShouldThrow),
+}));
 
 describe('labelsService', () => {
   beforeAll(() => {
@@ -80,7 +97,10 @@ describe('labelsService', () => {
     };
 
     await expect(updateLabel(flawUUID, label)).rejects.toThrow('missing a UUID');
+    expect(createCatchHandler).toHaveBeenCalledWith('Error updating label no uuid');
+
     await expect(deleteLabel(flawUUID, label)).rejects.toThrow('missing a UUID');
+    expect(createCatchHandler).toHaveBeenCalledWith('Error deleting label no uuid');
   });
 
   it('handles errors when creating a label', async () => {


### PR DESCRIPTION
 # [OSIDB-ID] Fix flaw label pending-state and key-collision bugs

  ## Checklist:

  - [x] Commits consolidated
  - [x] Changelog updated
  - [x] Test cases added/updated
  - [ ] Integration tests updated

  ## Summary:

  Follow-up fixes for the flaw labels v2 API migration (PR #828): editing an unsaved label queued a
  redundant/erroring update, failed label writes silently lost their pending state instead of staying
  queued for retry, and the issue queue could hit duplicate Vue keys for same-name labels with different
  contributors.

  ## Changes:

  - **`FlawLabelsTable.vue`**: `handleUpdateLabel` no longer marks a still-unsaved (`newLabels`) label as
  `updated`, preventing a redundant `updateLabel` request that was rejected for missing a uuid and showed
  a spurious error toast.
  - **`useFlawLabels.ts`**: `updateLabels()` now tracks per-operation success individually and only clears
  the `newLabels`/`updatedLabels`/`deletedLabels` entries that actually succeeded, returning `{ hasErrors
  }` instead of the raw `Promise.allSettled` array.
  - **`useFlawModel.ts`**: consumes `{ hasErrors }` from `updateLabels()` and preserves the local
  `flaw.value.labels` reference across the post-save refetch when there were errors, so failed edits stay
  queued for retry instead of being wiped out (mirrors the existing `affects` handling in the same
  function).
  - **`IssueQueueItem.vue`**: badge `v-for` now keys on `name` + `contributor` instead of `name` alone,
  since two labels can share a name with different contributors.
  - **`LabelsService.ts`**: extracted the duplicated missing-uuid check in `updateLabel`/`deleteLabel`
  into a shared `assertLabelUuid` helper, dropping the unnecessary `Promise.reject().catch()` indirection.
  - **`LabelsService.spec.ts`**: replaced the blanket `vi.mock('@/composables/service-helpers')` (which
  made `createCatchHandler` silently return `undefined`, letting rejection tests pass via
  `.catch(undefined)` passthrough rather than exercising the real handler) with a factory mock that
  mirrors the real throw-by-default behavior, and added assertions that the handler is actually invoked.
  - Added regression tests in `FlawLabelsTable.spec.ts` and `useFlawLabels.spec.ts` covering the fixed
  scenarios.

  ## Considerations:

  - The v2 `/osidb/api/v2/flaws/{uuid}/labels` endpoint used by `LabelsService.ts` isn't yet reflected in
  the checked-in `openapi-osidb.yml`/generated client — only the mock server was hand-patched for it.
  Worth confirming the spec gets regenerated once the backend change is confirmed live, or CI could mask a
  real 404.
  - Did not change the `labels` `Record` keying (by `name` only) in `useFlawLabels.ts` — only patched the
  safe symptom (Vue key) in `IssueQueueItem.vue`, since I couldn't confirm same-name/different-contributor
  labels are actually possible on a real flaw.
