### PR TITLE
OSIDB-5385, OSIDB-5375: General label UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # OSIM Changelog
+## [Unreleased]
+### Fixed
+* Make workflow, product_family and alias labels non-editable (`OSIDB-5385`)
+
 ## [2026.8.0-patch-missing-labels]
 ### Fixed
 * New labels can now be displayed on flaw page and queried on advanced search

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 ### Fixed
 * Make workflow, product_family and alias labels non-editable (`OSIDB-5385`)
+* Fix strikethrough incorrectly applied to labels without relevant field (`OSIDB-5375`)
 
 ## [2026.8.0-patch-missing-labels]
 ### Fixed

--- a/src/components/FlawLabels/FlawLabelTableEditingRow.vue
+++ b/src/components/FlawLabels/FlawLabelTableEditingRow.vue
@@ -92,7 +92,7 @@ const emitSave = () => {
   <td
     :class="{
       'fw-bold': labelState === 'REQ',
-      'text-decoration-line-through': !initalLabel?.relevant,
+      'text-decoration-line-through': initalLabel?.relevant === false,
     }"
   >
     <!-- Existing labels: name is immutable in OSIDB -->

--- a/src/components/FlawLabels/FlawLabelTableEditingRow.vue
+++ b/src/components/FlawLabels/FlawLabelTableEditingRow.vue
@@ -30,6 +30,10 @@ const isNewLabel = computed(() => !initalLabel);
 const isAliasType = computed(() => labelType.value === FlawLabelTypeEnum.ALIAS);
 const isBuType = computed(() => labelType.value === FlawLabelTypeEnum.BU);
 const isWorkflowType = computed(() => labelType.value === FlawLabelTypeEnum.WORKFLOW);
