### PR TITLE
💄 Make Affect Module field read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # OSIM Changelog
 ## [Unreleased]
 ### Fixed
+* Make `ps_module` field read-only in the affects table; OSIDB determines the module from `ps_update_stream`. Changed values now show a strikethrough until the flaw is saved (`OSIDB-4704`)
 * Allow empty Source Component on flaws in NEW state (`OSIDB-5273`)
 * Make workflow, product_family and alias labels non-editable (`OSIDB-5385`)
 * Fix strikethrough incorrectly applied to labels without relevant field (`OSIDB-5375`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@
 ### Fixed
 * Show top-level SRP overdue information from the latest report (`OSIDB-5480`)
 
+### Changed
+* Make `ps_module` field read-only in the affects table; OSIDB determines the module from `ps_update_stream`. Changed values now show a strikethrough until the flaw is saved (`OSIDB-4704`)
+
 ## [2026.8.2]
 ### Fixed
 * Restore OSIDB mid-air collision detection on PUT (`OSIDB-5285`)
 
 ## [2026.8.1]
 ### Fixed
+* Restore OSIDB mid-air collision detection on PUT (`OSIDB-5285`)
 * Allow empty Source Component on flaws in NEW state (`OSIDB-5273`)
 * Make workflow, product_family and alias labels non-editable (`OSIDB-5385`)
 * Fix strikethrough incorrectly applied to labels without relevant field (`OSIDB-5375`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 
 ## [2026.8.1]
 ### Fixed
-* Restore OSIDB mid-air collision detection on PUT (`OSIDB-5285`)
 * Allow empty Source Component on flaws in NEW state (`OSIDB-5273`)
 * Make workflow, product_family and alias labels non-editable (`OSIDB-5385`)
 * Fix strikethrough incorrectly applied to labels without relevant field (`OSIDB-5375`)

--- a/src/components/AffectsTable/EditableCell.vue
+++ b/src/components/AffectsTable/EditableCell.vue
@@ -116,7 +116,8 @@ const onBlur = () => {
 };
 
 const toggleEditMode = () => {
-  if (tableMeta?.filingTracker.has(props.row.id) || (metaEnum.value && !Object.keys(metaEnum.value).length)) {
+  if (columnMeta?.readonly || tableMeta?.filingTracker.has(props.row.id)
+    || (metaEnum.value && !Object.keys(metaEnum.value).length)) {
     return;
   }
   editMode.value = !editMode.value;
@@ -126,7 +127,27 @@ const toggleEditMode = () => {
 };
 
 // Watch currentAffects from the model to detect data changes (including reverts)
-const { state: { currentAffects } } = useAffectsModel();
+const { state: { currentAffects, initialAffects, modifiedAffects, newAffects } } = useAffectsModel();
+
+const isStale = computed(() => {
+  const siblingField = columnMeta?.staleWhenChanged as keyof ZodAffectType | undefined;
+  if (!siblingField) return false;
+
+  const uuid = props.row.original.uuid;
+  // New (unsaved) affects have no initial state to compare against
+  if (!uuid || newAffects.has(uuid)) return false;
+
+  // Only stale when the affect has been modified (modifiedAffects is a reactive Set)
+  if (!modifiedAffects.has(uuid)) return false;
+
+  const initial = initialAffects.value.find(a => a.uuid === uuid);
+  if (!initial) return false;
+
+  const current = currentAffects.value.find(a => a.uuid === uuid);
+  if (!current) return false;
+
+  return current[siblingField] !== initial[siblingField];
+});
 
 watch(currentAffects, () => {
   // Only update if not in edit mode to avoid losing user edits
@@ -148,11 +169,14 @@ watch(currentAffects, () => {
   <span
     v-if="!editMode"
     tabindex="0"
-    :title="tooltipValue"
-    :class="{ 'text-danger': hasError }"
+    :title="isStale ? 'Module will be updated by OSIDB after saving' : tooltipValue"
+    :class="{ 'text-danger': hasError, 'text-muted': isStale }"
     @dblclick="toggleEditMode"
     @keyup.tab="toggleEditMode"
-  >{{ displayValue || '&nbsp;' }}</span>
+  >
+    <s v-if="isStale">{{ displayValue || '&nbsp;' }}</s>
+    <template v-else>{{ displayValue || '&nbsp;' }}</template>
+  </span>
   <template v-else>
     <template v-if="metaEnum">
       <select

--- a/src/components/AffectsTable/__tests__/AffectsTable.spec.ts
+++ b/src/components/AffectsTable/__tests__/AffectsTable.spec.ts
@@ -631,6 +631,63 @@ describe('affectsTable', () => {
       });
     });
 
+    describe('ps_module field', () => {
+      beforeEach(() => {
+        // Ensure ps_module column is visible (a prior test may have hidden it)
+        const { settings } = useSettingsStore();
+        settings.affectsVisibility = { ...settings.affectsVisibility, ps_module: true };
+      });
+
+      it('should not enter edit mode when any ps_module cell is double-clicked', async () => {
+        const wrapper = await mountAffectsTable();
+
+        // Double-click every span in every data row; none should open a text input
+        const allSpans = wrapper.findAll('tbody td span');
+        expect(allSpans.length).toBeGreaterThan(0);
+
+        for (const span of allSpans) {
+          await span.trigger('dblclick');
+          await flushPromises();
+        }
+
+        // No text input should be open inside any ps_module cell specifically
+        // (ps_component and others CAN open inputs, but we verify ps_module cells don't)
+        // Verify by checking none of the inputs match the ps_module column value
+        const psModuleValue = SampleFlawFull.affects[0].ps_module;
+        const openInputs = wrapper.findAll('tbody td input[type="text"]');
+        const matchingInput = openInputs.find(
+          input => (input.element as HTMLInputElement).value === psModuleValue,
+        );
+        expect(matchingInput).toBeUndefined();
+      });
+
+      it('should show strikethrough on ps_module when ps_update_stream changes', async () => {
+        const wrapper = await mountAffectsTable();
+        const {
+          actions: { markModified },
+          state: { currentAffects },
+        } = useAffectsModel();
+
+        // Confirm no strikethrough initially
+        expect(wrapper.find('tbody s').exists()).toBe(false);
+
+        // Mutate ps_update_stream and mark affected — modifiedAffects (reactive Set) drives re-render
+        currentAffects.value[0].ps_update_stream = 'changed-stream';
+        markModified(currentAffects.value[0].uuid!);
+        await flushPromises();
+
+        // A strikethrough should now appear on the stale ps_module value
+        expect(wrapper.find('tbody s').exists()).toBe(true);
+        expect(wrapper.find('tbody s').text()).toBe(SampleFlawFull.affects[0].ps_module);
+      });
+
+      it('should not show strikethrough on ps_module when ps_update_stream is unchanged', async () => {
+        const wrapper = await mountAffectsTable();
+
+        expect(wrapper.find('tbody s').exists()).toBe(false);
+      });
+    });
+
     describe('bulk edit', () => {
       beforeEach(async () => {
         const { settings } = useSettingsStore();

--- a/src/components/AffectsTable/columnDefinitions.tsx
+++ b/src/components/AffectsTable/columnDefinitions.tsx
@@ -36,6 +36,8 @@ declare module '@tanstack/vue-table' {
     extraColumn?: DeepKeys<TData>;
     filter?: boolean;
     onValueChange?: (newValue: TValue, row: Row<TData>, table: Table<TData>) => void;
+    readonly?: boolean;
+    staleWhenChanged?: DeepKeys<TData>;
     validate?: (value: TValue) => null | string | string[];
   }
 }
@@ -163,8 +165,9 @@ export default function AffectColumnDefinitions() {
       header: 'Module',
       sortingFn: 'alphanumeric',
       meta: {
-        bulkEditable: true,
         clearable: false,
+        readonly: true,
+        staleWhenChanged: 'ps_update_stream',
       },
     }),
     columnHelper.accessor('ps_component', {

--- a/src/composables/__tests__/useAffectsModel.spec.ts
+++ b/src/composables/__tests__/useAffectsModel.spec.ts
@@ -1,0 +1,106 @@
+import { createTestingPinia } from '@pinia/testing';
+
+import { useAffectsModel } from '@/composables/useAffectsModel';
+import * as AffectService from '@/services/AffectService';
+import type { ZodAffectType } from '@/types';
+
+createTestingPinia();
+
+vi.mock('@/services/AffectService', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/services/AffectService')>(),
+  postAffectCvssScore: vi.fn(),
+  postAffects: vi.fn(),
+  putAffectCvssScore: vi.fn(),
+  putAffects: vi.fn(),
+}));
+
+// New rows are created with an empty ps_module (see useAffectsTable.ts createData);
+// OSIDB derives ps_module from ps_update_stream server-side and returns it filled in.
+function newLocalAffect(overrides: Partial<ZodAffectType> = {}): ZodAffectType {
+  return {
+    _uuid: 'local-uuid',
+    flaw: 'flaw-uuid',
+    ps_module: '',
+    ps_component: 'my-component',
+    ps_update_stream: 'my-stream',
+    embargoed: false,
+    alerts: [],
+    labels: [],
+    cvss_scores: [
+      {
+        comment: '',
+        cvss_version: 'V3',
+        issuer: 'RH',
+        score: 7.5,
+        vector: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N',
+        embargoed: false,
+        alerts: [],
+      },
+    ],
+    tracker: null,
+    subpackage_purls: [],
+    ...overrides,
+  } as unknown as ZodAffectType;
+}
+
+function savedAffectFromOsidb(overrides: Partial<ZodAffectType> = {}): ZodAffectType {
+  return {
+    uuid: 'saved-uuid',
+    flaw: 'flaw-uuid',
+    ps_module: 'my-module', // derived server-side from ps_update_stream
+    ps_component: 'my-component',
+    ps_update_stream: 'my-stream',
+    embargoed: false,
+    alerts: [],
+    labels: [],
+    cvss_scores: [],
+    tracker: null,
+    subpackage_purls: [],
+    ...overrides,
+  } as unknown as ZodAffectType;
+}
+
+describe('useAffectsModel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const { actions: { initializeAffects } } = useAffectsModel();
+    initializeAffects([]);
+  });
+
+  it('saves the CVSS score for a newly created affect even when OSIDB fills in ps_module', async () => {
+    const { actions: { markNew, saveAffects }, state: { currentAffects } } = useAffectsModel();
+
+    const localAffect = newLocalAffect();
+    currentAffects.value = [localAffect];
+    markNew(localAffect._uuid!);
+
+    const savedAffect = savedAffectFromOsidb();
+    vi.mocked(AffectService.postAffects).mockResolvedValue({
+      data: { results: [savedAffect], failed: [] },
+    } as any);
+    vi.mocked(AffectService.postAffectCvssScore).mockResolvedValue({
+      uuid: 'cvss-uuid',
+      affect: savedAffect.uuid,
+      ...localAffect.cvss_scores[0],
+    } as any);
+
+    await saveAffects();
+
+    expect(AffectService.postAffectCvssScore).toHaveBeenCalledWith(
+      savedAffect.uuid,
+      expect.objectContaining({ score: 7.5 }),
+    );
+  });
+
+  it('clears newAffects tracking for a saved affect despite the ps_module mismatch', async () => {
+    const { actions: { markNew, resetSavedAffects }, state: { currentAffects, newAffects } } = useAffectsModel();
+
+    const localAffect = newLocalAffect({ cvss_scores: [] });
+    currentAffects.value = [localAffect];
+    markNew(localAffect._uuid!);
+
+    resetSavedAffects([savedAffectFromOsidb()]);
+
+    expect(newAffects.has(localAffect._uuid!)).toBe(false);
+  });
+});

--- a/src/composables/__tests__/useAffectsModel.spec.ts
+++ b/src/composables/__tests__/useAffectsModel.spec.ts
@@ -1,0 +1,107 @@
+import { createTestingPinia } from '@pinia/testing';
+
+import { useAffectsModel } from '@/composables/useAffectsModel';
+
+import * as AffectService from '@/services/AffectService';
+import type { ZodAffectType } from '@/types';
+
+createTestingPinia();
+
+vi.mock('@/services/AffectService', async importOriginal => ({
+  ...await importOriginal<typeof import('@/services/AffectService')>(),
+  postAffectCvssScore: vi.fn(),
+  postAffects: vi.fn(),
+  putAffectCvssScore: vi.fn(),
+  putAffects: vi.fn(),
+}));
+
+// New rows are created with an empty ps_module (see useAffectsTable.ts createData);
+// OSIDB derives ps_module from ps_update_stream server-side and returns it filled in.
+function newLocalAffect(overrides: Partial<ZodAffectType> = {}): ZodAffectType {
+  return {
+    _uuid: 'local-uuid',
+    flaw: 'flaw-uuid',
+    ps_module: '',
+    ps_component: 'my-component',
+    ps_update_stream: 'my-stream',
+    embargoed: false,
+    alerts: [],
+    labels: [],
+    cvss_scores: [
+      {
+        comment: '',
+        cvss_version: 'V3',
+        issuer: 'RH',
+        score: 7.5,
+        vector: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N',
+        embargoed: false,
+        alerts: [],
+      },
+    ],
+    tracker: null,
+    subpackage_purls: [],
+    ...overrides,
+  } as unknown as ZodAffectType;
+}
+
+function savedAffectFromOsidb(overrides: Partial<ZodAffectType> = {}): ZodAffectType {
+  return {
+    uuid: 'saved-uuid',
+    flaw: 'flaw-uuid',
+    ps_module: 'my-module', // derived server-side from ps_update_stream
+    ps_component: 'my-component',
+    ps_update_stream: 'my-stream',
+    embargoed: false,
+    alerts: [],
+    labels: [],
+    cvss_scores: [],
+    tracker: null,
+    subpackage_purls: [],
+    ...overrides,
+  } as unknown as ZodAffectType;
+}
+
+describe('useAffectsModel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const { actions: { initializeAffects } } = useAffectsModel();
+    initializeAffects([]);
+  });
+
+  it('saves the CVSS score for a newly created affect even when OSIDB fills in ps_module', async () => {
+    const { actions: { markNew, saveAffects }, state: { currentAffects } } = useAffectsModel();
+
+    const localAffect = newLocalAffect();
+    currentAffects.value = [localAffect];
+    markNew(localAffect._uuid!);
+
+    const savedAffect = savedAffectFromOsidb();
+    vi.mocked(AffectService.postAffects).mockResolvedValue({
+      data: { results: [savedAffect], failed: [] },
+    } as any);
+    vi.mocked(AffectService.postAffectCvssScore).mockResolvedValue({
+      uuid: 'cvss-uuid',
+      affect: savedAffect.uuid,
+      ...localAffect.cvss_scores[0],
+    } as any);
+
+    await saveAffects();
+
+    expect(AffectService.postAffectCvssScore).toHaveBeenCalledWith(
+      savedAffect.uuid,
+      expect.objectContaining({ score: 7.5 }),
+    );
+  });
+
+  it('clears newAffects tracking for a saved affect despite the ps_module mismatch', async () => {
+    const { actions: { markNew, resetSavedAffects }, state: { currentAffects, newAffects } } = useAffectsModel();
+
+    const localAffect = newLocalAffect({ cvss_scores: [] });
+    currentAffects.value = [localAffect];
+    markNew(localAffect._uuid!);
+
+    resetSavedAffects([savedAffectFromOsidb()]);
+
+    expect(newAffects.has(localAffect._uuid!)).toBe(false);
+  });
+});

--- a/src/composables/__tests__/useAffectsModel.spec.ts
+++ b/src/composables/__tests__/useAffectsModel.spec.ts
@@ -104,4 +104,37 @@ describe('useAffectsModel', () => {
 
     expect(newAffects.has(localAffect._uuid!)).toBe(false);
   });
+
+  it('adopts the server identity so later edits to a saved new affect are persisted', async () => {
+    const {
+      actions: { markModified, markNew, resetSavedAffects, saveAffects },
+      state: { currentAffects },
+    } = useAffectsModel();
+
+    const localAffect = newLocalAffect({ cvss_scores: [] });
+    currentAffects.value = [localAffect];
+    markNew(localAffect._uuid!);
+
+    resetSavedAffects([savedAffectFromOsidb({ cvss_scores: [] })]);
+
+    // The saved affect replaces the local one in place (no duplicate row) and
+    // carries the server-derived uuid and ps_module.
+    expect(currentAffects.value).toHaveLength(1);
+    const [reconciled] = currentAffects.value;
+    expect(reconciled.uuid).toBe('saved-uuid');
+    expect(reconciled.ps_module).toBe('my-module');
+
+    // A later edit must be classified as an update (PUT) rather than dropped.
+    markModified(reconciled.uuid!);
+    vi.mocked(AffectService.putAffects).mockResolvedValue({
+      data: { results: [savedAffectFromOsidb({ cvss_scores: [] })], failed: [] },
+    } as any);
+
+    await saveAffects();
+
+    expect(AffectService.postAffects).not.toHaveBeenCalled();
+    expect(AffectService.putAffects).toHaveBeenCalledWith([
+      expect.objectContaining({ uuid: 'saved-uuid' }),
+    ]);
+  });
 });

