### PR TITLE
 updated dt put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # OSIM Changelog
+## [Unreleased]
+### Fixed
+* Restore OSIDB mid-air collision detection on PUT (`OSIDB-5285`)
+
 ## [2026.8.1]
 ### Fixed
 * Allow empty Source Component on flaws in NEW state (`OSIDB-5273`)

--- a/src/composables/__tests__/service-helpers.spec.ts
+++ b/src/composables/__tests__/service-helpers.spec.ts
@@ -1,0 +1,35 @@
+import { createCatchHandler } from '@/composables/service-helpers';
+
+import { useToastStore } from '@/stores/ToastStore';
+
+vi.mock('@/stores/ToastStore', () => ({
+  useToastStore: vi.fn(),
+}));
+
+describe('createCatchHandler', () => {
+  const addToast = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useToastStore).mockReturnValue({ addToast } as any);
+  });
+
+  it('shows mid-air collision message on 409', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const handler = createCatchHandler('Could not update Flaw', false);
+
+    handler({
+      response: {
+        status: 409,
+        statusText: 'Conflict',
+        data: { detail: 'updated_dt mismatch' },
+      },
+    });
+
+    expect(addToast).toHaveBeenCalledWith({
+      title: 'Mid-air collision detected',
+      body: 'This entity was modified by someone else. Reload to see the latest changes, then re-apply your edits.',
+      css: 'warning',
+    });
+  });
+});

--- a/src/composables/__tests__/useFlawAttributionsModel.spec.ts
+++ b/src/composables/__tests__/useFlawAttributionsModel.spec.ts
@@ -26,16 +26,20 @@ describe('useFlawAttributionsModel', () => {
       type: 'ARTICLE',
       url: 'http://example.com',
       embargoed: false,
-      updated_dt: null,
+      updated_dt: '2024-01-01T00:00:00Z',
       alerts: [] };
-    vi.mocked(putFlawReference).mockResolvedValue();
+    flaw.value.references = [reference];
+    vi.mocked(putFlawReference).mockResolvedValue({
+      data: { ...reference, updated_dt: '2024-01-02T00:00:00Z' },
+    } as any);
 
-    const { updateReference } = useFlawAttributionsModel(flaw, isSaving, afterSaveSuccess);
+    const { flawReferences, updateReference } = useFlawAttributionsModel(flaw, isSaving, afterSaveSuccess);
 
     await updateReference(reference);
     await flushPromises();
 
     expect(putFlawReference).toHaveBeenCalledWith('uuid-123', 'ref-123', reference);
+    expect(flawReferences.value[0].updated_dt).toBe('2024-01-02T00:00:00Z');
     expect(isSaving.value).toBe(false);
   });
 

