### PR TITLE
[OSIDB-5494] Add SRP milestone owner self-assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # OSIM Changelog
 ## [Unreleased]
+### Added
+* Add SRP milestone owner display, editing, and self-assignment (`OSIDB-5494`)
 
 ## [2026.8.2]
 ### Fixed

--- a/src/components/CRA/SRPMilestoneDialog.vue
+++ b/src/components/CRA/SRPMilestoneDialog.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 import Modal from '@/widgets/Modal/Modal.vue';
+import { useUserStore } from '@/stores/UserStore';
 import type { SRPMilestoneType, SRPReportMilestone, SRPReportStatus } from '@/types/cra';
+import { ZodFlawOwnerSchema } from '@/types/zodFlaw';
 
 const props = defineProps<{
   milestone?: SRPReportMilestone;
@@ -14,10 +16,13 @@ const emit = defineEmits<{
   save: [milestone: Partial<SRPReportMilestone>];
 }>();
 
+const userStore = useUserStore();
+
 const formData = ref({
   due_at: '',
   manual_completion_notes: '',
   milestone_type: 'additional_information_response',
+  owner: '',
   request_received_at: '',
   request_source: '',
   request_text: '',
@@ -40,12 +45,23 @@ function fromISO8601Date(iso: null | string): string {
   return iso.substring(0, 10);
 }
 
+function selfAssign() {
+  if (userStore.userEmail) {
+    formData.value.owner = userStore.userEmail;
+  }
+}
+
+const isAssignedToMe = computed(() =>
+  formData.value.owner === userStore.userEmail && userStore.userEmail !== '',
+);
+
 watch(() => props.show, (newShow) => {
   if (newShow) {
     formData.value = {
       due_at: fromISO8601Date(props.milestone?.due_at || ''),
       manual_completion_notes: props.milestone?.manual_completion_notes || '',
       milestone_type: props.milestone?.milestone_type || 'additional_information_response',
+      owner: props.milestone?.owner || '',
       request_received_at: fromISO8601Date(props.milestone?.request_received_at || ''),
       request_source: props.milestone?.request_source || '',
       request_text: props.milestone?.request_text || '',
@@ -53,7 +69,7 @@ watch(() => props.show, (newShow) => {
       updated_dt: props.milestone?.updated_dt || '',
     };
   }
-});
+}, { immediate: true });
 
 function handleSave() {
   // Validate required fields for new milestones
@@ -72,8 +88,17 @@ function handleSave() {
     }
   }
 
+  const owner = formData.value.owner.trim();
+  const ownerValidation = ZodFlawOwnerSchema.safeParse(owner);
+
+  if (!ownerValidation.success) {
+    console.error(ownerValidation.error.issues[0]?.message);
+    return;
+  }
+
   const payload: Partial<SRPReportMilestone> = {
     manual_completion_notes: formData.value.manual_completion_notes,
+    owner,
     request_source: formData.value.request_source,
     request_text: formData.value.request_text,
     status: formData.value.status as SRPReportStatus,
@@ -173,6 +198,27 @@ function handleClose() {
       </div>
 
       <hr class="my-3" />
+
+      <div class="mb-3">
+        <label class="form-label">Owner</label>
+        <div class="d-flex gap-2 align-items-start">
+          <input
+            v-model="formData.owner"
+            type="email"
+            class="form-control"
+            placeholder="owner@example.com"
+          />
+          <button
+            v-if="!isAssignedToMe"
+            type="button"
+            class="btn btn-primary osim-self-assign text-nowrap"
+            @click="selfAssign"
+          >
+            Self Assign
+          </button>
+        </div>
+        <small class="text-muted">Person responsible for this milestone</small>
+      </div>
 
       <div class="mb-3">
         <label class="form-label">Status</label>

--- a/src/components/CRA/SRPReportDetails.vue
+++ b/src/components/CRA/SRPReportDetails.vue
@@ -77,6 +77,7 @@ async function handleQuickAction(milestone: SRPReportMilestone, action: 'block' 
           <tr>
             <th>Type</th>
             <th>Status</th>
+            <th>Owner</th>
             <th>Due Date</th>
             <th>Time Remaining</th>
             <th style="width: 200px">Actions</th>
@@ -91,6 +92,10 @@ async function handleQuickAction(milestone: SRPReportMilestone, action: 'block' 
             <td class="ps-4">{{ milestone.milestone_type }}</td>
             <td>
               <SRPStatusBadge :status="milestone.status" />
+            </td>
+            <td>
+              <span v-if="milestone.owner">{{ milestone.owner }}</span>
+              <span v-else class="text-muted">Unassigned</span>
             </td>
             <td>{{ milestone.due_at ? formatDate(new Date(milestone.due_at), false) : 'N/A' }}</td>
             <td :class="{ 'text-danger': isMilestoneActionable(milestone) }">

--- a/src/components/CRA/__tests__/SRPMilestoneDialog.spec.ts
+++ b/src/components/CRA/__tests__/SRPMilestoneDialog.spec.ts
@@ -1,7 +1,14 @@
 import { mount } from '@vue/test-utils';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import SRPMilestoneDialog from '@/components/CRA/SRPMilestoneDialog.vue';
+import { mockSRPReport } from '@/components/CRA/__tests__/fixtures';
+
+vi.mock('@/stores/UserStore', () => ({
+  useUserStore: () => ({
+    userEmail: 'skynet@redhat.com',
+  }),
+}));
 
 describe('sRPMilestoneDialog', () => {
   it('renders when show is true', () => {
@@ -28,8 +35,47 @@ describe('sRPMilestoneDialog', () => {
     await wrapper.findAll('input[type="text"]').at(0)?.setValue('ENISA Portal');
     await wrapper.find('textarea').setValue('Request for additional information');
 
-    await wrapper.findAll('.btn-primary').at(0)?.trigger('click');
+    await wrapper.find('.modal-footer').find('.btn-primary').trigger('click');
     expect(wrapper.emitted('save')).toBeTruthy();
     expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('self assigns owner from current user email', async () => {
+    const milestone = {
+      ...mockSRPReport.milestones[0],
+      owner: '',
+    };
+    const wrapper = mount(SRPMilestoneDialog, {
+      props: {
+        milestone,
+        show: true,
+      },
+    });
+
+    await wrapper.find('button.osim-self-assign').trigger('click');
+    expect((wrapper.find('input[type="email"]').element as HTMLInputElement).value).toBe('skynet@redhat.com');
+
+    await wrapper.find('.modal-footer').find('.btn-primary').trigger('click');
+    expect(wrapper.emitted('save')?.[0]?.[0]).toMatchObject({
+      owner: 'skynet@redhat.com',
+      updated_dt: milestone.updated_dt,
+    });
+  });
+
+  it('does not save invalid owner email', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapper = mount(SRPMilestoneDialog, {
+      props: {
+        milestone: mockSRPReport.milestones[0],
+        show: true,
+      },
+    });
+
+    await wrapper.find('input[type="email"]').setValue('not-an-email');
+    await wrapper.find('.modal-footer').find('.btn-primary').trigger('click');
+
+    expect(wrapper.emitted('save')).toBeUndefined();
+    expect(wrapper.emitted('close')).toBeUndefined();
+    expect(console.error).toHaveBeenCalledWith('Owner must be a valid email address.');
   });
 });

--- a/src/components/CRA/__tests__/SRPReportDetails.spec.ts
+++ b/src/components/CRA/__tests__/SRPReportDetails.spec.ts
@@ -21,6 +21,23 @@ describe('sRPReportDetails', () => {
     expect(wrapper.text()).toContain('24h');
   });
 
+  it('renders milestone owner', () => {
+    const wrapper = mount(SRPReportDetails, {
+      props: {
+        report: {
+          ...mockSRPReport,
+          milestones: [{
+            ...mockSRPReport.milestones[0],
+            owner: 'analyst@redhat.com',
+          }],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Owner');
+    expect(wrapper.text()).toContain('analyst@redhat.com');
+  });
+
   it('emits add-milestone event', async () => {
     const wrapper = mount(SRPReportDetails, {
       props: {

--- a/src/components/CRA/__tests__/SRPSummary.spec.ts
+++ b/src/components/CRA/__tests__/SRPSummary.spec.ts
@@ -14,6 +14,12 @@ vi.mock('@/services/SRPService', () => ({
   updateSRPReport: vi.fn(() => Promise.resolve({})),
 }));
 
+vi.mock('@/stores/UserStore', () => ({
+  useUserStore: () => ({
+    userEmail: 'skynet@redhat.com',
+  }),
+}));
+
 describe('sRPSummary', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/components/CRA/__tests__/fixtures.ts
+++ b/src/components/CRA/__tests__/fixtures.ts
@@ -19,6 +19,7 @@ export const mockSRPReport: SRPReport = {
     manual_completion_notes: '',
     milestone_type: '24h',
     missing_required_fields: '',
+    owner: '',
     request_received_at: null,
     request_source: '',
     request_text: '',

--- a/src/types/cra.ts
+++ b/src/types/cra.ts
@@ -38,6 +38,7 @@ export interface SRPReportMilestone {
   manual_completion_notes: string;
   milestone_type: SRPMilestoneType;
   missing_required_fields: string;
+  owner: string;
   request_received_at: null | string;
   request_source: string;
   request_text: string;


### PR DESCRIPTION
# [OSIDB-5494] Add SRP milestone owner self-assignment

## Checklist:

- [x] Commits consolidated
- [x] Changelog updated
- [x] Test cases added/updated
- [ ] Integration tests updated

## Summary:

Add owner display, editing, and self-assignment support for SRP milestones in OSIM.

## Changes:

- Added `owner` to the SRP milestone TypeScript model and test fixture.
- Added an Owner column to the SRP milestone table.
- Added an Owner input to the SRP milestone dialog.
- Added a `Self Assign` button that sets the milestone owner to the current OSIM user email.
- Included `owner` in milestone save payloads.
- Updated component tests for owner rendering and self-assignment.
- Added a changelog entry for `OSIDB-5494`.

## Considerations:

The self-assignment behavior follows the existing flaw owner pattern and uses the current user email from `UserStore`. Integration tests were not updated, the behavior is covered by focused component tests and was manually verified locally with CRA reporting enabled.

I've tried for the best of my knowledge to follow the same code style from the self-assign of flaws, feel free to ask for any changes.


[OSIDB-5494]: https://redhat.atlassian.net/browse/OSIDB-5494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