### PR TITLE
🐛 Allow empty source component in flaws with NEW state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # OSIM Changelog
 ## [Unreleased]
 ### Fixed
+* Allow empty Source Component on flaws in NEW state (`OSIDB-5273`)
 * Make workflow, product_family and alias labels non-editable (`OSIDB-5385`)
 * Fix strikethrough incorrectly applied to labels without relevant field (`OSIDB-5375`)
 

--- a/src/components/__tests__/FlawForm.spec.ts
+++ b/src/components/__tests__/FlawForm.spec.ts
@@ -276,7 +276,7 @@ describe('flawForm', () => {
     const subject = mountWithProps(flaw, { mode: 'create' });
     const vm = subject.findComponent(FlawForm).vm as any;
     expect(vm.errors.title).not.toBe(null);
-    expect(vm.errors.component).not.toBe(null);
+    expect(vm.errors.components).toBe(null);
     expect(vm.errors.impact).not.toBe(null);
     expect(vm.errors.source).not.toBe(null);
     expect(vm.errors.comment_zero).not.toBe(null);
@@ -291,7 +291,7 @@ describe('flawForm', () => {
       .findAllComponents(LabelTagsInput)
       .find(component => component.props().label === 'Source Component')
       ?.find('.is-invalid');
-    expect(componentsField?.exists()).toBe(true);
+    expect(componentsField?.exists()).toBe(false);
 
     const invalidImpactField = subject
       .findAllComponents(LabelSelect)

--- a/src/composables/__tests__/useFlawModel.spec.ts
+++ b/src/composables/__tests__/useFlawModel.spec.ts
@@ -77,12 +77,20 @@ describe('useFlawModel', () => {
 
     expect(errors.value).toEqual(expect.objectContaining({
       comment_zero: expect.any(String),
-      components: expect.any(String),
       impact: expect.any(String),
       source: expect.any(String),
       title: expect.any(String),
       unembargo_dt: expect.any(String),
     }));
+    expect(errors.value.components).toBeNull();
+  });
+
+  it('requires components outside NEW and REJECTED states', () => {
+    const { flaw } = useFlaw();
+    flaw.value.classification = { state: 'TRIAGE', workflow: 'DEFAULT' };
+    const { errors } = mountFlawModel();
+
+    expect(errors.value.components).toEqual(expect.any(String));
   });
 
   it('calls onSaveSuccess and resets isSaving in afterSaveSuccess', () => {

--- a/src/types/zodFlaw.ts
+++ b/src/types/zodFlaw.ts
@@ -250,7 +250,9 @@ export const ZodFlawSchema = z.object({
       raiseIssue('You must select an impact before saving the Flaw.', ['impact']);
     }
 
-    if (zodFlaw.components.length === 0) {
+    // OSIDB allows empty components in NEW, REJECTED, and empty workflow states
+    const { state } = zodFlaw.classification ?? {};
+    if (state !== 'NEW' && state !== '' && zodFlaw.components.length === 0) {
       raiseIssue('Components cannot be empty.', ['components']);
     }
   }

--- a/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
+++ b/src/views/__tests__/__snapshots__/FlawCreateView.spec.ts.snap
@@ -35,9 +35,9 @@ exports[`flawCreateView > should render 1`] = `
           </div><label data-v-76f6bf34="" data-v-76e7a15d="" class="osim-input ps-3 mb-2 input-group">
             <div data-v-76f6bf34="" class="row"><span data-v-76f6bf34="" class="form-label col-3"><div data-v-76e7a15d="" class="d-flex align-items-center"><!--v-if--><!--v-if--> Source Component </div></span>
               <div data-v-76f6bf34="" class="col-9">
-                <div data-v-8bc603c3="" data-v-76f6bf34="" class="osim-pill-list form-control is-invalid">
+                <div data-v-8bc603c3="" data-v-76f6bf34="" class="osim-pill-list form-control">
                   <transition-group-stub data-v-8bc603c3="" appear="false" persisted="false" css="true"></transition-group-stub><input data-v-8bc603c3="" class="osim-pill-list-input no-drag" type="text">
-                  <div data-v-8bc603c3="" class="invalid-tooltip no-drag">Components cannot be empty.</div>
+                  <!--v-if-->
                 </div>
               </div>
             </div>


### PR DESCRIPTION
# OSIDB-5273 Allow empty source component in flaws with NEW state

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated

## Summary:

OSIM insists on Source Component being set while updating a flaw in NEW state.
This constraint should be lifted because OSIDB itself does not have such a limitation.

## Changes:

- Stop requiring Source Component when saving a flaw in NEW (or empty) state, matching OSIDB.

## Considerations:

- Tested against OSIDB UAT