--- a/src/composables/service-helpers.ts
+++ b/src/composables/service-helpers.ts
@@ -3,12 +3,15 @@ import { useToastStore } from '@/stores/ToastStore';
 
 export function createCatchHandler(title: string = 'Error', shouldThrow: boolean = true) {
   return (error: any) => {
-    const displayedError = Array.isArray(error)
-      ? parseOsidbErrors(error)
-      : getDisplayedOsidbError(error);
+    const isConflict = error?.response?.status === 409;
+    const displayedError = isConflict
+      ? 'This entity was modified by someone else. Reload to see the latest changes, then re-apply your edits.'
+      : Array.isArray(error)
+        ? parseOsidbErrors(error)
+        : getDisplayedOsidbError(error);
     const { addToast } = useToastStore();
     addToast({
-      title,
+      title: isConflict ? 'Mid-air collision detected' : title,
       body: displayedError,
       css: 'warning',
     });

--- a/src/composables/useFlawAttributionsModel.ts
+++ b/src/composables/useFlawAttributionsModel.ts
@@ -28,8 +28,18 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<b
 
   async function updateReference(reference: { uuid: string } & ZodFlawReferenceType) {
     isSaving.value = true;
-    await putFlawReference(flaw.value.uuid, reference.uuid, reference as any)
-      .finally(() => isSaving.value = false);
+    try {
+      const response = await putFlawReference(flaw.value.uuid, reference.uuid, reference as any);
+      // Sync concurrency token from response for subsequent edits
+      if (response?.data) {
+        const index = flawReferences.value.findIndex(ref => ref.uuid === reference.uuid);
+        if (index !== -1) {
+          flawReferences.value[index] = { ...flawReferences.value[index], ...response.data };
+        }
+      }
+    } finally {
+      isSaving.value = false;
+    }
   }
 
   async function createReference(reference: ZodFlawReferenceType) {
@@ -105,8 +115,18 @@ export function useFlawAttributionsModel(flaw: Ref<ZodFlawType>, isSaving: Ref<b
 
   async function updateAcknowledgment(acknowlegdment: any) {
     isSaving.value = true;
-    await putFlawAcknowledgment(flaw.value.uuid, acknowlegdment.uuid, acknowlegdment as any)
-      .finally(() => isSaving.value = false);
+    try {
+      const response = await putFlawAcknowledgment(flaw.value.uuid, acknowlegdment.uuid, acknowlegdment as any);
+      // Sync concurrency token from response for subsequent edits
+      if (response?.data) {
+        const index = flawAcknowledgments.value.findIndex(ack => ack.uuid === acknowlegdment.uuid);
+        if (index !== -1) {
+          flawAcknowledgments.value[index] = { ...flawAcknowledgments.value[index], ...response.data };
+        }
+      }
+    } finally {
+      isSaving.value = false;
+    }
   }
 
   async function saveAcknowledgments(acknowledgments: ZodFlawAcknowledgmentType[]) {

--- a/src/composables/useFlawModel.ts
+++ b/src/composables/useFlawModel.ts
@@ -270,6 +270,10 @@ export function useFlawModel() {
           ...validatedFlaw.data,
           ...getAegisMetadataIfChanged(),
         }, shouldCreateJiraTask.value);
+        // Sync concurrency token immediately so later edits/saves use the server value
+        if (response?.updated_dt) {
+          flaw.value.updated_dt = response.updated_dt;
+        }
         afterSuccessQueue.push(() => setFlaw(response));
       },
       );

--- a/src/services/AffectService.ts
+++ b/src/services/AffectService.ts
@@ -4,8 +4,6 @@ import { isCveValid } from '@/utils/helpers';
 import { osidbFetch } from '@/services/OsidbAuthService';
 import type { ZodAffectType, ZodAffectCVSSType } from '@/types/';
 
-import { beforeFetch } from './FlawService';
-
 type AffectFetchCallback = (fetchedCount: number, totalCount: number) => void;
 export async function getAffects(cveOrUuid: string, onFetchedCallback?: AffectFetchCallback):
 Promise<{ data: { results: ZodAffectType[] }; response: Response }> {
@@ -68,7 +66,7 @@ export async function putAffect(uuid: string, affectObject: any) {
     method: 'put',
     url: `/osidb/api/v1/affects/${uuid}`,
     data: affectObject,
-  }, { beforeFetch });
+  });
 }
 
 export async function putAffectWithHandlers(uuid: string, affectObject: any) {
@@ -130,7 +128,7 @@ export async function putAffectCvssScore(
     method: 'put',
     url: `/osidb/api/v2/affects/${affectId}/cvss-scores/${cvssScoresId}`,
     data: putObject,
-  }, { beforeFetch })
+  })
     .then(response => response.data)
     .catch(createCatchHandler('Problem updating affect CVSS scores:'));
 }

--- a/src/services/FlawService.ts
+++ b/src/services/FlawService.ts
@@ -4,24 +4,6 @@ import type { ZodFlawCVSSType, ZodFlawType } from '@/types';
 import { osidbFetch } from '@/services/OsidbAuthService';
 import router from '@/router';
 import { osimRuntime } from '@/stores/osimRuntime';
-import type { OsidbFetchOptions } from '@/services/OsidbAuthService';
-
-export async function beforeFetch(options: OsidbFetchOptions) {
-  if (options.data && ['PUT'].includes(options.method.toUpperCase())) {
-    try {
-      const updated_dt = await getUpdatedDt(options.url);
-
-      (options.data as Record<string, any>).updated_dt = updated_dt;
-
-      if (!updated_dt) {
-        throw new Error('An updated_dt could not be fetched');
-      }
-    } catch (error) {
-      console.error('FlawService::beforeFetch() Problem on fetch preparation. ', (error as Error).message);
-      throw new Error('Problem on fetch preparation. ' + (error as Error).message);
-    }
-  }
-}
 
 const FLAW_LIST_FIELDS = [
   'cve_id',
@@ -73,16 +55,6 @@ export async function getFlaw(uuidOrCve: string, breakCache?: boolean): Promise<
   }).then(response => response.data);
 }
 
