### PR TITLE
[OSIDB-5480] Show SRP overdue count from latest report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # OSIM Changelog
 ## [Unreleased]
+### Fixed
+* Show top-level SRP overdue information from the latest report (`OSIDB-5480`)
 
 ## [2026.8.2]
 ### Fixed

--- a/src/components/CRA/SRPSummary.vue
+++ b/src/components/CRA/SRPSummary.vue
@@ -80,26 +80,24 @@ const summary = computed<SRPReportSummary>(() => {
     };
   }
 
-  let totalOverdue = 0;
-
-  for (const report of srpReports.value) {
-    if (report.milestones) {
-      totalOverdue += report.milestones.filter(m =>
-        m.is_overdue
-        && m.status !== 'submitted'
-        && m.status !== 'not_required',
-      ).length;
-    }
-  }
+  const latestReport = getLatestReport(srpReports.value);
 
   return {
     hasReport: true,
     status: null,
     eventType: null,
     nextDueDate: null,
-    overdueMilestones: totalOverdue,
+    overdueMilestones: latestReport ? getOverdueMilestones(latestReport) : 0,
   };
 });
+
+function getLatestReport(reports: SRPReport[]): SRPReport | undefined {
+  return reports.reduce<SRPReport | undefined>((latest, report) => {
+    if (!latest) return report;
+
+    return new Date(report.created_dt) > new Date(latest.created_dt) ? report : latest;
+  }, undefined);
+}
 
 function getNextDueDate(report: SRPReport): Date | null {
   if (!report.milestones) return null;

--- a/src/components/CRA/__tests__/SRPSummary.spec.ts
+++ b/src/components/CRA/__tests__/SRPSummary.spec.ts
@@ -49,6 +49,33 @@ describe('sRPSummary', () => {
     expect(wrapper.text()).toContain('Event Type');
   });
 
+  it('shows top-level overdue count from the latest report only', async () => {
+    vi.mocked(SRPService.fetchSRPReports).mockResolvedValue([
+      {
+        ...mockSRPReport,
+        created_dt: '2026-01-01T00:00:00Z',
+        milestones: [
+          {
+            ...mockSRPReport.milestones[0],
+            is_overdue: true,
+            status: 'required',
+          },
+        ],
+        uuid: 'older-report',
+      },
+      {
+        ...mockSRPReport,
+        created_dt: '2026-01-02T00:00:00Z',
+        uuid: 'latest-report',
+      },
+    ]);
+
+    const wrapper = mount(SRPSummary, { props: { flawId: 'flaw-123' } });
+    await flushPromises();
+
+    expect(wrapper.find('.section-label + .badge.bg-danger.ms-2').exists()).toBe(false);
+  });
+
   it('does not fetch without flawId', async () => {
     mount(SRPSummary, { props: { flawId: '' } });
     await flushPromises();


### PR DESCRIPTION
# [OSIDB-5480 Show SRP overdue count from latest report

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated

## Summary:

Update the top-level SRP overdue indicator to reflect only the latest SRP report instead of aggregating overdue milestones across all reports.

## Changes:

- Added latest-report selection by `created_dt` in `SRPSummary.vue`.
- Reused existing overdue milestone filtering for the latest report.
- Added regression coverage for ignoring overdue milestones from older reports in the top-level summary.
- Added a changelog entry for `OSIDB-5480`.

## Considerations:

Per-report overdue counts remain unchanged in the report table. Integration tests were not updated because this behavior is covered by the focused component unit test.
