### PR TITLE
fix: Include the srp_status behind the feature flag

### DIFF
--- a/src/components/IssueQueue/IssueQueueItem.vue
+++ b/src/components/IssueQueue/IssueQueueItem.vue
@@ -7,6 +7,7 @@ import SRPStatusBadge from '@/components/CRA/SRPStatusBadge.vue';
 import { useUnprocessedFlawDetection } from '@/composables/unprocessedFlawCheck';
 
 import { labelColorMap } from '@/constants';
+import { osimRuntime } from '@/stores/osimRuntime';
 
 import type { FilteredIssue } from './IssueQueue.vue';
 
@@ -19,8 +20,14 @@ const { issue, showLabels } = defineProps<{
 // TODO: unhide it once final issue sources are defined. [OSIDB-2424]
 //       and update the CSS for the column width in IssueQueue
 
-const nonIdFields: Exclude<keyof FilteredIssue, 'cve_id' | 'uuid'>[] =
-  ['impact', 'formattedDate', 'title', 'srp_status', 'classification', 'owner'];
+const nonIdFields = computed<Exclude<keyof FilteredIssue, 'cve_id' | 'uuid'>[]>(() => [
+  'impact',
+  'formattedDate',
+  'title',
+  ...(osimRuntime.value.flags?.srpReporting ? ['srp_status' as const] : []),
+  'classification',
+  'owner',
+]);
 
 const { isFlawUnprocessed } = useUnprocessedFlawDetection();
 
@@ -125,7 +132,7 @@ function getLabelColor(label: string, type: string): string {
         </template>
       </div>
     </td>
-    <td colspan="90%"></td>
+    <td :colspan="nonIdFields.length"></td>
   </tr>
 </template>
 

--- a/src/components/__tests__/IssueQueue.spec.ts
+++ b/src/components/__tests__/IssueQueue.spec.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
+import { type Ref } from 'vue';
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DateTime, Settings } from 'luxon';
 import { flushPromises } from '@vue/test-utils';
 
@@ -8,7 +10,9 @@ import IssueQueue from '@/components/IssueQueue/IssueQueue.vue';
 import { mountWithConfig } from '@/__tests__/helpers';
 import LabelCheckbox from '@/widgets/LabelCheckbox/LabelCheckbox.vue';
 import type { ZodFlawType } from '@/types';
+import { type OsimRuntimeType } from '@/types/zodOsim';
 import { useSettingsStore } from '@/stores/SettingsStore';
+import { osimRuntime } from '@/stores/osimRuntime';
 
 vi.mock('@/stores/UserStore', () => ({
   useUserStore: () => ({
@@ -17,6 +21,21 @@ vi.mock('@/stores/UserStore', () => ({
 }));
 
 describe('issueQueue', () => {
+  // setup.ts mocks osimRuntime as a writable ref; cast once here for type safety.
+  const runtimeMock = osimRuntime as unknown as Ref<OsimRuntimeType>;
+
+  beforeEach(() => {
+    // srpReporting is slated for removal once SRP reporting is fully rolled out;
+    // tests run with it on to match the eventual always-on state.
+    runtimeMock.value = {
+      ...runtimeMock.value,
+      flags: {
+        ...runtimeMock.value.flags,
+        srpReporting: true,
+      },
+    };
+  });
+
   const mockData: Partial<ZodFlawType>[] = [
     {
       uuid: '709e9ea1-ed0f-49b8-a7ad-9164d4034849',
@@ -284,6 +303,53 @@ describe('issueQueue', () => {
     const labels = wrapper.findComponent(IssueQueueItem).findAll('span.badge');
     expect(labels.length).toBe(0);
     expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  describe('with srpReporting disabled', () => {
+    beforeEach(() => {
+      runtimeMock.value = {
+        ...runtimeMock.value,
+        flags: { ...runtimeMock.value.flags, srpReporting: false },
+      };
+      useSettingsStore().settings.isHidingLabels = false;
+    });
+
+    it('should not render SRP Status column in header', () => {
+      const wrapper = mountIssueQueue();
+      const headers = wrapper.findAll('th').map(th => th.text().replace(/\s+/g, ' ').trim());
+      expect(headers).not.toContain('SRP Status');
+      expect(headers).toContain('Owner');
+    });
+
+    it('should render 6 cells per data row without srp_status cell', () => {
+      const wrapper = mountIssueQueue();
+      const dataRow = wrapper.find('tbody tr');
+      expect(dataRow.findAll('td').length).toBe(6);
+    });
+
+    it('badge row filler td colspan matches nonIdFields length (5)', () => {
+      const wrapper = mountIssueQueue({
+        issues: [{ ...mockData[0], labels: [{ name: 'test', state: 'NEW', contributor: '' }] } as ZodFlawType],
+      });
+      const badgeRow = wrapper.find('tr.osim-badge-lane');
+      expect(badgeRow.exists()).toBe(true);
+      expect(badgeRow.findAll('td')[1].attributes('colspan')).toBe('5');
+    });
+
+    it('should still render flaw labels without SRP Status column', () => {
+      const wrapper = mountIssueQueue({
+        issues: [{
+          ...mockData[0],
+          labels: [
+            { name: 'label-a', state: 'NEW', contributor: '' },
+            { name: 'label-b', state: 'REQ', contributor: '' },
+          ],
+        } as ZodFlawType],
+      });
+      const labels = wrapper.findComponent(IssueQueueItem).findAll('span.badge');
+      expect(labels.length).toBe(2);
+      expect(labels[0].text()).toBe('label-b'); // REQ sorts first
+    });
   });
 
   it('should render flaw labels when isHidingLabels is toggled', async () => {

--- a/src/components/__tests__/__snapshots__/IssueQueue.spec.ts.snap
+++ b/src/components/__tests__/__snapshots__/IssueQueue.spec.ts.snap
@@ -17,6 +17,7 @@ exports[`issueQueue > should not render flaw labels that are already assigned 1`
           <th data-v-48717bcb="">Impact <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Created <i data-v-48717bcb="" class="bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Title <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
+          <th data-v-48717bcb="">SRP Status <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">State <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Owner <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
         </tr>
@@ -41,7 +42,7 @@ exports[`issueQueue > should not render flaw labels that are already assigned 1`
               <!--v-if-->
             </div>
           </td>
-          <td data-v-15d9c71d="" colspan="90%"></td>
+          <td data-v-15d9c71d="" colspan="6"></td>
         </tr>
       </tbody>
     </table><button data-v-48717bcb="" class="btn btn-primary" type="button">
@@ -70,6 +71,7 @@ exports[`issueQueue > should not render flaw labels when isHidingLabels is true 
           <th data-v-48717bcb="">Impact <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Created <i data-v-48717bcb="" class="bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Title <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
+          <th data-v-48717bcb="">SRP Status <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">State <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Owner <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
         </tr>
@@ -113,6 +115,7 @@ exports[`issueQueue > should render flaw labels 1`] = `
           <th data-v-48717bcb="">Impact <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Created <i data-v-48717bcb="" class="bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Title <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
+          <th data-v-48717bcb="">SRP Status <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">State <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
           <th data-v-48717bcb="">Owner <i data-v-48717bcb="" class="opacity-0 bi-caret-down-fill bi"></i></th>
         </tr>
@@ -135,7 +138,7 @@ exports[`issueQueue > should render flaw labels 1`] = `
               <!--v-if--><span data-v-15d9c71d="" style="background-color: rgb(255, 255, 255);" class="badge rounded-pill border text-bg-warning fw-bold border-warning" title="Requested">test-3</span><span data-v-15d9c71d="" style="background-color: rgb(255, 255, 255);" class="badge rounded-pill border text-black" title="">test</span><span data-v-15d9c71d="" style="background-color: rgb(255, 255, 255);" class="badge rounded-pill border text-black" title="">test-2</span>
             </div>
           </td>
-          <td data-v-15d9c71d="" colspan="90%"></td>
+          <td data-v-15d9c71d="" colspan="6"></td>
         </tr>
       </tbody>
     </table><button data-v-48717bcb="" class="btn btn-primary" type="button">


### PR DESCRIPTION
## Summary

The `srp_status` field was being included in the `IssueQueueItem` column list unconditionally, leaking the SRP reporting header even when the `srpReporting` feature flag was disabled. This also exposed a pre-existing layout bug where the badge lane's filler `<td>` used `colspan="90%"` — an invalid value that browsers parse as `90`, creating 89 phantom columns and a large blank horizontal space to the right of the table whenever labels were visible.

## Changes

- Converted `nonIdFields` from a static array to a `computed` so it reacts to the feature flag; `srp_status` is now only included when `osimRuntime.value.flags?.srpReporting` is truthy.
- Fixed `colspan="90%"` on the badge lane filler `<td>` to `:colspan="nonIdFields.length"`, so it always spans exactly the remaining columns regardless of the flag state.
- Added a `with srpReporting disabled` test suite covering: header omits SRP Status column, data rows render 6 cells, badge row filler `colspan` is `5`, and labels still render correctly.
- Updated snapshots to reflect the corrected `colspan` value (`6` with SRP on).