+const isProductFamilyType = computed(() => labelType.value === FlawLabelTypeEnum.PRODUCT_FAMILY);
+const isNonEditableType = computed(() =>
+  isWorkflowType.value || isProductFamilyType.value || isAliasType.value,
+);
 
 const emitSave = () => {
   // if nothing changed, do not emit save
@@ -49,10 +53,10 @@ const emitSave = () => {
 
   emit('save', {
     ...initalLabel,
-    state: labelState.value,
+    state: isNonEditableType.value ? undefined : labelState.value,
     name: labelName.value,
-    contributor: labelContributor.value,
-    relevant: initalLabel?.relevant ?? true,
+    contributor: isNonEditableType.value ? undefined : labelContributor.value,
+    relevant: isNonEditableType.value ? undefined : (initalLabel?.relevant ?? true),
     type: labelType.value,
   });
 };
@@ -60,7 +64,7 @@ const emitSave = () => {
 
 <template>
   <td>
-    <select v-model="labelState" class="form-select">
+    <select v-if="!isNonEditableType" v-model="labelState" class="form-select">
       <option
         v-for="state in StateEnum"
         :key="state"
@@ -135,7 +139,7 @@ const emitSave = () => {
     </template>
   </td>
   <td>
-    <FlawLabelsContributor v-model="labelContributor" />
+    <FlawLabelsContributor v-if="!isNonEditableType" v-model="labelContributor" />
   </td>
   <td>
     <div class="actions">

--- a/src/components/FlawLabels/FlawLabelsTable.vue
+++ b/src/components/FlawLabels/FlawLabelsTable.vue
@@ -39,6 +39,13 @@ const availableBuLabels = computed(() =>
   ),
 );
 
+const nonEditableLabelTypes: FlawLabelTypeEnum[] = [
+  FlawLabelTypeEnum.WORKFLOW,
+  FlawLabelTypeEnum.PRODUCT_FAMILY,
+  FlawLabelTypeEnum.ALIAS,
+];
+const isNonEditableLabelType = (type: FlawLabelTypeEnum) => nonEditableLabelTypes.includes(type);
+
 const isExpandedDefault = labelsFromProps.value.some(label => label.contributor || label.state === 'NEW');
 const [isExpanded, toggleExpanded] = useToggle(isExpandedDefault);
 
@@ -121,8 +128,8 @@ function handleUndoDelete(label: ZodFlawLabelType) {
               <div class="actions">
                 <template v-if="!isDeletedLabel(label)">
                   <span
-                    v-if="label.type === FlawLabelTypeEnum.WORKFLOW && !isNewLabel(label)"
-                    title="Workflow labels are not editable"
+                    v-if="isNonEditableLabelType(label.type)"
+                    :title="`${label.type} labels are not editable`"
                   >
                     <button
                       type="button"

--- a/src/components/FlawLabels/FlawLabelsTable.vue
+++ b/src/components/FlawLabels/FlawLabelsTable.vue
@@ -119,9 +119,9 @@ function handleUndoDelete(label: ZodFlawLabelType) {
             <td
               :class="{
                 'fw-bold': label.state === 'REQ',
-                'text-decoration-line-through': !label.relevant,
+                'text-decoration-line-through': label.relevant === false,
               }"
-              :title="!label.relevant ? 'Associated affect was removed' : undefined"
+              :title="label.relevant === false ? 'Associated affect was removed' : undefined"
             >{{ label.name }}</td>
             <td>{{ label.contributor }}</td>
             <td>

--- a/src/components/FlawLabels/__tests__/FlawLabelsTable.spec.ts
+++ b/src/components/FlawLabels/__tests__/FlawLabelsTable.spec.ts
@@ -116,4 +116,61 @@ describe('flawLabelsTable', () => {
     expect(areLabelsUpdated.value).toBe(false);
     expect(wrapper.html()).toMatchSnapshot();
   });
+
+  it.each([
+    FlawLabelTypeEnum.WORKFLOW,
+    FlawLabelTypeEnum.PRODUCT_FAMILY,
+    FlawLabelTypeEnum.ALIAS,
+  ])('should disable edit button for %s labels', async (type) => {
+    const wrapper = mountFlawLabelsTable({
+      modelValue: [
+        { type, name: 'test-label', contributor: '', state: StateEnum.New },
+      ],
+    });
+    await flushPromises();
+
+    const editButton = wrapper.find('.actions button');
+    expect(editButton.attributes('disabled')).toBeDefined();
+  });
+
+  it.each([
+    FlawLabelTypeEnum.CONTEXT_BASED,
+    FlawLabelTypeEnum.BU,
+  ])('should enable edit button for %s labels', async (type) => {
+    const wrapper = mountFlawLabelsTable({
+      modelValue: [
+        { type, name: 'test-label', contributor: '', state: StateEnum.New },
+      ],
+    });
+    await flushPromises();
+
+    const editButton = wrapper.find('button[title="Edit label"]');
+    expect(editButton.exists()).toBe(true);
+    expect(editButton.attributes('disabled')).toBeUndefined();
+  });
+
+  it('should not show delete button for product_family labels', async () => {
+    const wrapper = mountFlawLabelsTable({
+      modelValue: [
+        { type: FlawLabelTypeEnum.PRODUCT_FAMILY, name: 'test-pf', contributor: '', state: StateEnum.New },
+      ],
+    });
+    await flushPromises();
+
+    expect(wrapper.find('button[title="Delete label"]').exists()).toBe(false);
+  });
+
+  it.each([
+    FlawLabelTypeEnum.WORKFLOW,
+    FlawLabelTypeEnum.ALIAS,
+  ])('should show delete button for %s labels', async (type) => {
+    const wrapper = mountFlawLabelsTable({
+      modelValue: [
+        { type, name: 'test-label', contributor: '', state: StateEnum.New },
+      ],
+    });
+    await flushPromises();
+
+    expect(wrapper.find('button[title="Delete label"]').exists()).toBe(true);
+  });
 });

--- a/src/components/FlawLabels/__tests__/FlawLabelsTable.spec.ts
+++ b/src/components/FlawLabels/__tests__/FlawLabelsTable.spec.ts
@@ -173,4 +173,34 @@ describe('flawLabelsTable', () => {
 
     expect(wrapper.find('button[title="Delete label"]').exists()).toBe(true);
   });
+
+  it.each([
+    FlawLabelTypeEnum.WORKFLOW,
+    FlawLabelTypeEnum.PRODUCT_FAMILY,
+    FlawLabelTypeEnum.ALIAS,
+  ])('should not apply strikethrough to %s labels without relevant field', async (type) => {
+    const wrapper = mountFlawLabelsTable({
+      modelValue: [
+        { type, name: 'test-label', contributor: '', state: StateEnum.New },
+      ],
+    });
+    await flushPromises();
+
+    const nameTd = wrapper.findAll('td')[2];
+    expect(nameTd.classes()).not.toContain('text-decoration-line-through');
+    expect(nameTd.attributes('title')).toBeUndefined();
+  });
+
+  it('should apply strikethrough to labels with relevant explicitly false', async () => {
+    const wrapper = mountFlawLabelsTable({
+      modelValue: [
+        { type: FlawLabelTypeEnum.CONTEXT_BASED, name: 'test', contributor: '', state: StateEnum.New, relevant: false },
+      ],
+    });
+    await flushPromises();
+
+    const nameTd = wrapper.findAll('td')[2];
+    expect(nameTd.classes()).toContain('text-decoration-line-through');
+    expect(nameTd.attributes('title')).toBe('Associated affect was removed');
+  });
 });