-export async function getUpdatedDt(url: string): Promise<string> {
-  return osidbFetch({
-    method: 'get',
-    url: url,
-    params: {
-      include_fields: 'updated_dt',
-    },
-  }).then(response => response.data.updated_dt);
-}
-
 export async function putFlaw(uuid: string, flawObject: ZodFlawType, createJiraTask = false): Promise<ZodFlawType> {
   try {
     const response = await osidbFetch({
@@ -92,7 +64,7 @@ export async function putFlaw(uuid: string, flawObject: ZodFlawType, createJiraT
       params: {
         ...(createJiraTask && { create_jira_task: true }),
       },
-    }, { beforeFetch });
+    });
 
     const result = response.data;
     createSuccessHandler({ title: 'Success!', body: 'Flaw saved' })({ data: result });
@@ -116,7 +88,7 @@ export async function putFlawCvssScores(
     method: 'put',
     url: `/osidb/api/v1/flaws/${flawId}/cvss_scores/${cvssScoresId}`,
     data: putObject,
-  }, { beforeFetch })
+  })
     .then(createSuccessHandler({ title: 'Success!', body: 'Saved CVSS Scores' }))
     .then(response => response.data)
     .catch(createCatchHandler('CVSS Scores Update Error'));
@@ -247,7 +219,7 @@ export function putFlawReference(
     method: 'put',
     url: `/osidb/api/v1/flaws/${flawId}/references/${referenceId}`,
     data: requestBody,
-  }, { beforeFetch })
+  })
     .then(createSuccessHandler({ title: 'Success!', body: 'Reference updated.' }))
     .catch(createCatchHandler('Error updating Reference:'));
 }
@@ -294,7 +266,7 @@ export async function putFlawAcknowledgment(
     method: 'put',
     url: `/osidb/api/v1/flaws/${flawId}/acknowledgments/${acknowledgmentId}`,
     data: requestBody,
-  }, { beforeFetch })
+  })
     .then(createSuccessHandler({ title: 'Success!', body: 'Acknowledgment updated.' }))
     .catch(createCatchHandler('Error updating Acknowledgment:'));
 }

--- a/src/services/__tests__/FlawService.spec.ts
+++ b/src/services/__tests__/FlawService.spec.ts
@@ -38,4 +38,29 @@ describe('flawService', () => {
 
     expect(createSuccessHandler).toHaveBeenCalled();
   });
+
+  it('should send client updated_dt on PUT without fetching a fresh one first', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    const clientUpdatedDt = '2024-01-01T00:00:00Z';
+
+    await putFlaw('1', {
+      ...blankFlaw(),
+      title: 'Test',
+      updated_dt: clientUpdatedDt,
+    }, false);
+
+    const putCalls = fetchSpy.mock.calls.filter(([, init]) =>
+      String(init?.method ?? '').toUpperCase() === 'PUT',
+    );
+    const getCallsForUpdatedDt = fetchSpy.mock.calls.filter(([url, init]) =>
+      String(init?.method ?? 'GET').toUpperCase() === 'GET'
+      && String(url).includes('include_fields=updated_dt'),
+    );
+
+    expect(putCalls.length).toBeGreaterThan(0);
+    expect(getCallsForUpdatedDt).toHaveLength(0);
+
+    const putBody = JSON.parse(String(putCalls[0][1]?.body));
+    expect(putBody.updated_dt).toBe(clientUpdatedDt);
+  });
 });


### PR DESCRIPTION
# OSIDB-5285 Restore OSIDB mid-air collision detection

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [-] Integration tests updated
- [x] Jira ticket updated

## Summary

OSIM was fetching a fresh `updated_dt` before every PUT and writing it into the request body. That made the timestamp always match the server, so OSIDB never returned `409 Conflict` and concurrent editors could silently overwrite each other.

PUTs now send the `updated_dt` from when the entity was loaded. After a successful save, the local concurrency token is updated from the response so the same user's next save does not 409. On a real collision, the user gets a toast asking them to reload and re-apply their edits.

## Changes

- Removed `beforeFetch` / `getUpdatedDt` from flaw, CVSS, reference, acknowledgment, and affect PUTs
- Sync `updated_dt` from save responses in `useFlawModel` and `useFlawAttributionsModel`
- Show a dedicated mid-air collision toast on HTTP 409
- Unit tests for client `updated_dt` on PUT and 409 handling

Closes OSIDB-5285