### PR TITLE
✨ Hide bot processing badges in flaw lists for flaws with manual workflow

### DIFF
--- a/src/composables/__tests__/unprocessedFlawCheck.spec.ts
+++ b/src/composables/__tests__/unprocessedFlawCheck.spec.ts
@@ -201,6 +201,18 @@ describe('useUnprocessedFlawDetection', () => {
     expect(isFlawUnprocessed(flaw)).toBe(false);
   });
 
+  it('returns false for flaw on MANUAL workflow', () => {
+    const flaw = {
+      uuid: 'test-uuid',
+      classification: { state: FlawClassificationStateEnum.New, workflow: 'MANUAL' },
+      cve_id: 'CVE-2024-1234',
+      created_dt: DateTime.now().minus({ hours: 1 }).toISO(),
+      aegis_meta: null,
+    } as ZodFlawType;
+
+    expect(isFlawUnprocessed(flaw)).toBe(false);
+  });
+
   it('returns true for flaw with whitespace-only cve_description', () => {
     const flaw = {
       uuid: 'test-uuid',

--- a/src/composables/unprocessedFlawCheck.ts
+++ b/src/composables/unprocessedFlawCheck.ts
@@ -25,7 +25,8 @@ function areRequiredFieldsEmpty(flaw: ZodFlawType): boolean {
  * 2. It has a valid CVE ID assigned
  * 3. It's newer than the processing threshold (24 hours or less)
  * 4. Processed meta false
- * 5. Fields are empty:
+ * 5. Fields are empty
+ * 6. Not on MANUAL workflow (or manual-triage label)
  */
 export function useUnprocessedFlawDetection() {
   const PROCESSING_THRESHOLD_HOURS = 24;
@@ -42,6 +43,7 @@ export function useUnprocessedFlawDetection() {
   function isFlawUnprocessed(flaw: ZodFlawType): boolean {
     return (flaw.classification?.state === FlawClassificationStateEnum.New
       || flaw.classification?.state === FlawClassificationStateEnum.Empty)
+      && flaw.classification?.workflow !== 'MANUAL'
       && !!flaw.cve_id && isCveValid(flaw.cve_id)
       && !isOlderThanThreshold(flaw.created_dt)
       && areRequiredFieldsEmpty(flaw)


### PR DESCRIPTION
# OSIDB-5338 Hide bot processing badges in flaw lists for flaws with manual workflow

## Checklist:

- [x] Commits consolidated
- [-] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated

## Summary:

Due to OSIDB workflow state changes the badges are incorrectly displayed in OSIM flaw lists. It is required an adjustment to omit the "Pending bot processing" badges in flaws with manual workflow.

## Changes:

- Add manual workflow as a restriction for the "Pending bot processing" badge display
- Add unit test