--- a/src/composables/useAffectsModel.ts
+++ b/src/composables/useAffectsModel.ts
@@ -67,7 +67,8 @@ function useAffects() {
     }
 
     // Remove successfully created affects from newAffects tracking
-    // Match by comparing ps_update_stream, ps_module, and ps_component
+    // Match by comparing ps_update_stream and ps_component (ps_module is empty
+    // locally until OSIDB derives it from ps_update_stream on creation)
     for (const affect of savedAffects) {
       // Find if this saved affect was previously tracked as new
       const wasNew = currentAffects.value.find(
@@ -75,7 +76,6 @@ function useAffects() {
           currentAffect._uuid
           && newAffects.has(currentAffect._uuid)
           && currentAffect.ps_update_stream === affect.ps_update_stream
-          && currentAffect.ps_module === affect.ps_module
           && currentAffect.ps_component === affect.ps_component,
       );
 
@@ -180,9 +180,10 @@ function useAffects() {
         }
       } else if (affect._uuid && newAffects.has(affect._uuid) && rhCvss3Score?.score) {
         // Find corresponding saved affect for new affects
+        // Match by ps_update_stream and ps_component (ps_module is empty
+        // locally until OSIDB derives it from ps_update_stream on creation)
         const matchingUpdatedAffect = updatedAffects.find(updatedAffect =>
           updatedAffect.ps_update_stream === affect.ps_update_stream
-          && updatedAffect.ps_module === affect.ps_module
           && updatedAffect.ps_component === affect.ps_component,
         );
 

--- a/src/composables/useAffectsModel.ts
+++ b/src/composables/useAffectsModel.ts
@@ -50,37 +50,42 @@ function useAffects() {
   }
 
   function resetSavedAffects(savedAffects: ZodAffectType[]) {
-    // Sync server data (e.g. updated_dt) so later edits don't 409
-    if (savedAffects.length) {
-      currentAffects.value = mergeBy(currentAffects.value, savedAffects, 'uuid');
-      initialAffects.value = mergeBy(initialAffects.value, savedAffects, 'uuid');
+    if (!savedAffects.length) {
+      return;
     }
 
-    // Create a set of saved affect UUIDs for quick lookup
-    const savedUuids = new Set(savedAffects.map(affect => affect.uuid));
-
-    // Remove successfully saved modified affects from tracking
-    for (const uuid of modifiedAffects) {
-      if (savedUuids.has(uuid)) {
-        modifiedAffects.delete(uuid);
-      }
-    }
-
-    // Remove successfully created affects from newAffects tracking
-    // Match by comparing ps_update_stream and ps_component (ps_module is empty
-    // locally until OSIDB derives it from ps_update_stream on creation)
+    // Adopt the server identity for successfully created affects before merging.
+    // New affects are tracked by a local _uuid and have no server uuid or
+    // ps_module yet (OSIDB derives ps_module from ps_update_stream on creation),
+    // so match them by ps_update_stream + ps_component. Assigning the saved uuid
+    // and ps_module lets mergeBy replace the local affect in place (rather than
+    // duplicating it) and ensures later edits are classified as updates.
     for (const affect of savedAffects) {
-      // Find if this saved affect was previously tracked as new
       const wasNew = currentAffects.value.find(
         currentAffect =>
           currentAffect._uuid
           && newAffects.has(currentAffect._uuid)
+          && !currentAffect.uuid
           && currentAffect.ps_update_stream === affect.ps_update_stream
           && currentAffect.ps_component === affect.ps_component,
       );
 
       if (wasNew?._uuid) {
+        wasNew.uuid = affect.uuid;
+        wasNew.ps_module = affect.ps_module;
         newAffects.delete(wasNew._uuid);
+      }
+    }
+
+    // Sync server data (e.g. updated_dt, ps_module) so later edits don't 409
+    currentAffects.value = mergeBy(currentAffects.value, savedAffects, 'uuid');
+    initialAffects.value = mergeBy(initialAffects.value, savedAffects, 'uuid');
+
+    // Remove successfully saved modified affects from tracking
+    const savedUuids = new Set(savedAffects.map(affect => affect.uuid));
+    for (const uuid of modifiedAffects) {
+      if (savedUuids.has(uuid)) {
+        modifiedAffects.delete(uuid);
       }
     }
   }


### PR DESCRIPTION
# [OSIDB-4704] Read-only affect module column

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated

## Summary:

Makes ps_module read only, automatically set after save to OSIDB.

## Changes:

Module field in Affects table is now read-only.
Changes to ps_update_stream will cause the previous value of ps_module to appear crossed out.

## Considerations:


[OSIDB-4704]: https://redhat.atlassian.net/browse/OSIDB-4704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