### PR TITLE
OISDB-5297: Do not override affects with flaw PUT response. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Allow empty Source Component on flaws in NEW state (`OSIDB-5273`)
 * Make workflow, product_family and alias labels non-editable (`OSIDB-5385`)
 * Fix strikethrough incorrectly applied to labels without relevant field (`OSIDB-5375`)
+* Do not update affects from Flaw PUT response (OSIDB-5297)
 
 ## [2026.8.0-patch-missing-labels]
 ### Fixed

--- a/src/composables/__tests__/useFlawModel.spec.ts
+++ b/src/composables/__tests__/useFlawModel.spec.ts
@@ -119,6 +119,30 @@ describe('useFlawModel', () => {
       expect(putFlaw).not.toHaveBeenCalled();
     });
 
+    it('should not apply affects from the putFlaw response', async () => {
+      const { flaw, setFlaw } = useFlaw();
+      const flawData = deepCopyFromRaw(sampleFlawFull as ZodFlawType);
+      const localAffects = [{ ...flawData.affects[0], uuid: 'local-affect' }];
+      flawData.affects = localAffects;
+      setFlaw(flawData);
+
+      vi.mocked(putFlaw).mockResolvedValue({
+        ...flawData,
+        title: 'from-put',
+        affects: [{ ...flawData.affects[0], uuid: 'stale-from-put' }],
+      });
+
+      const { updateFlaw } = mountFlawModel();
+      flaw.value.title = 'altered';
+      await flushPromises();
+      await updateFlaw();
+      await flushPromises();
+
+      expect(putFlaw).toHaveBeenCalled();
+      expect(flaw.value.title).toBe('from-put');
+      expect(flaw.value.affects).toEqual(localAffects);
+    });
+
     it('should call postFlaw on createFlaw', () => {
       const { flaw } = useFlaw();
       flaw.value = sampleFlawRequired as ZodFlawType;

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -270,7 +270,10 @@ export function useFlawModel() {
           ...validatedFlaw.data,
           ...getAegisMetadataIfChanged(),
         }, shouldCreateJiraTask.value);
-        afterSuccessQueue.push(() => setFlaw(response));
+        afterSuccessQueue.push(() => setFlaw({
+          ...response,
+          affects: flaw.value.affects,
+        }));
       },
       );
     }


### PR DESCRIPTION
# [OSIDB-ID] [Title]

## Checklist:

- [ ] Commits consolidated
- [ ] Changelog updated
- [ ] Test cases added/updated
- [ ] Integration tests updated

## Summary:

User complain that the affects were being rolled back, after checking when a Flaw is updated the response overrides the affects. 

## Changes:

Before updating the Flaw object it replaces the affects with the actual model.

## Considerations:

Still not working