--- a/src/components/FlawLabels/__tests__/FlawLabelsTableEditingRow.spec.ts
+++ b/src/components/FlawLabels/__tests__/FlawLabelsTableEditingRow.spec.ts
@@ -1,6 +1,9 @@
 import { mountWithConfig } from '@/__tests__/helpers';
+import { FlawLabelTypeEnum } from '@/types/zodFlaw';
+import { StateEnum } from '@/generated-client';
 
 import FlawLabelTableEditingRow from '../FlawLabelTableEditingRow.vue';
+import FlawLabelsContributor from '../FlawLabelsContributor.vue';
 
 describe('flawLabelsTableEditingRow', () => {
   it('should render', () => {
@@ -31,5 +34,128 @@ describe('flawLabelsTableEditingRow', () => {
 
     expect(wrapper.emitted()).toHaveProperty('save');
     expect(wrapper.emitted('save')).toEqual([[expect.objectContaining({ name: 'test' })]]);
+  });
+
+  it.each([
+    FlawLabelTypeEnum.WORKFLOW,
+    FlawLabelTypeEnum.PRODUCT_FAMILY,
+    FlawLabelTypeEnum.ALIAS,
+  ])('should not show state select for %s labels', (type) => {
+    const wrapper = mountWithConfig(FlawLabelTableEditingRow, {
+      props: {
+        initalLabel: { type, name: 'test-label', contributor: '', state: StateEnum.New, relevant: true },
+      },
+    });
+
+    const selects = wrapper.findAll('select');
+    expect(selects.length).toBe(0);
+  });
+
+  it.each([
+    FlawLabelTypeEnum.WORKFLOW,
+    FlawLabelTypeEnum.PRODUCT_FAMILY,
+    FlawLabelTypeEnum.ALIAS,
+  ])('should not show contributor input for %s labels', (type) => {
+    const wrapper = mountWithConfig(FlawLabelTableEditingRow, {
+      props: {
+        initalLabel: { type, name: 'test-label', contributor: '', state: StateEnum.New, relevant: true },
+      },
+    });
+
+    expect(wrapper.findComponent(FlawLabelsContributor).exists()).toBe(false);
+  });
+
+  it.each([
+    FlawLabelTypeEnum.CONTEXT_BASED,
+    FlawLabelTypeEnum.BU,
+  ])('should show state select and contributor input for %s labels', (type) => {
+    const wrapper = mountWithConfig(FlawLabelTableEditingRow, {
+      props: {
+        initalLabel: { type, name: 'test-label', contributor: '', state: StateEnum.New, relevant: true },
+      },
+    });
+
+    const stateSelect = wrapper.find('select');
+    expect(stateSelect.exists()).toBe(true);
+    expect(wrapper.findComponent(FlawLabelsContributor).exists()).toBe(true);
+  });
+
+  it('should show state select when creating new context_based label', () => {
+    const wrapper = mountWithConfig(FlawLabelTableEditingRow, {
+      props: {
+        contextLabels: ['test'],
+      },
+    });
+
+    const selects = wrapper.findAll('select');
+    expect(selects.length).toBe(3);
+  });
+
+  it('should not show state select when creating new workflow label', async () => {
+    const wrapper = mountWithConfig(FlawLabelTableEditingRow);
+
+    const typeSelect = wrapper.findAll('select')[1];
+    await typeSelect.setValue(FlawLabelTypeEnum.WORKFLOW);
+
+    const selects = wrapper.findAll('select');
+    expect(selects.length).toBe(1);
+  });
+
+  it.each([
+    FlawLabelTypeEnum.WORKFLOW,
+    FlawLabelTypeEnum.ALIAS,
+  ])('should not show state text when creating new %s label', async (type) => {
+    const wrapper = mountWithConfig(FlawLabelTableEditingRow);
+
+    const typeSelect = wrapper.findAll('select')[1];
+    await typeSelect.setValue(type);
+
+    const stateTd = wrapper.findAll('td')[0];
+    expect(stateTd.text()).toBe('');
+  });
+
+  it('should not apply strikethrough on name for new labels', () => {
+    const wrapper = mountWithConfig(FlawLabelTableEditingRow, {
+      props: {
+        contextLabels: ['test'],
+      },
+    });
+
+    const nameTd = wrapper.findAll('td')[2];
+    expect(nameTd.classes()).not.toContain('text-decoration-line-through');
+  });
+
+  it.each([
+    FlawLabelTypeEnum.WORKFLOW,
+    FlawLabelTypeEnum.ALIAS,
+  ])('should not emit state or contributor when saving new %s label', async (type) => {
+    const wrapper = mountWithConfig(FlawLabelTableEditingRow);
+
+    const typeSelect = wrapper.findAll('select')[1];
+    await typeSelect.setValue(type);
+
+    const nameInput = wrapper.find('input[type="text"]');
+    await nameInput.setValue('test-name');
+
+    await wrapper.find('button[title="Save"]').trigger('click');
+
+    const saved = wrapper.emitted('save')?.[0]?.[0] as Record<string, unknown>;
+    expect(saved.state).toBeUndefined();
+    expect(saved.contributor).toBeUndefined();
+    expect(saved.relevant).toBeUndefined();
+  });
+
+  it.each([
+    FlawLabelTypeEnum.WORKFLOW,
+    FlawLabelTypeEnum.ALIAS,
+  ])('should not show state when re-editing a draft %s label', (type) => {
+    const wrapper = mountWithConfig(FlawLabelTableEditingRow, {
+      props: {
+        initalLabel: { type, name: 'draft-label', state: undefined, contributor: undefined, relevant: undefined },
+      },
+    });
+
+    const stateTd = wrapper.findAll('td')[0];
+    expect(stateTd.text()).toBe('');
   });
 });

--- a/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTable.spec.ts.snap
+++ b/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTable.spec.ts.snap
@@ -18,7 +18,7 @@ exports[`flawLabelsTable > should handle add label 1`] = `
           <tr data-v-5d530569="" class="">
             <td data-v-5d530569="" class="">NEW</td>
             <td data-v-5d530569="">context_based</td>
-            <td data-v-5d530569="" class="text-decoration-line-through" title="Associated affect was removed">test</td>
+            <td data-v-5d530569="" class="">test</td>
             <td data-v-5d530569="">skynet</td>
             <td data-v-5d530569="">
               <div data-v-5d530569="" class="actions"><button data-v-5d530569="" type="button" title="Edit label" class="btn btn-sm btn-dark"><i data-v-5d530569="" class="bi bi-pencil"></i></button>
@@ -29,7 +29,7 @@ exports[`flawLabelsTable > should handle add label 1`] = `
           <tr data-v-5d530569="" class="new">
             <td data-v-5d530569="" class="">NEW</td>
             <td data-v-5d530569="">context_based</td>
-            <td data-v-5d530569="" class="text-decoration-line-through" title="Associated affect was removed">test1</td>
+            <td data-v-5d530569="" class="">test1</td>
             <td data-v-5d530569="">skynet</td>
             <td data-v-5d530569="">
               <div data-v-5d530569="" class="actions"><button data-v-5d530569="" type="button" title="Edit label" class="btn btn-sm btn-dark"><i data-v-5d530569="" class="bi bi-pencil"></i></button>
@@ -66,7 +66,7 @@ exports[`flawLabelsTable > should handle delete label 1`] = `
           <tr data-v-5d530569="" class="deleted">
             <td data-v-5d530569="" class="">NEW</td>
             <td data-v-5d530569="">context_based</td>
-            <td data-v-5d530569="" class="text-decoration-line-through" title="Associated affect was removed">test</td>
+            <td data-v-5d530569="" class="">test</td>
             <td data-v-5d530569="">skynet</td>
             <td data-v-5d530569="">
               <div data-v-5d530569="" class="actions">
@@ -104,7 +104,7 @@ exports[`flawLabelsTable > should handle edit label 1`] = `
           <tr data-v-5d530569="" class="">
             <td data-v-5d530569="" class="">NEW</td>
             <td data-v-5d530569="">context_based</td>
-            <td data-v-5d530569="" class="text-decoration-line-through" title="Associated affect was removed">test</td>
+            <td data-v-5d530569="" class="">test</td>
             <td data-v-5d530569="">skynet</td>
             <td data-v-5d530569="">
               <div data-v-5d530569="" class="actions"><button data-v-5d530569="" type="button" title="Edit label" class="btn btn-sm btn-dark"><i data-v-5d530569="" class="bi bi-pencil"></i></button>
@@ -115,7 +115,7 @@ exports[`flawLabelsTable > should handle edit label 1`] = `
           <tr data-v-5d530569="" class="updated">
             <td data-v-5d530569="" class="">NEW</td>
             <td data-v-5d530569="">context_based</td>
-            <td data-v-5d530569="" class="text-decoration-line-through" title="Associated affect was removed">test1</td>
+            <td data-v-5d530569="" class="">test1</td>
             <td data-v-5d530569="">skynet</td>
             <td data-v-5d530569="">
               <div data-v-5d530569="" class="actions"><button data-v-5d530569="" type="button" title="Edit label" class="btn btn-sm btn-dark"><i data-v-5d530569="" class="bi bi-pencil"></i></button>
@@ -152,7 +152,7 @@ exports[`flawLabelsTable > should handle undo delete label 1`] = `
           <tr data-v-5d530569="" class="">
             <td data-v-5d530569="" class="">NEW</td>
             <td data-v-5d530569="">context_based</td>
-            <td data-v-5d530569="" class="text-decoration-line-through" title="Associated affect was removed">test</td>
+            <td data-v-5d530569="" class="">test</td>
             <td data-v-5d530569="">skynet</td>
             <td data-v-5d530569="">
               <div data-v-5d530569="" class="actions"><button data-v-5d530569="" type="button" title="Edit label" class="btn btn-sm btn-dark"><i data-v-5d530569="" class="bi bi-pencil"></i></button>
@@ -189,7 +189,7 @@ exports[`flawLabelsTable > should render flaw labels table 1`] = `
           <tr data-v-5d530569="" class="">
             <td data-v-5d530569="" class="">NEW</td>
             <td data-v-5d530569="">context_based</td>
-            <td data-v-5d530569="" class="text-decoration-line-through" title="Associated affect was removed">test</td>
+            <td data-v-5d530569="" class="">test</td>
             <td data-v-5d530569="">skynet</td>
             <td data-v-5d530569="">
               <div data-v-5d530569="" class="actions"><button data-v-5d530569="" type="button" title="Edit label" class="btn btn-sm btn-dark"><i data-v-5d530569="" class="bi bi-pencil"></i></button>

--- a/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTableEditingRow.spec.ts.snap
+++ b/src/components/FlawLabels/__tests__/__snapshots__/FlawLabelsTableEditingRow.spec.ts.snap
@@ -15,7 +15,7 @@ exports[`flawLabelsTableEditingRow > should render 1`] = `
     <option data-v-627548cb="" value="workflow">workflow</option>
   </select>
 </td>
-<td data-v-627548cb="" class="text-decoration-line-through">
+<td data-v-627548cb="" class="">
   <!-- Existing labels: name is immutable in OSIDB -->
   <!-- New context-based labels use dropdown --><select data-v-627548cb="" class="form-select" required=""></select>
 </td>

--- a/src/components/FlawWorkflowState/FlawWorkflowState.vue
+++ b/src/components/FlawWorkflowState/FlawWorkflowState.vue
@@ -26,7 +26,7 @@ const stateValue = computed(() => props.classification?.state || null);
 
 const workflowLabels = computed(() =>
   (props.labels ?? []).filter(
-    l => l.type === FlawLabelTypeEnum.WORKFLOW && l.relevant,
+    l => l.type === FlawLabelTypeEnum.WORKFLOW,
   ),
 );
 

--- a/src/components/FlawWorkflowState/__tests__/FlawWorkflowState.spec.ts
+++ b/src/components/FlawWorkflowState/__tests__/FlawWorkflowState.spec.ts
@@ -1,0 +1,42 @@
+import { mountWithConfig } from '@/__tests__/helpers';
+import { FlawLabelTypeEnum } from '@/types/zodFlaw';
+
+import FlawWorkflowState from '../FlawWorkflowState.vue';
+
+describe('flawWorkflowState', () => {
+  it('should display workflow labels without relevant field', () => {
+    const wrapper = mountWithConfig(FlawWorkflowState, {
+      props: {
+        flawUuid: 'test-uuid',
+        shouldCreateJiraTask: false,
+        classification: { workflow: 'DEFAULT', state: 'NEW' },
+        labels: [
+          { type: FlawLabelTypeEnum.WORKFLOW, name: 'wf-label-1' },
+          { type: FlawLabelTypeEnum.WORKFLOW, name: 'wf-label-2' },
+        ],
+      },
+    });
+
+    const badges = wrapper.findAll('.osim-workflow-label-badge');
+    expect(badges.length).toBe(2);
+    expect(badges[0].text()).toBe('wf-label-1');
+    expect(badges[1].text()).toBe('wf-label-2');
+  });
+
+  it('should not display non-workflow labels', () => {
+    const wrapper = mountWithConfig(FlawWorkflowState, {
+      props: {
+        flawUuid: 'test-uuid',
+        shouldCreateJiraTask: false,
+        classification: { workflow: 'DEFAULT', state: 'NEW' },
+        labels: [
+          { type: FlawLabelTypeEnum.CONTEXT_BASED, name: 'ctx-label' },
+          { type: FlawLabelTypeEnum.ALIAS, name: 'alias-label' },
+        ],
+      },
+    });
+
+    const badges = wrapper.findAll('.osim-workflow-label-badge');
+    expect(badges.length).toBe(0);
+  });
+});

--- a/src/components/IssueQueue/IssueQueueItem.vue
+++ b/src/components/IssueQueue/IssueQueueItem.vue
@@ -116,8 +116,8 @@ function getLabelColor(label: string, type: string): string {
               class="badge rounded-pill border"
               :class="{
                 'text-bg-warning fw-bold border-warning': label.state == 'REQ',
-                'text-black': label.state != 'REQ' && label.relevant,
-                'text-decoration-line-through text-bg-gray border-secondary': !label.relevant,
+                'text-black': label.state != 'REQ' && label.relevant !== false,
+                'text-decoration-line-through text-bg-gray border-secondary': label.relevant === false,
               }"
               :title="label.state === 'REQ' ? 'Requested' : ''"
             >{{ label.name }}</span>

--- a/src/components/__tests__/IssueQueue.spec.ts
+++ b/src/components/__tests__/IssueQueue.spec.ts
@@ -230,6 +230,28 @@ describe('issueQueue', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
+  it('should not apply strikethrough to labels without relevant field', () => {
+    const wrapper = mountIssueQueue({
+      issues: [{
+        ...mockData[0],
+        labels: [
+          { name: 'wf-label', type: 'workflow', state: 'NEW', contributor: '' },
+          { name: 'alias-label', type: 'alias', state: 'NEW', contributor: '' },
+          { name: 'irrelevant-label', type: 'context_based', state: 'NEW', contributor: '', relevant: false },
+        ],
+      } as ZodFlawType],
+    });
+
+    const labels = wrapper.findComponent(IssueQueueItem).findAll('span.badge');
+    const wfLabel = labels.find(l => l.text() === 'wf-label')!;
+    const aliasLabel = labels.find(l => l.text() === 'alias-label')!;
+    const irrelevantLabel = labels.find(l => l.text() === 'irrelevant-label')!;
+
+    expect(wfLabel.classes()).not.toContain('text-decoration-line-through');
+    expect(aliasLabel.classes()).not.toContain('text-decoration-line-through');
+    expect(irrelevantLabel.classes()).toContain('text-decoration-line-through');
+  });
+
   it('should not render flaw labels that are already assigned', () => {
     const wrapper = mountIssueQueue({
       issues: [{

--- a/src/components/__tests__/__snapshots__/IssueQueue.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/IssueQueue.spec.ts.snap
@@ -135,7 +135,7 @@ exports[`issueQueue > should render flaw labels 1`] = `
           <td data-v-15d9c71d="" colspan="1">
             <div data-v-15d9c71d="" class="gap-1 d-flex flex-wrap">
               <!--v-if-->
-              <!--v-if--><span data-v-15d9c71d="" style="background-color: rgb(255, 255, 255);" class="badge rounded-pill border text-bg-warning fw-bold border-warning text-decoration-line-through text-bg-gray border-secondary" title="Requested">test-3</span><span data-v-15d9c71d="" style="background-color: rgb(255, 255, 255);" class="badge rounded-pill border text-decoration-line-through text-bg-gray border-secondary" title="">test</span><span data-v-15d9c71d="" style="background-color: rgb(255, 255, 255);" class="badge rounded-pill border text-decoration-line-through text-bg-gray border-secondary" title="">test-2</span>
+              <!--v-if--><span data-v-15d9c71d="" style="background-color: rgb(255, 255, 255);" class="badge rounded-pill border text-bg-warning fw-bold border-warning" title="Requested">test-3</span><span data-v-15d9c71d="" style="background-color: rgb(255, 255, 255);" class="badge rounded-pill border text-black" title="">test</span><span data-v-15d9c71d="" style="background-color: rgb(255, 255, 255);" class="badge rounded-pill border text-black" title="">test-2</span>
             </div>
           </td>
           <td data-v-15d9c71d="" colspan="90%"></td>


### PR DESCRIPTION
## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [x] Integration tests updated

## Summary:

This PR introduces two UX fixes to the labels feature:
* OSIDB-5385 which disables editing of informational-only labels (workflow, product_family, alias)
* OSIDB-5375 which removes strikethrough for labels without a relevant field (workflow, product_family, alias)

## Changes:

- Disabled the edit button for workflow, product_family, and alias labels (previously only workflow
  existing labels)
- Hidden state select and contributor input in the editing row for those label types
- emitSave omits state, contributor, and relevant from the payload for non-editable types
- Changed strikethrough condition from !label.relevant to label.relevant === false in both FlawLabelsTable.vue and FlawLabelTableEditingRow.vue
- Delete restriction remains on product_family only
- The workflow labels in the Flaw detail view in the workflow state/resolution box are now correctly shown, they were being filtered out due to relevant not being a valid attribute for workflow label type.

## Considerations:

- While OSIDB does not reject updates to state/contributor/relevant on non-editable label types, the updates are a no-op — hiding these fields prevents misleading edits
- The strict === false check distinguishes between undefined (field not applicable for this label type) and false (associated affect was removed), which are semantically different
- undefined values in the save payload are stripped by JSON.stringify before reaching the API, so omitting vs. sending undefined is functionally equivalent
